### PR TITLE
Fix CI test failures from port conflict and double-close panic

### DIFF
--- a/receiver/besreceiver/metadata.yaml
+++ b/receiver/besreceiver/metadata.yaml
@@ -6,3 +6,7 @@ status:
     alpha: [traces, logs]
   codeowners:
     active: [chagui]
+
+tests:
+  config:
+    endpoint: localhost:0

--- a/receiver/besreceiver/receiver.go
+++ b/receiver/besreceiver/receiver.go
@@ -49,6 +49,7 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 		r.grpcServer, err = r.config.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings)
 		if err != nil {
 			r.traceBuilder.Stop()
+			r.traceBuilder = nil
 			startErr = fmt.Errorf("failed to create gRPC server: %w", err)
 			return
 		}
@@ -58,6 +59,7 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 		r.listener, err = r.config.NetAddr.Listen(ctx)
 		if err != nil {
 			r.traceBuilder.Stop()
+			r.traceBuilder = nil
 			startErr = fmt.Errorf("failed to listen on %s: %w", r.config.NetAddr.Endpoint, err)
 			return
 		}
@@ -69,6 +71,13 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 			}
 		}()
 	})
+
+	if startErr != nil {
+		r.refCount.Add(-1)
+		sharedReceiversMu.Lock()
+		delete(sharedReceivers, r.config.NetAddr.Endpoint)
+		sharedReceiversMu.Unlock()
+	}
 
 	return startErr
 }

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/consumer"
@@ -53,6 +54,7 @@ type TraceBuilder struct {
 	eventCh           chan eventMsg
 	stopCh            chan struct{}
 	doneCh            chan struct{}
+	stopOnce          sync.Once
 
 	// Internal metrics for observability.
 	activeInvocations metric.Int64UpDownCounter
@@ -109,9 +111,14 @@ func (tb *TraceBuilder) Start() {
 }
 
 // Stop signals the owner goroutine to exit and waits for it to finish.
+// It is safe to call multiple times.
 func (tb *TraceBuilder) Stop() {
-	if tb.stopCh != nil {
-		close(tb.stopCh)
+	tb.stopOnce.Do(func() {
+		if tb.stopCh != nil {
+			close(tb.stopCh)
+		}
+	})
+	if tb.doneCh != nil {
 		<-tb.doneCh
 	}
 }


### PR DESCRIPTION
The CI workflow runs race and coverage tests sequentially. The generated component test used hardcoded localhost:8082, causing the second run to fail with "address already in use" (TCP TIME_WAIT). The failed Start left a stale shared receiver, leading to a double-close panic on TraceBuilder.

- Use ephemeral port (localhost:0) in test config via metadata.yaml
- Make TraceBuilder.Stop() idempotent with sync.Once
- Clean up shared receiver state on Start failure