### PR TITLE
Add low-cardinality qualifiers to span names for flame graph readability

### DIFF
--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -76,7 +76,11 @@ func (s *invocationState) addAction(label, configID string, action *bep.ActionEx
 	span := s.appendSpan()
 	span.SetSpanID(newSpanID())
 	span.SetParentSpanID(parentSpanID)
-	span.SetName("bazel.action")
+	if mnemonic := action.GetType(); mnemonic != "" {
+		span.SetName("bazel.action " + mnemonic)
+	} else {
+		span.SetName("bazel.action")
+	}
 	span.SetKind(ptrace.SpanKindInternal)
 
 	if action.GetStartTime() != nil {
@@ -146,7 +150,14 @@ func (s *invocationState) finalize(finished *bep.BuildFinished) (ptrace.Traces, 
 
 	span := s.appendSpan()
 	span.SetSpanID(s.rootSpanID)
-	span.SetName("bazel.build")
+	// command is a free-form string in the proto, but in practice bounded to
+	// Bazel's fixed command set (~20: build, test, run, query, clean, etc.).
+	// Only a subset (~5-7) emit BES events that reach this code path.
+	if s.started != nil && s.started.GetCommand() != "" {
+		span.SetName("bazel.build " + s.started.GetCommand())
+	} else {
+		span.SetName("bazel.build")
+	}
 	span.SetKind(ptrace.SpanKindServer)
 
 	if s.started != nil && s.started.GetStartTime() != nil {

--- a/receiver/besreceiver/receiver_test.go
+++ b/receiver/besreceiver/receiver_test.go
@@ -61,8 +61,8 @@ func TestPublishBuildToolEventStream_HappyPath(t *testing.T) {
 		t.Fatalf("expected 1 span, got %d", sink.SpanCount())
 	}
 	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-	if span.Name() != "bazel.build" {
-		t.Errorf("expected span name bazel.build, got %s", span.Name())
+	if span.Name() != "bazel.build build" {
+		t.Errorf("expected span name 'bazel.build build', got %s", span.Name())
 	}
 }
 
@@ -267,7 +267,7 @@ func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 		switch spans.At(i).Name() {
 		case "bazel.target":
 			targetSpan = spans.At(i)
-		case "bazel.action":
+		case "bazel.action Javac":
 			actionSpan = spans.At(i)
 		}
 	}
@@ -287,8 +287,8 @@ func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 	}
 
 	// Verify the target's spanID is used as parent for the action.
-	if actionSpan.Name() != "bazel.action" {
-		t.Fatal("expected to find bazel.action span in batch")
+	if actionSpan.Name() != "bazel.action Javac" {
+		t.Fatal("expected to find 'bazel.action Javac' span in batch")
 	}
 	if actionSpan.ParentSpanID() != targetSpan.SpanID() {
 		t.Errorf("expected action parent to be target span %v, got %v", targetSpan.SpanID(), actionSpan.ParentSpanID())
@@ -412,8 +412,8 @@ func TestIntegration_RealGRPCServer(t *testing.T) {
 	}
 
 	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-	if span.Name() != "bazel.build" {
-		t.Errorf("expected span name bazel.build, got %s", span.Name())
+	if span.Name() != "bazel.build build" {
+		t.Errorf("expected span name 'bazel.build build', got %s", span.Name())
 	}
 	cmd, ok := span.Attributes().Get("bazel.command")
 	if !ok || cmd.Str() != "build" {

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -90,14 +90,14 @@ func TestTraceBuilder_ActionExecuted(t *testing.T) {
 	spans := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
 	var span ptrace.Span
 	for i := range spans.Len() {
-		if spans.At(i).Name() == "bazel.action" {
+		if spans.At(i).Name() == "bazel.action Javac" {
 			span = spans.At(i)
 			break
 		}
 	}
 
-	if span.Name() != "bazel.action" {
-		t.Fatal("expected to find bazel.action span in batch")
+	if span.Name() != "bazel.action Javac" {
+		t.Fatal("expected to find 'bazel.action Javac' span in batch")
 	}
 	if span.Status().Code() != ptrace.StatusCodeError {
 		t.Error("expected error status for failed action")
@@ -130,8 +130,8 @@ func TestTraceBuilder_BuildFinished(t *testing.T) {
 
 	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
-	if span.Name() != "bazel.build" {
-		t.Errorf("expected span name bazel.build, got %s", span.Name())
+	if span.Name() != "bazel.build test" {
+		t.Errorf("expected span name 'bazel.build test', got %s", span.Name())
 	}
 
 	// Verify both start and end timestamps are set.
@@ -371,7 +371,7 @@ func TestTraceBuilder_BatchFlushSingleConsumeCall(t *testing.T) {
 	for i := range spans.Len() {
 		names[spans.At(i).Name()] = true
 	}
-	for _, want := range []string{"bazel.target", "bazel.action", "bazel.build"} {
+	for _, want := range []string{"bazel.target", "bazel.action Javac", "bazel.build build"} {
 		if !names[want] {
 			t.Errorf("expected span %q in batch, got names: %v", want, names)
 		}
@@ -847,5 +847,58 @@ func TestTraceBuilder_LogConsumerErrorDoesNotBreakTraces(t *testing.T) {
 	// Traces should still be emitted despite log consumer failures.
 	if tracesSink.SpanCount() != 1 {
 		t.Fatalf("expected 1 span despite log consumer errors, got %d", tracesSink.SpanCount())
+	}
+}
+
+func TestActionSpanName_EmptyMnemonic(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-em", "uuid-em", "build", 1)); err != nil {
+		t.Fatal(err)
+	}
+	// Action with empty mnemonic.
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeActionOBE(t, "inv-em", "//pkg:lib", "", 2, true)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-em", 3, 0, "SUCCESS")); err != nil {
+		t.Fatal(err)
+	}
+
+	spans := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	for i := range spans.Len() {
+		if spans.At(i).Name() == "bazel.action" {
+			return // Pass — no trailing space.
+		}
+	}
+	// Collect names for diagnostics.
+	var names []string
+	for i := range spans.Len() {
+		names = append(names, spans.At(i).Name())
+	}
+	t.Fatalf("expected 'bazel.action' span (no trailing space) in batch, got names: %v", names)
+}
+
+func TestBuildSpanName_EmptyCommand(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// BuildStarted with empty command.
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-ec", "uuid-ec", "", 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-ec", 2, 0, "SUCCESS")); err != nil {
+		t.Fatal(err)
+	}
+
+	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	if span.Name() != "bazel.build" {
+		t.Errorf("expected span name 'bazel.build' (no trailing space), got %q", span.Name())
 	}
 }


### PR DESCRIPTION
## Summary

Action spans now include the action [mnemonic](https://bazel.build/reference/glossary#mnemonic) (e.g. `bazel.action Javac`) and build spans include the Bazel [command](https://bazel.build/run/build#specifying-build-targets) (e.g. `bazel.build test`). Falls back to the bare name when the qualifier is empty.

## Why

Static span names produce unhelpful flame graphs — every action looks identical until you drill into attributes. Adding the mnemonic lets you distinguish Javac from Turbine at a glance in any trace backend. The command qualifier on `bazel.build` similarly distinguishes `build` vs `test` vs `query` invocations at the root span level.

This follows the [OTel span naming convention](https://opentelemetry.io/docs/specs/semconv/general/trace/) of embedding low-cardinality qualifiers in span names while keeping high-cardinality values (target labels) as attributes only.

## Breaking change

Span names change from static `bazel.action` / `bazel.build` to qualified forms. Dashboards or monitors keyed on exact span name matches will need updating. The OTel Collector's [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) can restore static names if needed.

## Test plan

Existing tests updated to expect qualified span names. Two new edge-case tests verify that an empty mnemonic and an empty command fall back to the bare span name without a trailing space.

<img width="230" height="71" alt="image" src="https://github.com/user-attachments/assets/64125928-0d49-43e8-9c66-69a012f3a599" />
