### PR TITLE
Chagui/examples/structured logging toggle

### DIFF
--- a/examples/datadog/.env.example
+++ b/examples/datadog/.env.example
@@ -1,0 +1,5 @@
+# Datadog API key (required)
+DD_API_KEY=your-api-key-here
+
+# OTel Collector log encoding: "json" for structured logs, "console" for human-readable
+OTEL_LOG_ENCODING=json

--- a/examples/datadog/collector-config.yaml
+++ b/examples/datadog/collector-config.yaml
@@ -38,6 +38,7 @@ service:
   telemetry:
     logs:
       level: info
+      output_paths: ["stdout", "/var/log/otelcol/collector.log"]
       encoding: ${env:OTEL_LOG_ENCODING}
     metrics:
       readers:

--- a/examples/datadog/collector-config.yaml
+++ b/examples/datadog/collector-config.yaml
@@ -38,6 +38,7 @@ service:
   telemetry:
     logs:
       level: info
+      encoding: ${env:OTEL_LOG_ENCODING}
     metrics:
       readers:
         - pull:

--- a/examples/datadog/conf.d/otelcol.yaml
+++ b/examples/datadog/conf.d/otelcol.yaml
@@ -1,0 +1,8 @@
+logs:
+  - type: file
+    path: /var/log/otelcol/collector.log
+    source: otelcol-bazel
+    service: otelcol-bazel
+    tags:
+      - "env:dev"
+      - "version:dev"

--- a/examples/datadog/datadog.yaml
+++ b/examples/datadog/datadog.yaml
@@ -1,3 +1,5 @@
+logs_enabled: true
+
 otlp_config:
   receiver:
     protocols:

--- a/examples/datadog/docker-compose.yaml
+++ b/examples/datadog/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
     ports:
       - "8082:8082"
       - "13133:13133"
+    environment:
+      - OTEL_LOG_ENCODING=${OTEL_LOG_ENCODING:-json}
     stop_grace_period: 3s
     depends_on:
       - dd-agent

--- a/examples/datadog/docker-compose.yaml
+++ b/examples/datadog/docker-compose.yaml
@@ -4,10 +4,13 @@ services:
     image: gcr.io/datadoghq/agent:7
     volumes:
       - ./datadog.yaml:/etc/datadog-agent/datadog.yaml:ro
+      - ./conf.d/otelcol.yaml:/etc/datadog-agent/conf.d/otelcol.d/conf.yaml:ro
+      - otelcol-logs:/var/log/otelcol:ro
     env_file: .env
     environment:
       - DD_HOSTNAME=besreceiver-dev
       - DD_APM_ENABLED=true
+      - DD_LOGS_ENABLED=true
 
   otelcol-bazel:
     build:
@@ -18,6 +21,7 @@ services:
       - ./collector-config.yaml:/etc/otelcol-bazel/config.yaml:ro
       - gomodcache:/go/pkg/mod
       - gobuildcache:/root/.cache/go-build
+      - otelcol-logs:/var/log/otelcol
     ports:
       - "8082:8082"
       - "13133:13133"
@@ -30,3 +34,4 @@ services:
 volumes:
   gomodcache:
   gobuildcache:
+  otelcol-logs:


### PR DESCRIPTION
## Summary

Adds configurable log encoding to the OTel Collector (`json` or `console` via `OTEL_LOG_ENCODING`) and wires up Datadog Agent log collection so collector logs are ingested alongside traces. A new `.env.example` documents required and optional env vars for the Datadog example.

## Motivation

Without this, the collector's logs are only visible via `docker compose logs` and aren't ingested into Datadog. This closes the observability gap: traces flow through OTLP, but operator-level logs (startup errors, gRPC handler warnings, pipeline issues) now land in Datadog Logs with proper `source: otelcol-bazel` tagging.

The encoding toggle lets developers switch to human-readable output locally while keeping structured JSON for Datadog ingestion.

## How it works

The collector config gains `output_paths` (stdout + file) and `encoding: ${env:OTEL_LOG_ENCODING}`. A shared `otelcol-logs` Docker volume connects the collector's log file to the Datadog Agent, which tails it via a new `conf.d/otelcol.yaml` integration conf with source, service, and env tags. `datadog.yaml` enables `logs_enabled: true` and the compose file sets `DD_LOGS_ENABLED=true` on the agent container.

## Test plan

Run `docker compose up` with `OTEL_LOG_ENCODING=json` and verify structured logs appear in Datadog Logs explorer under `source:otelcol-bazel`. Repeat with `OTEL_LOG_ENCODING=console` and confirm human-readable output on stdout while the file is still written. Trigger a Bazel build with `--bes_backend` and check that both traces and collector logs are visible in Datadog.