### PR TITLE
fix(config): rename deprecated "otlp" exporter to "otlp_grpc"

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -17,7 +17,7 @@ processors:
     timeout: 200ms
 
 exporters:
-  otlp/datadog:
+  otlp_grpc/datadog:
     endpoint: "localhost:4317"
     tls:
       insecure: true # Only acceptable for same-host communication (e.g. sidecar Datadog Agent).
@@ -49,7 +49,7 @@ service:
     traces:
       receivers: [bes]
       processors: [memory_limiter, batch]
-      exporters: [otlp/datadog, debug]
+      exporters: [otlp_grpc/datadog, debug]
     logs:
       receivers: [bes]
       processors: [memory_limiter, batch]

--- a/examples/custom-collector/collector-config.yaml
+++ b/examples/custom-collector/collector-config.yaml
@@ -12,7 +12,7 @@ processors:
     timeout: 200ms
 
 exporters:
-  # Replace with your own exporter (otlp, datadog, jaeger, etc.)
+  # Replace with your own exporter (otlp_grpc, datadog, jaeger, etc.)
   debug:
     verbosity: detailed
 

--- a/examples/datadog/collector-config.yaml
+++ b/examples/datadog/collector-config.yaml
@@ -17,7 +17,7 @@ processors:
     timeout: 200ms
 
 exporters:
-  otlp/datadog:
+  otlp_grpc/datadog:
     endpoint: "dd-agent:4317"
     tls:
       insecure: true
@@ -51,7 +51,7 @@ service:
     traces:
       receivers: [bes]
       processors: [memory_limiter, batch]
-      exporters: [otlp/datadog, debug]
+      exporters: [otlp_grpc/datadog, debug]
     logs:
       receivers: [bes]
       processors: [memory_limiter, batch]

--- a/examples/datadog/collector-config.yaml
+++ b/examples/datadog/collector-config.yaml
@@ -30,8 +30,6 @@ exporters:
       enabled: true
       num_consumers: 10
       queue_size: 5000
-  debug:
-    verbosity: basic
 
 service:
   extensions: [health_check]
@@ -51,8 +49,4 @@ service:
     traces:
       receivers: [bes]
       processors: [memory_limiter, batch]
-      exporters: [otlp_grpc/datadog, debug]
-    logs:
-      receivers: [bes]
-      processors: [memory_limiter, batch]
-      exporters: [debug]
+      exporters: [otlp_grpc/datadog]


### PR DESCRIPTION
## Summary

The `otlp` exporter alias was [deprecated in collector v0.120.0](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md) in favor of the explicit `otlp_grpc` / `otlp_http` names and will be removed in a future release. This renames all `otlp/datadog` instances to `otlp_grpc/datadog` across collector configs and updates the comment in the custom-collector example accordingly.

The Datadog example also had a `debug` exporter and a `logs` pipeline that don't belong in a production-like reference config — those are removed.

 