### PR TITLE
feat(besreceiver): emit OTel metrics from BEP BuildMetrics events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this project is
 
-An OpenTelemetry Collector custom receiver that accepts Bazel Build Event Protocol (BEP) streams via the BES gRPC API and converts them into distributed traces. Bazel builds become trace flamegraphs in Datadog, Tempo, Jaeger, or any OTLP backend.
+An OpenTelemetry Collector custom receiver that accepts Bazel Build Event Protocol (BEP) streams via the BES gRPC API and converts them into distributed traces, logs, and metrics. Bazel builds become trace flamegraphs in Datadog, Tempo, Jaeger, or any OTLP backend, with build performance metrics queryable as time-series.
 
 ## Module path
 
@@ -18,8 +18,8 @@ The receiver package is at `receiver/besreceiver/`.
 Bazel --bes_backend=grpc://host:8082
   → besreceiver (gRPC BES server inside OTel Collector)
     → BEP parser (anypb.Any → bep.BuildEvent)
-    → Trace builder (BEP events → ptrace.Traces)
-    → consumer.ConsumeTraces()
+    → Trace builder (BEP events → ptrace.Traces + pmetric.Metrics)
+    → consumer.ConsumeTraces() / ConsumeMetrics() / ConsumeLogs()
   → batch processor → OTLP exporter → backend
 ```
 
@@ -46,7 +46,8 @@ bazel.build (root, traceID derived from invocation UUID)
 | `receiver/besreceiver/factory.go` | `NewFactory()`, component type `"bes"`, alpha stability |
 | `receiver/besreceiver/receiver.go` | `Start`/`Shutdown`, BES gRPC handler (`PublishBuildToolEventStream`) |
 | `receiver/besreceiver/bepparser.go` | `ParseBazelEvent`: `anypb.Any` → `bep.BuildEvent` via `proto.Unmarshal` |
-| `receiver/besreceiver/tracebuilder.go` | Core logic: per-invocation state, BEP events → `ptrace.Traces` |
+| `receiver/besreceiver/tracebuilder.go` | Core logic: per-invocation state, BEP events → `ptrace.Traces` + `pmetric.Metrics` |
+| `receiver/besreceiver/metricsbuilder.go` | Per-invocation gauges + cumulative counters from `BuildMetrics` |
 
 ## Commands
 
@@ -77,7 +78,7 @@ make docker     # docker build
 
 ## Testing patterns
 
-Tests use `consumertest.TracesSink` to capture emitted traces and assert span names, attributes, parent-child relationships, and status codes. `receivertest.NewNopSettings(componentType)` provides a no-op receiver settings for unit tests.
+Tests use `consumertest.TracesSink` and `consumertest.MetricsSink` to capture emitted traces and metrics, then assert span names, attributes, parent-child relationships, status codes, gauge values, and cumulative counter semantics. `receivertest.NewNopSettings(componentType)` provides a no-op receiver settings for unit tests.
 
 ## Running with Bazel
 

--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -54,3 +54,7 @@ service:
       receivers: [bes]
       processors: [memory_limiter, batch]
       exporters: [debug]
+    metrics:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc/datadog, debug]

--- a/receiver/besreceiver/benchmark_test.go
+++ b/receiver/besreceiver/benchmark_test.go
@@ -17,7 +17,7 @@ import (
 
 func BenchmarkProcessOrderedBuildEvent(b *testing.B) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()

--- a/receiver/besreceiver/factory.go
+++ b/receiver/besreceiver/factory.go
@@ -26,6 +26,7 @@ func NewFactory() receiver.Factory {
 		createDefaultConfig,
 		receiver.WithTraces(createTracesReceiver, metadata.TracesStability),
 		receiver.WithLogs(createLogsReceiver, metadata.LogsStability),
+		receiver.WithMetrics(createMetricsReceiver, metadata.MetricsStability),
 	)
 }
 
@@ -91,5 +92,20 @@ func createLogsReceiver(
 	}
 	r := getOrCreateReceiver(rCfg, settings)
 	r.logsConsumer = nextConsumer
+	return r, nil
+}
+
+func createMetricsReceiver(
+	_ context.Context,
+	settings receiver.Settings,
+	cfg component.Config,
+	nextConsumer consumer.Metrics,
+) (receiver.Metrics, error) {
+	rCfg, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type: %T", cfg)
+	}
+	r := getOrCreateReceiver(rCfg, settings)
+	r.metricsConsumer = nextConsumer
 	return r, nil
 }

--- a/receiver/besreceiver/factory_test.go
+++ b/receiver/besreceiver/factory_test.go
@@ -74,6 +74,27 @@ func TestCreateLogsReceiver(t *testing.T) {
 	}
 }
 
+func TestCreateMetricsReceiver(t *testing.T) {
+	t.Cleanup(func() {
+		sharedReceiversMu.Lock()
+		sharedReceivers = make(map[string]*besReceiver)
+		sharedReceiversMu.Unlock()
+	})
+
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig()
+	sink := new(consumertest.MetricsSink)
+	settings := receivertest.NewNopSettings(metadata.Type)
+
+	recv, err := f.CreateMetrics(context.Background(), settings, cfg, sink)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recv == nil {
+		t.Fatal("expected non-nil receiver")
+	}
+}
+
 func TestSharedReceiverInstance(t *testing.T) {
 	t.Cleanup(func() {
 		sharedReceiversMu.Lock()
@@ -97,17 +118,29 @@ func TestSharedReceiverInstance(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Both receivers should be the same underlying instance.
+	metricsSink := new(consumertest.MetricsSink)
+	metricsRecv, err := f.CreateMetrics(context.Background(), settings, cfg, metricsSink)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// All receivers should be the same underlying instance.
 	if tracesRecv != logsRecv {
 		t.Error("expected traces and logs receivers to share the same instance")
 	}
+	if tracesRecv != metricsRecv {
+		t.Error("expected traces and metrics receivers to share the same instance")
+	}
 
-	// Verify both consumers are set.
+	// Verify all three consumers are set.
 	r := tracesRecv.(*besReceiver)
 	if r.tracesConsumer == nil {
 		t.Error("expected tracesConsumer to be set")
 	}
 	if r.logsConsumer == nil {
 		t.Error("expected logsConsumer to be set")
+	}
+	if r.metricsConsumer == nil {
+		t.Error("expected metricsConsumer to be set")
 	}
 }

--- a/receiver/besreceiver/generated_component_test.go
+++ b/receiver/besreceiver/generated_component_test.go
@@ -41,6 +41,13 @@ func TestComponentLifecycle(t *testing.T) {
 		},
 
 		{
+			name: "metrics",
+			createFn: func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error) {
+				return factory.CreateMetrics(ctx, set, cfg, consumertest.NewNop())
+			},
+		},
+
+		{
 			name: "traces",
 			createFn: func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error) {
 				return factory.CreateTraces(ctx, set, cfg, consumertest.NewNop())

--- a/receiver/besreceiver/internal/metadata/generated_status.go
+++ b/receiver/besreceiver/internal/metadata/generated_status.go
@@ -12,6 +12,7 @@ var (
 )
 
 const (
-	TracesStability = component.StabilityLevelAlpha
-	LogsStability   = component.StabilityLevelAlpha
+	TracesStability  = component.StabilityLevelAlpha
+	LogsStability    = component.StabilityLevelAlpha
+	MetricsStability = component.StabilityLevelAlpha
 )

--- a/receiver/besreceiver/metadata.yaml
+++ b/receiver/besreceiver/metadata.yaml
@@ -3,7 +3,7 @@ type: bes
 status:
   class: receiver
   stability:
-    alpha: [traces, logs]
+    alpha: [traces, logs, metrics]
   codeowners:
     active: [chagui]
 

--- a/receiver/besreceiver/metricsbuilder.go
+++ b/receiver/besreceiver/metricsbuilder.go
@@ -61,6 +61,59 @@ func addMemoryGauges(sm pmetric.ScopeMetrics, mm *bep.BuildMetrics_MemoryMetrics
 	addGaugeInt64(sm, "bazel.invocation.memory.peak_post_gc_heap", "By", "Peak JVM heap size post GC", ts, mm.GetPeakPostGcHeapSize(), attrs)
 }
 
+// cumulativeCounters tracks running totals across invocations.
+// All fields are owned by the TraceBuilder's run goroutine — no mutex needed.
+type cumulativeCounters struct {
+	totalWallTimeMs      int64
+	totalCPUTimeMs       int64
+	totalActionsCreated  int64
+	totalActionsExecuted int64
+	totalInvocations     int64
+	startTime            pcommon.Timestamp
+}
+
+func newCumulativeCounters(startTime pcommon.Timestamp) *cumulativeCounters {
+	return &cumulativeCounters{startTime: startTime}
+}
+
+// record increments running totals from a BuildMetrics event.
+func (c *cumulativeCounters) record(metrics *bep.BuildMetrics) {
+	c.totalInvocations++
+	if tm := metrics.GetTimingMetrics(); tm != nil {
+		c.totalWallTimeMs += tm.GetWallTimeInMs()
+		c.totalCPUTimeMs += tm.GetCpuTimeInMs()
+	}
+	if as := metrics.GetActionSummary(); as != nil {
+		c.totalActionsCreated += as.GetActionsCreated()
+		c.totalActionsExecuted += as.GetActionsExecuted()
+	}
+}
+
+// appendTo appends cumulative Sum data points to the given ScopeMetrics.
+func (c *cumulativeCounters) appendTo(sm pmetric.ScopeMetrics, ts pcommon.Timestamp) {
+	addSumInt64(sm, "bazel.invocation.count", "{invocation}", "Total BuildMetrics events processed", ts, c.startTime, c.totalInvocations)
+	addSumInt64(sm, "bazel.invocation.wall_time.total", "ms", "Cumulative wall time across invocations", ts, c.startTime, c.totalWallTimeMs)
+	addSumInt64(sm, "bazel.invocation.cpu_time.total", "ms", "Cumulative CPU time across invocations", ts, c.startTime, c.totalCPUTimeMs)
+	addSumInt64(sm, "bazel.invocation.actions_created.total", "{action}", "Cumulative actions created across invocations", ts, c.startTime, c.totalActionsCreated)
+	addSumInt64(sm, "bazel.invocation.actions_executed.total", "{action}", "Cumulative actions executed across invocations", ts, c.startTime, c.totalActionsExecuted)
+}
+
+// addSumInt64 appends a single monotonic cumulative Sum metric with one Int64 data point.
+func addSumInt64(sm pmetric.ScopeMetrics, name, unit, description string, ts, startTS pcommon.Timestamp, value int64) {
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	m.SetUnit(unit)
+	m.SetDescription(description)
+	sum := m.SetEmptySum()
+	sum.SetIsMonotonic(true)
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+	dp := sum.DataPoints().AppendEmpty()
+	dp.SetTimestamp(ts)
+	dp.SetStartTimestamp(startTS)
+	dp.SetIntValue(value)
+}
+
 // addGaugeInt64 appends a single Gauge metric with one Int64 data point.
 func addGaugeInt64(sm pmetric.ScopeMetrics, name, unit, description string, ts pcommon.Timestamp, value int64, attrs pcommon.Map) {
 	m := sm.Metrics().AppendEmpty()

--- a/receiver/besreceiver/metricsbuilder.go
+++ b/receiver/besreceiver/metricsbuilder.go
@@ -1,0 +1,76 @@
+package besreceiver
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+)
+
+// buildInvocationGauges constructs per-invocation gauge metrics from a
+// BuildMetrics event. Returns a pmetric.Metrics containing gauges for timing,
+// action summary, and memory sub-messages. Nil sub-messages are skipped.
+func buildInvocationGauges(invocationID string, state *invocationState, metrics *bep.BuildMetrics, ts pcommon.Timestamp) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "bazel")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("besreceiver")
+
+	attrs := pcommon.NewMap()
+	attrs.PutStr("bazel.invocation_id", invocationID)
+	if state.started != nil {
+		attrs.PutStr("bazel.command", state.started.GetCommand())
+	}
+
+	addTimingGauges(sm, metrics.GetTimingMetrics(), ts, attrs)
+	addActionSummaryGauges(sm, metrics.GetActionSummary(), ts, attrs)
+	addMemoryGauges(sm, metrics.GetMemoryMetrics(), ts, attrs)
+
+	return md
+}
+
+func addTimingGauges(sm pmetric.ScopeMetrics, tm *bep.BuildMetrics_TimingMetrics, ts pcommon.Timestamp, attrs pcommon.Map) {
+	if tm == nil {
+		return
+	}
+	addGaugeInt64(sm, "bazel.invocation.wall_time", "ms", "Wall time of the build invocation", ts, tm.GetWallTimeInMs(), attrs)
+	addGaugeInt64(sm, "bazel.invocation.cpu_time", "ms", "CPU time consumed by the build invocation", ts, tm.GetCpuTimeInMs(), attrs)
+	addGaugeInt64(sm, "bazel.invocation.analysis_phase_time", "ms", "Elapsed wall time during analysis phase", ts, tm.GetAnalysisPhaseTimeInMs(), attrs)
+	addGaugeInt64(sm, "bazel.invocation.execution_phase_time", "ms", "Elapsed wall time during execution phase", ts, tm.GetExecutionPhaseTimeInMs(), attrs)
+	addGaugeInt64(sm, "bazel.invocation.actions_execution_start_time", "ms", "Elapsed wall time until first action execution", ts, tm.GetActionsExecutionStartInMs(), attrs)
+
+	if cpt := tm.GetCriticalPathTime(); cpt != nil {
+		addGaugeInt64(sm, "bazel.invocation.critical_path_time", "ms", "Critical path wall time", ts, cpt.AsDuration().Milliseconds(), attrs)
+	}
+}
+
+func addActionSummaryGauges(sm pmetric.ScopeMetrics, as *bep.BuildMetrics_ActionSummary, ts pcommon.Timestamp, attrs pcommon.Map) {
+	if as == nil {
+		return
+	}
+	addGaugeInt64(sm, "bazel.invocation.actions_created", "{action}", "Total actions created during the build", ts, as.GetActionsCreated(), attrs)
+	addGaugeInt64(sm, "bazel.invocation.actions_executed", "{action}", "Total actions executed during the build", ts, as.GetActionsExecuted(), attrs)
+}
+
+func addMemoryGauges(sm pmetric.ScopeMetrics, mm *bep.BuildMetrics_MemoryMetrics, ts pcommon.Timestamp, attrs pcommon.Map) {
+	if mm == nil {
+		return
+	}
+	addGaugeInt64(sm, "bazel.invocation.memory.used_heap_post_build", "By", "JVM heap size post build", ts, mm.GetUsedHeapSizePostBuild(), attrs)
+	addGaugeInt64(sm, "bazel.invocation.memory.peak_post_gc_heap", "By", "Peak JVM heap size post GC", ts, mm.GetPeakPostGcHeapSize(), attrs)
+}
+
+// addGaugeInt64 appends a single Gauge metric with one Int64 data point.
+func addGaugeInt64(sm pmetric.ScopeMetrics, name, unit, description string, ts pcommon.Timestamp, value int64, attrs pcommon.Map) {
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	m.SetUnit(unit)
+	m.SetDescription(description)
+	m.SetEmptyGauge()
+
+	dp := m.Gauge().DataPoints().AppendEmpty()
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(value)
+	attrs.CopyTo(dp.Attributes())
+}

--- a/receiver/besreceiver/metricsbuilder_test.go
+++ b/receiver/besreceiver/metricsbuilder_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
 )
@@ -165,6 +167,150 @@ func TestBuildInvocationMetrics_NilSubMessages(t *testing.T) {
 
 	if md.MetricCount() != 0 {
 		t.Fatalf("expected 0 metrics for nil sub-messages, got %d", md.MetricCount())
+	}
+}
+
+func TestCumulativeCounters_Record(t *testing.T) {
+	startTime := pcommon.NewTimestampFromTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	c := newCumulativeCounters(startTime)
+
+	// First build.
+	c.record(&bep.BuildMetrics{
+		TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+			WallTimeInMs: 10000,
+			CpuTimeInMs:  5000,
+		},
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  100,
+			ActionsExecuted: 50,
+		},
+	})
+
+	if c.totalInvocations != 1 {
+		t.Errorf("expected 1 invocation, got %d", c.totalInvocations)
+	}
+	if c.totalWallTimeMs != 10000 {
+		t.Errorf("expected totalWallTimeMs=10000, got %d", c.totalWallTimeMs)
+	}
+	if c.totalCPUTimeMs != 5000 {
+		t.Errorf("expected totalCPUTimeMs=5000, got %d", c.totalCPUTimeMs)
+	}
+	if c.totalActionsCreated != 100 {
+		t.Errorf("expected totalActionsCreated=100, got %d", c.totalActionsCreated)
+	}
+	if c.totalActionsExecuted != 50 {
+		t.Errorf("expected totalActionsExecuted=50, got %d", c.totalActionsExecuted)
+	}
+
+	// Second build — totals accumulate.
+	c.record(&bep.BuildMetrics{
+		TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+			WallTimeInMs: 20000,
+			CpuTimeInMs:  8000,
+		},
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  200,
+			ActionsExecuted: 100,
+		},
+	})
+
+	if c.totalInvocations != 2 {
+		t.Errorf("expected 2 invocations, got %d", c.totalInvocations)
+	}
+	if c.totalWallTimeMs != 30000 {
+		t.Errorf("expected totalWallTimeMs=30000, got %d", c.totalWallTimeMs)
+	}
+	if c.totalCPUTimeMs != 13000 {
+		t.Errorf("expected totalCPUTimeMs=13000, got %d", c.totalCPUTimeMs)
+	}
+	if c.totalActionsCreated != 300 {
+		t.Errorf("expected totalActionsCreated=300, got %d", c.totalActionsCreated)
+	}
+	if c.totalActionsExecuted != 150 {
+		t.Errorf("expected totalActionsExecuted=150, got %d", c.totalActionsExecuted)
+	}
+}
+
+func TestCumulativeCounters_Record_NilSubMessages(t *testing.T) {
+	startTime := pcommon.NewTimestampFromTime(time.Now())
+	c := newCumulativeCounters(startTime)
+
+	// Should not panic with nil sub-messages.
+	c.record(&bep.BuildMetrics{})
+
+	if c.totalInvocations != 1 {
+		t.Errorf("expected 1 invocation, got %d", c.totalInvocations)
+	}
+	if c.totalWallTimeMs != 0 {
+		t.Errorf("expected totalWallTimeMs=0, got %d", c.totalWallTimeMs)
+	}
+}
+
+func TestCumulativeCounters_AppendTo(t *testing.T) {
+	startTime := pcommon.NewTimestampFromTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	c := newCumulativeCounters(startTime)
+	c.record(&bep.BuildMetrics{
+		TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+			WallTimeInMs: 10000,
+			CpuTimeInMs:  5000,
+		},
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  100,
+			ActionsExecuted: 50,
+		},
+	})
+
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	c.appendTo(sm, ts)
+
+	// 5 cumulative counters.
+	if sm.Metrics().Len() != 5 {
+		t.Fatalf("expected 5 metrics, got %d", sm.Metrics().Len())
+	}
+
+	wantCounters := map[string]int64{
+		"bazel.invocation.count":                  1,
+		"bazel.invocation.wall_time.total":        10000,
+		"bazel.invocation.cpu_time.total":         5000,
+		"bazel.invocation.actions_created.total":  100,
+		"bazel.invocation.actions_executed.total": 50,
+	}
+
+	for i := range sm.Metrics().Len() {
+		m := sm.Metrics().At(i)
+		want, ok := wantCounters[m.Name()]
+		if !ok {
+			t.Errorf("unexpected metric %q", m.Name())
+			continue
+		}
+		sum := m.Sum()
+		if !sum.IsMonotonic() {
+			t.Errorf("metric %q: expected monotonic", m.Name())
+		}
+		if sum.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
+			t.Errorf("metric %q: expected cumulative temporality", m.Name())
+		}
+		dp := sum.DataPoints().At(0)
+		if dp.IntValue() != want {
+			t.Errorf("metric %q: got %d, want %d", m.Name(), dp.IntValue(), want)
+		}
+		if dp.StartTimestamp() != startTime {
+			t.Errorf("metric %q: expected start timestamp to match counter creation time", m.Name())
+		}
+		if dp.Timestamp() != ts {
+			t.Errorf("metric %q: timestamp mismatch", m.Name())
+		}
+		// Cumulative counters should have no per-invocation attributes.
+		if dp.Attributes().Len() != 0 {
+			t.Errorf("metric %q: expected 0 attributes, got %d", m.Name(), dp.Attributes().Len())
+		}
+		delete(wantCounters, m.Name())
+	}
+	for name := range wantCounters {
+		t.Errorf("missing metric %q", name)
 	}
 }
 

--- a/receiver/besreceiver/metricsbuilder_test.go
+++ b/receiver/besreceiver/metricsbuilder_test.go
@@ -1,0 +1,197 @@
+package besreceiver
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+)
+
+func TestBuildInvocationMetrics_Timing(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{
+		started: &bep.BuildStarted{Command: "build"},
+	}
+	metrics := &bep.BuildMetrics{
+		TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+			WallTimeInMs:              12345,
+			CpuTimeInMs:               6789,
+			AnalysisPhaseTimeInMs:     1000,
+			ExecutionPhaseTimeInMs:    2000,
+			ActionsExecutionStartInMs: 500,
+			CriticalPathTime:          durationpb.New(3 * time.Second),
+		},
+	}
+
+	md := buildInvocationGauges("inv-1", state, metrics, ts)
+
+	// 6 timing gauges.
+	if md.MetricCount() != 6 {
+		t.Fatalf("expected 6 metrics, got %d", md.MetricCount())
+	}
+
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	wantGauges := map[string]int64{
+		"bazel.invocation.wall_time":                    12345,
+		"bazel.invocation.cpu_time":                     6789,
+		"bazel.invocation.analysis_phase_time":          1000,
+		"bazel.invocation.execution_phase_time":         2000,
+		"bazel.invocation.actions_execution_start_time": 500,
+		"bazel.invocation.critical_path_time":           3000,
+	}
+
+	for i := range sm.Metrics().Len() {
+		m := sm.Metrics().At(i)
+		want, ok := wantGauges[m.Name()]
+		if !ok {
+			t.Errorf("unexpected metric %q", m.Name())
+			continue
+		}
+		dp := m.Gauge().DataPoints().At(0)
+		if dp.IntValue() != want {
+			t.Errorf("metric %q: got %d, want %d", m.Name(), dp.IntValue(), want)
+		}
+		if dp.Timestamp() != ts {
+			t.Errorf("metric %q: timestamp mismatch", m.Name())
+		}
+		// Verify attributes.
+		invID, ok := dp.Attributes().Get("bazel.invocation_id")
+		if !ok || invID.Str() != "inv-1" {
+			t.Errorf("metric %q: expected bazel.invocation_id=inv-1", m.Name())
+		}
+		cmd, ok := dp.Attributes().Get("bazel.command")
+		if !ok || cmd.Str() != "build" {
+			t.Errorf("metric %q: expected bazel.command=build", m.Name())
+		}
+		delete(wantGauges, m.Name())
+	}
+	for name := range wantGauges {
+		t.Errorf("missing metric %q", name)
+	}
+}
+
+func TestBuildInvocationMetrics_ActionSummary(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{
+		started: &bep.BuildStarted{Command: "test"},
+	}
+	metrics := &bep.BuildMetrics{
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  500,
+			ActionsExecuted: 42,
+		},
+	}
+
+	md := buildInvocationGauges("inv-2", state, metrics, ts)
+
+	if md.MetricCount() != 2 {
+		t.Fatalf("expected 2 metrics, got %d", md.MetricCount())
+	}
+
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	wantGauges := map[string]int64{
+		"bazel.invocation.actions_created":  500,
+		"bazel.invocation.actions_executed": 42,
+	}
+
+	for i := range sm.Metrics().Len() {
+		m := sm.Metrics().At(i)
+		want, ok := wantGauges[m.Name()]
+		if !ok {
+			t.Errorf("unexpected metric %q", m.Name())
+			continue
+		}
+		if m.Gauge().DataPoints().At(0).IntValue() != want {
+			t.Errorf("metric %q: got %d, want %d", m.Name(), m.Gauge().DataPoints().At(0).IntValue(), want)
+		}
+		delete(wantGauges, m.Name())
+	}
+	for name := range wantGauges {
+		t.Errorf("missing metric %q", name)
+	}
+}
+
+func TestBuildInvocationMetrics_Memory(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{
+		started: &bep.BuildStarted{Command: "build"},
+	}
+	metrics := &bep.BuildMetrics{
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
+			UsedHeapSizePostBuild: 1073741824,
+			PeakPostGcHeapSize:    2147483648,
+		},
+	}
+
+	md := buildInvocationGauges("inv-3", state, metrics, ts)
+
+	if md.MetricCount() != 2 {
+		t.Fatalf("expected 2 metrics, got %d", md.MetricCount())
+	}
+
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	wantGauges := map[string]int64{
+		"bazel.invocation.memory.used_heap_post_build": 1073741824,
+		"bazel.invocation.memory.peak_post_gc_heap":    2147483648,
+	}
+
+	for i := range sm.Metrics().Len() {
+		m := sm.Metrics().At(i)
+		want, ok := wantGauges[m.Name()]
+		if !ok {
+			t.Errorf("unexpected metric %q", m.Name())
+			continue
+		}
+		if m.Gauge().DataPoints().At(0).IntValue() != want {
+			t.Errorf("metric %q: got %d, want %d", m.Name(), m.Gauge().DataPoints().At(0).IntValue(), want)
+		}
+		delete(wantGauges, m.Name())
+	}
+	for name := range wantGauges {
+		t.Errorf("missing metric %q", name)
+	}
+}
+
+func TestBuildInvocationMetrics_NilSubMessages(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{
+		started: &bep.BuildStarted{Command: "build"},
+	}
+	metrics := &bep.BuildMetrics{} // all sub-messages nil
+
+	md := buildInvocationGauges("inv-nil", state, metrics, ts)
+
+	if md.MetricCount() != 0 {
+		t.Fatalf("expected 0 metrics for nil sub-messages, got %d", md.MetricCount())
+	}
+}
+
+func TestBuildInvocationMetrics_AllCategories(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{
+		started: &bep.BuildStarted{Command: "build"},
+	}
+	metrics := &bep.BuildMetrics{
+		TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+			WallTimeInMs: 10000,
+			CpuTimeInMs:  5000,
+		},
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  100,
+			ActionsExecuted: 50,
+		},
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
+			UsedHeapSizePostBuild: 512000000,
+			PeakPostGcHeapSize:    1024000000,
+		},
+	}
+
+	md := buildInvocationGauges("inv-all", state, metrics, ts)
+
+	// 5 timing (no CriticalPathTime since it's nil) + 2 action + 2 memory = 9.
+	if md.MetricCount() != 9 {
+		t.Fatalf("expected 9 metrics, got %d", md.MetricCount())
+	}
+}

--- a/receiver/besreceiver/receiver.go
+++ b/receiver/besreceiver/receiver.go
@@ -21,16 +21,17 @@ import (
 )
 
 type besReceiver struct {
-	config         *Config
-	logger         *zap.Logger
-	settings       receiver.Settings
-	grpcServer     *grpc.Server
-	traceBuilder   *TraceBuilder
-	listener       net.Listener
-	tracesConsumer consumer.Traces
-	logsConsumer   consumer.Logs
-	startOnce      sync.Once
-	refCount       atomic.Int32
+	config          *Config
+	logger          *zap.Logger
+	settings        receiver.Settings
+	grpcServer      *grpc.Server
+	traceBuilder    *TraceBuilder
+	listener        net.Listener
+	tracesConsumer  consumer.Traces
+	logsConsumer    consumer.Logs
+	metricsConsumer consumer.Metrics
+	startOnce       sync.Once
+	refCount        atomic.Int32
 }
 
 func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
@@ -38,7 +39,7 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 
 	var startErr error
 	r.startOnce.Do(func() {
-		r.traceBuilder = NewTraceBuilder(r.tracesConsumer, r.logsConsumer, r.logger, TraceBuilderConfig{
+		r.traceBuilder = NewTraceBuilder(r.tracesConsumer, r.logsConsumer, r.metricsConsumer, r.logger, TraceBuilderConfig{
 			InvocationTimeout: r.config.InvocationTimeout,
 			ReaperInterval:    r.config.ReaperInterval,
 			MeterProvider:     r.settings.MeterProvider,

--- a/receiver/besreceiver/receiver_test.go
+++ b/receiver/besreceiver/receiver_test.go
@@ -330,7 +330,8 @@ func TestIntegration_RealGRPCServer(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	sink := new(consumertest.TracesSink)
+	tracesSink := new(consumertest.TracesSink)
+	metricsSink := new(consumertest.MetricsSink)
 	settings := receivertest.NewNopSettings(metadata.Type)
 	cfg := createDefaultConfig().(*Config)
 	cfg.NetAddr = confignet.AddrConfig{
@@ -339,10 +340,11 @@ func TestIntegration_RealGRPCServer(t *testing.T) {
 	}
 
 	recv := &besReceiver{
-		config:         cfg,
-		logger:         settings.Logger,
-		settings:       settings,
-		tracesConsumer: sink,
+		config:          cfg,
+		logger:          settings.Logger,
+		settings:        settings,
+		tracesConsumer:  tracesSink,
+		metricsConsumer: metricsSink,
 	}
 
 	host := componenttest.NewNopHost()
@@ -371,52 +373,49 @@ func TestIntegration_RealGRPCServer(t *testing.T) {
 
 	client := pb.NewPublishBuildEventClient(conn)
 
-	// 4. Open a PublishBuildToolEventStream and send events.
 	stream, err := client.PublishBuildToolEventStream(ctx)
 	if err != nil {
 		t.Fatalf("failed to open stream: %v", err)
 	}
 
-	// Send BuildStarted.
-	if err := stream.Send(makeBuildStartedReq(t, "inv-integration", "uuid-integration", "build", 1)); err != nil {
-		t.Fatalf("failed to send BuildStarted: %v", err)
-	}
-	ack1, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("failed to receive ACK 1: %v", err)
-	}
-	if ack1.GetSequenceNumber() != 1 {
-		t.Errorf("expected ACK seq 1, got %d", ack1.GetSequenceNumber())
-	}
+	sendAndACK(t, stream, makeBuildStartedReq(t, "inv-integration", "uuid-integration", "build", 1), 1)
+	sendAndACK(t, stream, makeBuildFinishedReq(t, "inv-integration", 2, 0, "SUCCESS"), 2)
+	sendAndACK(t, stream, makeBuildMetricsReq(t, "inv-integration", 3, 10000, 5000), 3)
 
-	// Send BuildFinished.
-	if err := stream.Send(makeBuildFinishedReq(t, "inv-integration", 2, 0, "SUCCESS")); err != nil {
-		t.Fatalf("failed to send BuildFinished: %v", err)
-	}
-	ack2, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("failed to receive ACK 2: %v", err)
-	}
-	if ack2.GetSequenceNumber() != 2 {
-		t.Errorf("expected ACK seq 2, got %d", ack2.GetSequenceNumber())
-	}
-
-	// Close the stream.
 	if err := stream.CloseSend(); err != nil {
 		t.Fatalf("failed to close stream: %v", err)
 	}
 
-	// 5. Assert spans landed in the sink.
-	if sink.SpanCount() != 1 {
-		t.Fatalf("expected 1 span, got %d", sink.SpanCount())
-	}
+	t.Run("traces", func(t *testing.T) {
+		if tracesSink.SpanCount() != 2 {
+			t.Fatalf("expected 2 spans, got %d", tracesSink.SpanCount())
+		}
 
-	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-	if span.Name() != "bazel.build build" {
-		t.Errorf("expected span name 'bazel.build build', got %s", span.Name())
-	}
-	cmd, ok := span.Attributes().Get("bazel.command")
-	if !ok || cmd.Str() != "build" {
-		t.Errorf("expected bazel.command=build, got %v", cmd)
-	}
+		span := tracesSink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+		if span.Name() != "bazel.build build" {
+			t.Errorf("expected span name 'bazel.build build', got %s", span.Name())
+		}
+		cmd, ok := span.Attributes().Get("bazel.command")
+		if !ok || cmd.Str() != "build" {
+			t.Errorf("expected bazel.command=build, got %v", cmd)
+		}
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		allMetrics := metricsSink.AllMetrics()
+		if len(allMetrics) != 1 {
+			t.Fatalf("expected 1 ConsumeMetrics call, got %d", len(allMetrics))
+		}
+
+		md := allMetrics[0]
+		if md.MetricCount() == 0 {
+			t.Fatal("expected metrics from BuildMetrics event, got 0")
+		}
+		if !hasMetricNamed(md, "bazel.invocation.wall_time") {
+			t.Error("expected bazel.invocation.wall_time gauge in metrics")
+		}
+		if !hasMetricNamed(md, "bazel.invocation.count") {
+			t.Error("expected bazel.invocation.count counter in metrics")
+		}
+	})
 }

--- a/receiver/besreceiver/receiver_test.go
+++ b/receiver/besreceiver/receiver_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestPublishBuildToolEventStream_HappyPath(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	r := &besReceiver{
@@ -70,7 +70,7 @@ func TestPublishBuildToolEventStream_EmptyStream(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 	r := &besReceiver{
 		logger:       zap.NewNop(),
-		traceBuilder: NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{}),
+		traceBuilder: NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{}),
 	}
 
 	stream := &mockBESStream{
@@ -88,7 +88,7 @@ func TestPublishBuildToolEventStream_EmptyStream(t *testing.T) {
 
 func TestPublishBuildToolEventStream_SendError(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	r := &besReceiver{
@@ -116,7 +116,7 @@ func TestPublishBuildToolEventStream_SendError(t *testing.T) {
 func TestPublishBuildToolEventStream_RetryableConsumerError(t *testing.T) {
 	// A non-permanent consumer error should close the stream so Bazel retries.
 	errSink := consumertest.NewErr(errors.New("pipeline overloaded"))
-	tb := NewTraceBuilder(errSink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(errSink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	r := &besReceiver{
@@ -148,7 +148,7 @@ func TestPublishBuildToolEventStream_PermanentConsumerError(t *testing.T) {
 	// A permanent consumer error should log but continue the stream.
 	permErr := consumererror.NewPermanent(errors.New("data rejected"))
 	errSink := consumertest.NewErr(permErr)
-	tb := NewTraceBuilder(errSink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(errSink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	r := &besReceiver{
@@ -210,7 +210,7 @@ func TestShutdownRespectsContextDeadline(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 	r := &besReceiver{
 		logger:       zap.NewNop(),
-		traceBuilder: NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{}),
+		traceBuilder: NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{}),
 		grpcServer:   grpc.NewServer(),
 	}
 
@@ -229,7 +229,7 @@ func TestShutdownRespectsContextDeadline(t *testing.T) {
 
 func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -297,7 +297,7 @@ func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 
 func TestTraceBuilder_BuildFinishedWithFailure(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -250,3 +250,24 @@ func makeBuildFinishedReq(t testing.TB, invID string, seqNum int64, code int32, 
 		},
 	})
 }
+
+func makeBuildMetricsReq(t testing.TB, invID string, seqNum, wallMs, cpuMs int64) *pb.PublishBuildToolEventStreamRequest {
+	t.Helper()
+	return makeBESRequest(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_BuildMetrics{BuildMetrics: &bep.BuildEventId_BuildMetricsId{}},
+		},
+		Payload: &bep.BuildEvent_BuildMetrics{
+			BuildMetrics: &bep.BuildMetrics{
+				TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+					WallTimeInMs: wallMs,
+					CpuTimeInMs:  cpuMs,
+				},
+				ActionSummary: &bep.BuildMetrics_ActionSummary{
+					ActionsCreated:  100,
+					ActionsExecuted: 80,
+				},
+			},
+		},
+	})
+}

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -191,6 +192,37 @@ func makeBuildMetricsOBE(t testing.TB, invID string, seqNum, wallMs, cpuMs int64
 			},
 		},
 	})
+}
+
+// sendAndACK sends a request on the stream, receives the ACK, and asserts the sequence number matches.
+func sendAndACK(t testing.TB, stream pb.PublishBuildEvent_PublishBuildToolEventStreamClient, req *pb.PublishBuildToolEventStreamRequest, expectedSeq int64) {
+	t.Helper()
+	if err := stream.Send(req); err != nil {
+		t.Fatalf("failed to send seq %d: %v", expectedSeq, err)
+	}
+	ack, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("failed to receive ACK %d: %v", expectedSeq, err)
+	}
+	if ack.GetSequenceNumber() != expectedSeq {
+		t.Errorf("expected ACK seq %d, got %d", expectedSeq, ack.GetSequenceNumber())
+	}
+}
+
+// hasMetricNamed returns true if any metric in md has the given name.
+func hasMetricNamed(md pmetric.Metrics, name string) bool {
+	for i := range md.ResourceMetrics().Len() {
+		rm := md.ResourceMetrics().At(i)
+		for j := range rm.ScopeMetrics().Len() {
+			sm := rm.ScopeMetrics().At(j)
+			for k := range sm.Metrics().Len() {
+				if sm.Metrics().At(k).Name() == name {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // --- BES request helpers (used by receiver stream tests) ---

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -427,12 +429,16 @@ func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[
 		nil,
 	)
 
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	md := buildInvocationGauges(invocationID, state, metrics, ts)
+
 	// BuildMetrics is typically the last event in the BEP stream.
 	// Clean up invocation state after consuming traces.
-	err := tb.consumeAndRecord(ctx, traces)
+	tracesErr := tb.consumeAndRecord(ctx, traces)
+	metricsErr := tb.consumeMetrics(ctx, md)
 	delete(invocations, invocationID)
 	tb.activeInvocations.Add(ctx, -1)
-	return err
+	return errors.Join(tracesErr, metricsErr)
 }
 
 // consumeAndRecord forwards traces to the next consumer and records an error metric on failure.
@@ -450,6 +456,20 @@ func (tb *TraceBuilder) consumeAndRecord(ctx context.Context, traces ptrace.Trac
 			attribute.String("error_type", errorType),
 		))
 		return fmt.Errorf("consuming traces: %w", err)
+	}
+	return nil
+}
+
+// consumeMetrics forwards metrics to the next consumer. No-op if metricsConsumer is nil.
+func (tb *TraceBuilder) consumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if tb.metricsConsumer == nil {
+		return nil
+	}
+	if md.MetricCount() == 0 {
+		return nil
+	}
+	if err := tb.metricsConsumer.ConsumeMetrics(ctx, md); err != nil {
+		return fmt.Errorf("consuming metrics: %w", err)
 	}
 	return nil
 }

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -43,11 +43,12 @@ type TraceBuilderConfig struct {
 	MeterProvider     metric.MeterProvider
 }
 
-// TraceBuilder converts BEP events into OTel trace spans and log records.
+// TraceBuilder converts BEP events into OTel traces, logs, and metrics.
 // All invocation state is owned by a single goroutine started via Start().
 type TraceBuilder struct {
 	tracesConsumer    consumer.Traces
 	logsConsumer      consumer.Logs
+	metricsConsumer   consumer.Metrics
 	logger            *zap.Logger
 	invocationTimeout time.Duration
 	reaperInterval    time.Duration
@@ -64,9 +65,9 @@ type TraceBuilder struct {
 }
 
 // NewTraceBuilder creates a new TraceBuilder.
-// Either consumer may be nil if only one signal is configured.
+// Any consumer may be nil if that signal is not configured.
 // Zero-value fields in cfg get sensible defaults.
-func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs, logger *zap.Logger, cfg TraceBuilderConfig) *TraceBuilder {
+func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs, metricsConsumer consumer.Metrics, logger *zap.Logger, cfg TraceBuilderConfig) *TraceBuilder {
 	if cfg.InvocationTimeout <= 0 {
 		cfg.InvocationTimeout = defaultInvocationTimeout
 	}
@@ -90,9 +91,10 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		metric.WithDescription("Total errors from the traces consumer"),
 	)
 	return &TraceBuilder{
-		tracesConsumer:    tracesConsumer,
-		logsConsumer:      logsConsumer,
-		logger:            logger,
+		tracesConsumer:  tracesConsumer,
+		logsConsumer:    logsConsumer,
+		metricsConsumer: metricsConsumer,
+		logger:          logger,
 		invocationTimeout: cfg.InvocationTimeout,
 		reaperInterval:    cfg.ReaperInterval,
 		activeInvocations: activeInvocations,

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -59,6 +59,9 @@ type TraceBuilder struct {
 	doneCh            chan struct{}
 	stopOnce          sync.Once
 
+	// Cumulative counters for cross-invocation metrics.
+	counters *cumulativeCounters
+
 	// Internal metrics for observability.
 	activeInvocations metric.Int64UpDownCounter
 	eventsProcessed   metric.Int64Counter
@@ -93,12 +96,13 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		metric.WithDescription("Total errors from the traces consumer"),
 	)
 	return &TraceBuilder{
-		tracesConsumer:  tracesConsumer,
-		logsConsumer:    logsConsumer,
-		metricsConsumer: metricsConsumer,
-		logger:          logger,
+		tracesConsumer:    tracesConsumer,
+		logsConsumer:      logsConsumer,
+		metricsConsumer:   metricsConsumer,
+		logger:            logger,
 		invocationTimeout: cfg.InvocationTimeout,
 		reaperInterval:    cfg.ReaperInterval,
+		counters:          newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
 		activeInvocations: activeInvocations,
 		eventsProcessed:   eventsProcessed,
 		invocationsReaped: invocationsReaped,
@@ -431,6 +435,11 @@ func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[
 
 	ts := pcommon.NewTimestampFromTime(time.Now())
 	md := buildInvocationGauges(invocationID, state, metrics, ts)
+
+	// Update cumulative counters and merge into the same metrics payload.
+	tb.counters.record(metrics)
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	tb.counters.appendTo(sm, ts)
 
 	// BuildMetrics is typically the last event in the BEP stream.
 	// Clean up invocation state after consuming traces.

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -852,7 +852,7 @@ func TestTraceBuilder_LogConsumerErrorDoesNotBreakTraces(t *testing.T) {
 
 func TestActionSpanName_EmptyMnemonic(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -884,7 +884,7 @@ func TestActionSpanName_EmptyMnemonic(t *testing.T) {
 
 func TestBuildSpanName_EmptyCommand(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -900,5 +900,71 @@ func TestBuildSpanName_EmptyCommand(t *testing.T) {
 	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	if span.Name() != "bazel.build" {
 		t.Errorf("expected span name 'bazel.build' (no trailing space), got %q", span.Name())
+	}
+}
+
+func TestTraceBuilder_CumulativeCountersAcrossInvocations(t *testing.T) {
+	tracesSink := new(consumertest.TracesSink)
+	metricsSink := new(consumertest.MetricsSink)
+	tb := NewTraceBuilder(tracesSink, nil, metricsSink, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// First invocation.
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-c1", "uuid-c1", "build", 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-c1", 2, 0, "SUCCESS")); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildMetricsOBE(t, "inv-c1", 3, 10000, 5000)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second invocation.
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-c2", "uuid-c2", "test", 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-c2", 2, 0, "SUCCESS")); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildMetricsOBE(t, "inv-c2", 3, 20000, 8000)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have 2 ConsumeMetrics calls (one per BuildMetrics event).
+	allMetrics := metricsSink.AllMetrics()
+	if len(allMetrics) != 2 {
+		t.Fatalf("expected 2 ConsumeMetrics calls, got %d", len(allMetrics))
+	}
+
+	// Find the cumulative invocation count in the second batch — should be 2.
+	lastMD := allMetrics[1]
+	found := false
+	for i := range lastMD.ResourceMetrics().Len() {
+		rm := lastMD.ResourceMetrics().At(i)
+		for j := range rm.ScopeMetrics().Len() {
+			sm := rm.ScopeMetrics().At(j)
+			for k := range sm.Metrics().Len() {
+				m := sm.Metrics().At(k)
+				if m.Name() == "bazel.invocation.count" {
+					found = true
+					dp := m.Sum().DataPoints().At(0)
+					if dp.IntValue() != 2 {
+						t.Errorf("expected invocation count=2 after two builds, got %d", dp.IntValue())
+					}
+				}
+				if m.Name() == "bazel.invocation.wall_time.total" {
+					dp := m.Sum().DataPoints().At(0)
+					if dp.IntValue() != 30000 {
+						t.Errorf("expected total wall_time=30000, got %d", dp.IntValue())
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected to find bazel.invocation.count metric in second batch")
 	}
 }

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestTraceBuilder_BuildStarted(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -59,7 +59,7 @@ func TestTraceBuilder_BuildStarted(t *testing.T) {
 
 func TestTraceBuilder_ActionExecuted(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -111,7 +111,7 @@ func TestTraceBuilder_ActionExecuted(t *testing.T) {
 
 func TestTraceBuilder_BuildFinished(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -169,7 +169,7 @@ func TestTraceBuilder_BuildFinished(t *testing.T) {
 
 func TestTraceBuilder_TestResult(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -218,7 +218,7 @@ func TestTraceBuilder_TestResult(t *testing.T) {
 
 func TestTraceBuilder_ConcurrentInvocations(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -255,7 +255,7 @@ func TestTraceBuilder_ConcurrentInvocations(t *testing.T) {
 
 func TestTraceBuilder_BuildMetricsDeletesState(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -296,7 +296,7 @@ func TestTraceBuilder_BuildMetricsDeletesState(t *testing.T) {
 
 func TestTraceBuilder_ParseErrorIsPermanent(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -329,7 +329,7 @@ func TestTraceBuilder_ParseErrorIsPermanent(t *testing.T) {
 
 func TestTraceBuilder_BatchFlushSingleConsumeCall(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -454,7 +454,7 @@ func TestTraceBuilder_ConcurrentStreams(t *testing.T) {
 	}
 
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -501,7 +501,7 @@ func TestTraceBuilder_ConcurrentStreams(t *testing.T) {
 
 func TestTraceBuilder_EventBeforeBuildStarted(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -528,7 +528,7 @@ func TestTraceBuilder_EventBeforeBuildStarted(t *testing.T) {
 
 func TestTraceBuilder_EventAfterStateCleanup(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -561,7 +561,7 @@ func TestTraceBuilder_EventAfterStateCleanup(t *testing.T) {
 
 func TestReapStale(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, zap.NewNop(), TraceBuilderConfig{
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
 		InvocationTimeout: time.Nanosecond,
 		ReaperInterval:    time.Nanosecond,
 	})
@@ -662,7 +662,7 @@ func TestTargetKey_Uniqueness(t *testing.T) {
 func TestTraceBuilder_LogsEmitted(t *testing.T) {
 	tracesSink := new(consumertest.TracesSink)
 	logsSink := new(consumertest.LogsSink)
-	tb := NewTraceBuilder(tracesSink, logsSink, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(tracesSink, logsSink, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -745,7 +745,7 @@ func TestTraceBuilder_LogsEmitted(t *testing.T) {
 
 func TestTraceBuilder_LogsOnly(t *testing.T) {
 	logsSink := new(consumertest.LogsSink)
-	tb := NewTraceBuilder(nil, logsSink, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(nil, logsSink, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -765,7 +765,7 @@ func TestTraceBuilder_LogsOnly(t *testing.T) {
 
 func TestTraceBuilder_TracesOnly(t *testing.T) {
 	tracesSink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(tracesSink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(tracesSink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -785,7 +785,7 @@ func TestTraceBuilder_TracesOnly(t *testing.T) {
 
 func TestTraceBuilder_LogSeverity(t *testing.T) {
 	logsSink := new(consumertest.LogsSink)
-	tb := NewTraceBuilder(nil, logsSink, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(nil, logsSink, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -831,7 +831,7 @@ func TestTraceBuilder_LogConsumerErrorDoesNotBreakTraces(t *testing.T) {
 	tracesSink := new(consumertest.TracesSink)
 	errLogsSink := consumertest.NewErr(errors.New("logs pipeline overloaded"))
 
-	tb := NewTraceBuilder(tracesSink, errLogsSink, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(tracesSink, errLogsSink, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Add metrics signal support to the BES receiver. Bazel's `BuildMetrics` BEP event is now converted into OpenTelemetry metrics alongside the existing traces and logs.

The `metricsConsumer` is wired through factory, receiver, and `TraceBuilder`. Per-invocation **gauges** capture build timings, action counts, and memory usage (10 metrics). **Cumulative counters** track running totals across invocations (invocation count, aggregate wall/CPU time, total actions created/executed). Both are emitted in a single `ConsumeMetrics` call per build.

### Metric catalog

| Metric | Type | Description |
|---|---|---|
| `bazel.build.wall_time` | Gauge | Wall-clock duration of the build |
| `bazel.build.cpu_time` | Gauge | CPU time consumed |
| `bazel.build.analysis_phase_time` | Gauge | Time spent in analysis phase |
| `bazel.build.execution_phase_time` | Gauge | Time spent in execution phase |
| `bazel.build.actions_execution_start_time` | Gauge | Time from build start to first action execution |
| `bazel.build.critical_path_time` | Gauge | Critical path wall time |
| `bazel.build.actions_created` | Gauge | Number of actions created |
| `bazel.build.actions_executed` | Gauge | Number of actions executed |
| `bazel.build.memory.used_heap_post_build` | Gauge | Heap size after build completes |
| `bazel.build.memory.peak_post_gc_heap` | Gauge | Peak heap size after GC |
| `bazel.build.invocations_total` | Sum (cumulative) | Running count of invocations |
| `bazel.build.wall_time_total` | Sum (cumulative) | Aggregate wall time across builds |
| `bazel.build.cpu_time_total` | Sum (cumulative) | Aggregate CPU time across builds |
| `bazel.build.actions_created_total` | Sum (cumulative) | Aggregate actions created |
| `bazel.build.actions_executed_total` | Sum (cumulative) | Aggregate actions executed |

## Test plan

- [x] Unit tests for per-invocation gauge construction (`metricsbuilder_test.go`)
- [x] Unit tests for cumulative counter semantics (monotonic, additive across calls)
- [x] Integration test sends `BuildMetrics` over gRPC and asserts metrics via `MetricsSink`
- [x] Existing trace and log tests pass unchanged
