### PR TITLE
feat(ci): add nilaway and deadcode static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,21 @@ jobs:
         with:
           version: v2.10
 
+  analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Run nilaway
+        run: go run go.uber.org/nilaway/cmd/nilaway@latest ./...
+
+      - name: Run deadcode
+        run: go run golang.org/x/tools/cmd/deadcode@latest -test ./...
+
   bench:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all build test test-short test-cover test-bench lint vet clean fuzz fix generate ocb ci docker \
-       compose-build compose-up compose-down compose-clean example agent-status
+       compose-build compose-up compose-down compose-clean example agent-status nilaway deadcode
 
 # Use absolute path: GNU Make 3.81 (macOS default) doesn't propagate export PATH to recipe shells.
 GOTESTSUM := $(shell go env GOPATH)/bin/gotestsum
@@ -60,6 +60,14 @@ clean:
 ## ocb: Build the custom collector binary with OCB
 ocb:
 	builder --config builder-config.yaml
+
+## nilaway: Run Uber's nil-pointer flow analysis
+nilaway:
+	go run go.uber.org/nilaway/cmd/nilaway@latest ./...
+
+## deadcode: Find unreachable functions via call-graph analysis
+deadcode:
+	go run golang.org/x/tools/cmd/deadcode@latest -test ./...
 
 ## ci: Run the full CI chain locally
 ci: vet lint test build

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -180,18 +180,40 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 	tb.eventsProcessed.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("event_type", eventTypeName(event)),
 	))
-	switch p := event.GetPayload().(type) {
+	payload := event.GetPayload()
+	if payload == nil {
+		return nil
+	}
+	switch p := payload.(type) {
 	case *bep.BuildEvent_Started:
+		if p.Started == nil {
+			return nil
+		}
 		return tb.handleBuildStarted(ctx, invocations, invocationID, p.Started)
 	case *bep.BuildEvent_Configured:
+		if p.Configured == nil {
+			return nil
+		}
 		return tb.handleTargetConfigured(ctx, invocations, invocationID, event.GetId(), p.Configured)
 	case *bep.BuildEvent_Action:
+		if p.Action == nil {
+			return nil
+		}
 		return tb.handleActionExecuted(ctx, invocations, invocationID, event.GetId(), p.Action)
 	case *bep.BuildEvent_TestResult:
+		if p.TestResult == nil {
+			return nil
+		}
 		return tb.handleTestResult(ctx, invocations, invocationID, event.GetId(), p.TestResult)
 	case *bep.BuildEvent_Finished:
+		if p.Finished == nil {
+			return nil
+		}
 		return tb.handleBuildFinished(ctx, invocations, invocationID, p.Finished)
 	case *bep.BuildEvent_BuildMetrics:
+		if p.BuildMetrics == nil {
+			return nil
+		}
 		return tb.handleBuildMetrics(ctx, invocations, invocationID, p.BuildMetrics)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Add `make nilaway` (Uber's nil-pointer flow analysis) and `make deadcode` (call-graph reachability from x/tools) as Makefile targets and a CI `analysis` job. Fix the nil-dereference finding nilaway flagged in `processEvent`'s oneof type switch by guarding `GetPayload()` and its inner fields before dereferencing.

## Test plan

Verify `make nilaway`, `make deadcode`, `make test`, and `make lint` all pass clean.
