### PR TITLE
Pin vendored BEP protos to specific Bazel commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ make docker     # docker build
 
 ## Dependencies
 
-- **BEP types**: vendored proto sources in `third_party/bazel/protobuf/`, generated Go code in `internal/bep/`
+- **BEP types**: vendored proto sources in `third_party/bazel/protobuf/`, generated Go code in `internal/bep/`. Version pinned in `third_party/bazel/VERSION`
 - **BES gRPC transport**: `google.golang.org/genproto/googleapis/devtools/build/v1` (pre-compiled `PublishBuildEvent` service)
 - **OTel Collector**: `go.opentelemetry.io/collector/{component,consumer,receiver,pdata,config/configgrpc}` — v1.52.0 stable / v0.146.1 experimental
 
@@ -74,7 +74,7 @@ make docker     # docker build
 - **OpenTelemetry over Datadog native**: vendor-neutral, multi-backend via YAML config
 - **pdata API, not OTel SDK**: we construct traces retrospectively from an event stream, not instrumenting live code — pdata gives explicit control over TraceIDs, SpanIDs, timestamps
 - **Deterministic traceID**: SHA-256 of invocation UUID, so the same build always produces the same trace ID
-- **Vendored BEP protos**: proto sources in `third_party/bazel/protobuf/`, generated Go code in `internal/bep/` — keeps the project self-contained with no external replace directives
+- **Vendored BEP protos**: proto sources in `third_party/bazel/protobuf/`, generated Go code in `internal/bep/` — keeps the project self-contained with no external replace directives. Pinned to a specific Bazel commit in `third_party/bazel/VERSION`; see `third_party/bazel/README.md` for update instructions
 
 ## Testing patterns
 

--- a/third_party/bazel/README.md
+++ b/third_party/bazel/README.md
@@ -4,3 +4,44 @@ There is no official generated Go code for the Build Event Stream protobuf defin
 This directory contains the original protobuf definitions extracted from the
 [Bazel source tree](https://github.com/bazelbuild/bazel/tree/master/src/main/protobuf).
 Go code is generated with `buf generate` and committed to `internal/bep/`.
+
+## Version
+
+The vendored protos are pinned to a specific Bazel commit recorded in the
+[VERSION](VERSION) file. See that file for the exact commit hash and nearest
+release tag.
+
+Proto3 wire compatibility means this receiver works with a range of Bazel
+versions — older Bazel simply won't emit newer fields (zero-valued), and newer
+Bazel's unknown fields are silently preserved on the wire but ignored by the
+generated Go code. Update the protos when a new Bazel version adds events or
+fields you want to handle.
+
+**Tested with**: Bazel 7.x through 9.x.
+
+## Updating
+
+1. Identify the target Bazel commit or release tag.
+2. Copy the proto files listed below from the Bazel source tree.
+3. Flatten import paths (e.g., `src/main/protobuf/foo.proto` → `foo.proto`).
+4. Replace `java_package`/`java_outer_classname` options with the appropriate
+   `go_package` option for each file.
+5. Update `VERSION` with the new commit hash, date, and nearest release.
+6. Run `make generate` to regenerate the Go code in `internal/bep/`.
+7. Run `make test` to verify nothing broke.
+
+## Source files
+
+Proto files in this directory and their Bazel source locations:
+
+| Local file | Bazel source path |
+|---|---|
+| `build_event_stream.proto` | `src/main/java/com/google/devtools/build/lib/buildeventstream/proto/` |
+| `package_load_metrics.proto` | `src/main/java/com/google/devtools/build/lib/packages/metrics/` |
+| `analysis_cache_service_metadata_status.proto` | `src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis/proto/` |
+| `action_cache.proto` | `src/main/protobuf/` |
+| `command_line.proto` | `src/main/protobuf/` |
+| `failure_details.proto` | `src/main/protobuf/` |
+| `invocation_policy.proto` | `src/main/protobuf/` |
+| `option_filters.proto` | `src/main/protobuf/` |
+| `strategy_policy.proto` | `src/main/protobuf/` |

--- a/third_party/bazel/VERSION
+++ b/third_party/bazel/VERSION
@@ -1,0 +1,10 @@
+# Bazel source commit from which the BEP protobuf definitions were extracted.
+# This is a master branch commit (post-9.0.1), not a tagged release.
+#
+# To update: check out the target commit, copy the proto files listed in
+# README.md, adjust import paths and go_package options, then run
+# `make generate` to regenerate the Go code.
+
+BAZEL_COMMIT=7761553ba254f84cfdf34981b5a4a536e9b014b9
+BAZEL_COMMIT_DATE=2026-02-19
+BAZEL_NEAREST_RELEASE=9.0.1


### PR DESCRIPTION
## Summary

The vendored protobuf definitions in `third_party/bazel/` were extracted from Bazel's master branch with no record of which version they came from. This makes it impossible to reason about compatibility with specific Bazel releases or to know what changed when updating the protos.

This adds a `VERSION` file that records the exact source commit (`7761553`, 2026-02-19, post-9.0.1) and expands the README with a compatibility statement (tested with Bazel 7.x through 9.x), step-by-step update instructions, and a table mapping each local proto file to its location in the Bazel source tree. Proto3 wire compatibility gives us a wide working range — older Bazel versions simply leave newer fields zero-valued, and newer Bazel versions add unknown fields that the generated Go code ignores — so pinning is about hygiene and diffability, not strict version locking.

No code changes, no regenerated files.

## Test plan

- `make test` passes (docs-only change, no functional impact)
- Verified vendored protos match Bazel commit `7761553` by diffing each file against the GitHub API (only expected import path and `go_package` differences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)