### PR TITLE
Add start_position to Datadog log collection config

### DIFF
--- a/examples/datadog/conf.d/otelcol.yaml
+++ b/examples/datadog/conf.d/otelcol.yaml
@@ -3,6 +3,9 @@ logs:
     path: /var/log/otelcol/collector.log
     source: otelcol-bazel
     service: otelcol-bazel
+    # Read the log file from the start on first discovery, useful for debugging
+    # and local development. In production, remove this to only tail new entries.
+    start_position: beginning
     tags:
       - "env:dev"
       - "version:dev"


### PR DESCRIPTION
The Datadog Agent log collection config for the example setup defaults to tailing from the end of the log file, which means logs written before the Agent starts are silently dropped. This is inconvenient during local development and debugging where the collector often starts before the Agent.

Setting `start_position: beginning` ensures the full log file is ingested on first discovery. This is scoped to the dev example config — production deployments should remove it to avoid reprocessing old entries on Agent restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)