### PR TITLE
feat(besdiff): add tool to structurally diff .besstream files

### DIFF
--- a/cmd/besdiff/main.go
+++ b/cmd/besdiff/main.go
@@ -23,14 +23,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "usage: besdiff <file1> <file2>\n")
 		os.Exit(1)
 	}
-	a, err := loadStream(os.Args[1])
+	pathA, pathB := os.Args[1], os.Args[2]
+	a, err := loadStream(pathA)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "loading %s: %v\n", os.Args[1], err)
+		fmt.Fprintln(os.Stderr, "loading:", err)
 		os.Exit(1)
 	}
-	b, err := loadStream(os.Args[2])
+	b, err := loadStream(pathB)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "loading %s: %v\n", os.Args[2], err)
+		fmt.Fprintln(os.Stderr, "loading:", err)
 		os.Exit(1)
 	}
 
@@ -163,6 +164,9 @@ func bepEventType(be *bep.BuildEvent) string { //nolint:gocyclo,cyclop // type s
 	case *bep.BuildEventId_UnstructuredCommandLine:
 		return "UnstructuredCommandLine"
 	case *bep.BuildEventId_StructuredCommandLine:
+		if v.StructuredCommandLine == nil {
+			return "StructuredCommandLine()"
+		}
 		return fmt.Sprintf("StructuredCommandLine(%s)", v.StructuredCommandLine.GetCommandLineLabel())
 	case *bep.BuildEventId_WorkspaceStatus:
 		return "WorkspaceStatus"

--- a/cmd/besdiff/main.go
+++ b/cmd/besdiff/main.go
@@ -5,18 +5,21 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
-	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
-	"github.com/chagui/besreceiver/internal/besio"
+	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+	"github.com/chagui/besreceiver/internal/besio"
 )
 
+const expectedArgs = 3
+
 func main() {
-	if len(os.Args) != 3 {
+	if len(os.Args) != expectedArgs {
 		fmt.Fprintf(os.Stderr, "usage: besdiff <file1> <file2>\n")
 		os.Exit(1)
 	}
@@ -39,7 +42,11 @@ func main() {
 	fmt.Println("=== BEP event type sequence ===")
 	fmt.Printf("A: %d BEP events, B: %d BEP events\n\n", len(eventsA), len(eventsB))
 
-	// Count event types.
+	printTypeCounts(eventsA, eventsB)
+	printStructuralDiffs(eventsA, eventsB)
+}
+
+func printTypeCounts(eventsA, eventsB []eventInfo) {
 	countsA := countTypes(eventsA)
 	countsB := countTypes(eventsB)
 
@@ -62,16 +69,14 @@ func main() {
 		}
 		fmt.Printf("%-50s %5d %5d %s\n", t, ca, cb, delta)
 	}
+}
 
-	// Show structural diffs: events only in one side, or different BEP type at same index.
+func printStructuralDiffs(eventsA, eventsB []eventInfo) {
 	fmt.Println("\n=== Structural differences (ignoring timestamps/UUIDs) ===")
-	max := len(eventsA)
-	if len(eventsB) > max {
-		max = len(eventsB)
-	}
+	total := max(len(eventsA), len(eventsB))
 	diffs := 0
 	opts := prototext.MarshalOptions{Multiline: true, Indent: "  "}
-	for i := 0; i < max; i++ {
+	for i := range total {
 		if i >= len(eventsA) {
 			diffs++
 			fmt.Printf("Message %d: only in B — %s\n", i, eventsB[i].eventType)
@@ -107,7 +112,7 @@ type eventInfo struct {
 }
 
 func extractBEPTypes(reqs []*pb.PublishBuildToolEventStreamRequest) []eventInfo {
-	var events []eventInfo
+	events := make([]eventInfo, 0, len(reqs))
 	for _, req := range reqs {
 		obe := req.GetOrderedBuildEvent()
 		if obe == nil {
@@ -147,12 +152,12 @@ func parseBEP(a *anypb.Any) *bep.BuildEvent {
 	return &be
 }
 
-func bepEventType(be *bep.BuildEvent) string {
+func bepEventType(be *bep.BuildEvent) string { //nolint:gocyclo,cyclop // type switch over BEP event IDs is inherently branchy
 	id := be.GetId()
 	if id == nil {
 		return "no_id"
 	}
-	switch v := id.Id.(type) {
+	switch v := id.GetId().(type) {
 	case *bep.BuildEventId_Started:
 		return "Started"
 	case *bep.BuildEventId_UnstructuredCommandLine:
@@ -191,7 +196,7 @@ func bepEventType(be *bep.BuildEvent) string {
 	case *bep.BuildEventId_BuildToolLogs:
 		return "BuildToolLogs"
 	default:
-		return fmt.Sprintf("other(%T)", id.Id)
+		return fmt.Sprintf("other(%T)", id.GetId())
 	}
 }
 
@@ -204,10 +209,14 @@ func countTypes(events []eventInfo) map[string]int {
 }
 
 func loadStream(path string) ([]*pb.PublishBuildToolEventStreamRequest, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("opening %s: %w", path, err)
 	}
 	defer f.Close()
-	return besio.ReadStream(f)
+	reqs, err := besio.ReadStream(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading stream from %s: %w", path, err)
+	}
+	return reqs, nil
 }

--- a/cmd/besdiff/main.go
+++ b/cmd/besdiff/main.go
@@ -3,9 +3,9 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -16,20 +16,18 @@ import (
 	"github.com/chagui/besreceiver/internal/besio"
 )
 
-const expectedArgs = 3
-
 func main() {
-	if len(os.Args) != expectedArgs {
+	flag.Parse()
+	if flag.NArg() != 2 { //nolint:mnd // exactly two positional args: file1 and file2
 		fmt.Fprintf(os.Stderr, "usage: besdiff <file1> <file2>\n")
 		os.Exit(1)
 	}
-	pathA, pathB := os.Args[1], os.Args[2]
-	a, err := loadStream(pathA)
+	a, err := loadStream(flag.Arg(0))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "loading:", err)
 		os.Exit(1)
 	}
-	b, err := loadStream(pathB)
+	b, err := loadStream(flag.Arg(1))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "loading:", err)
 		os.Exit(1)
@@ -158,15 +156,16 @@ func bepEventType(be *bep.BuildEvent) string { //nolint:gocyclo,cyclop // type s
 	if id == nil {
 		return "no_id"
 	}
-	switch v := id.GetId().(type) {
+	idVal := id.GetId()
+	if idVal == nil {
+		return "no_id"
+	}
+	switch v := idVal.(type) {
 	case *bep.BuildEventId_Started:
 		return "Started"
 	case *bep.BuildEventId_UnstructuredCommandLine:
 		return "UnstructuredCommandLine"
 	case *bep.BuildEventId_StructuredCommandLine:
-		if v.StructuredCommandLine == nil {
-			return "StructuredCommandLine()"
-		}
 		return fmt.Sprintf("StructuredCommandLine(%s)", v.StructuredCommandLine.GetCommandLineLabel())
 	case *bep.BuildEventId_WorkspaceStatus:
 		return "WorkspaceStatus"
@@ -200,7 +199,7 @@ func bepEventType(be *bep.BuildEvent) string { //nolint:gocyclo,cyclop // type s
 	case *bep.BuildEventId_BuildToolLogs:
 		return "BuildToolLogs"
 	default:
-		return fmt.Sprintf("other(%T)", id.GetId())
+		return fmt.Sprintf("other(%T)", idVal)
 	}
 }
 
@@ -213,7 +212,7 @@ func countTypes(events []eventInfo) map[string]int {
 }
 
 func loadStream(path string) ([]*pb.PublishBuildToolEventStreamRequest, error) {
-	f, err := os.Open(filepath.Clean(path))
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening %s: %w", path, err)
 	}

--- a/cmd/besdiff/main.go
+++ b/cmd/besdiff/main.go
@@ -1,0 +1,213 @@
+// Command besdiff decodes two .besstream files and prints a structural summary
+// comparing their BEP events, ignoring ephemeral fields (UUIDs, timestamps).
+package main
+
+import (
+	"fmt"
+	"os"
+
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+	"github.com/chagui/besreceiver/internal/besio"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: besdiff <file1> <file2>\n")
+		os.Exit(1)
+	}
+	a, err := loadStream(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "loading %s: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
+	b, err := loadStream(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "loading %s: %v\n", os.Args[2], err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("File A: %d messages\nFile B: %d messages\n\n", len(a), len(b))
+
+	eventsA := extractBEPTypes(a)
+	eventsB := extractBEPTypes(b)
+
+	fmt.Println("=== BEP event type sequence ===")
+	fmt.Printf("A: %d BEP events, B: %d BEP events\n\n", len(eventsA), len(eventsB))
+
+	// Count event types.
+	countsA := countTypes(eventsA)
+	countsB := countTypes(eventsB)
+
+	allTypes := make(map[string]bool)
+	for k := range countsA {
+		allTypes[k] = true
+	}
+	for k := range countsB {
+		allTypes[k] = true
+	}
+
+	fmt.Println("=== Event type counts ===")
+	fmt.Printf("%-50s %5s %5s %s\n", "Event Type", "A", "B", "Delta")
+	fmt.Println("---")
+	for t := range allTypes {
+		ca, cb := countsA[t], countsB[t]
+		delta := ""
+		if ca != cb {
+			delta = fmt.Sprintf("%+d", cb-ca)
+		}
+		fmt.Printf("%-50s %5d %5d %s\n", t, ca, cb, delta)
+	}
+
+	// Show structural diffs: events only in one side, or different BEP type at same index.
+	fmt.Println("\n=== Structural differences (ignoring timestamps/UUIDs) ===")
+	max := len(eventsA)
+	if len(eventsB) > max {
+		max = len(eventsB)
+	}
+	diffs := 0
+	opts := prototext.MarshalOptions{Multiline: true, Indent: "  "}
+	for i := 0; i < max; i++ {
+		if i >= len(eventsA) {
+			diffs++
+			fmt.Printf("Message %d: only in B — %s\n", i, eventsB[i].eventType)
+			if eventsB[i].bepEvent != nil {
+				fmt.Printf("  %s\n", opts.Format(eventsB[i].bepEvent))
+			}
+			continue
+		}
+		if i >= len(eventsB) {
+			diffs++
+			fmt.Printf("Message %d: only in A — %s\n", i, eventsA[i].eventType)
+			if eventsA[i].bepEvent != nil {
+				fmt.Printf("  %s\n", opts.Format(eventsA[i].bepEvent))
+			}
+			continue
+		}
+		if eventsA[i].eventType != eventsB[i].eventType {
+			diffs++
+			fmt.Printf("Message %d: type changed: %s → %s\n", i, eventsA[i].eventType, eventsB[i].eventType)
+		}
+	}
+	if diffs == 0 {
+		fmt.Println("No structural differences — same event types in the same order.")
+		fmt.Println("Differences are limited to ephemeral fields (UUIDs, timestamps, hashes).")
+	} else {
+		fmt.Printf("\n%d structural difference(s) found.\n", diffs)
+	}
+}
+
+type eventInfo struct {
+	eventType string
+	bepEvent  *bep.BuildEvent
+}
+
+func extractBEPTypes(reqs []*pb.PublishBuildToolEventStreamRequest) []eventInfo {
+	var events []eventInfo
+	for _, req := range reqs {
+		obe := req.GetOrderedBuildEvent()
+		if obe == nil {
+			continue
+		}
+		evt := obe.GetEvent()
+		if evt == nil {
+			continue
+		}
+		bazelEvt := evt.GetBazelEvent()
+		if bazelEvt == nil {
+			// Component lifecycle events (TOOL/CONTROLLER streams).
+			events = append(events, eventInfo{
+				eventType: fmt.Sprintf("lifecycle:%s:seq%d",
+					obe.GetStreamId().GetComponent(), obe.GetSequenceNumber()),
+			})
+			continue
+		}
+		be := parseBEP(bazelEvt)
+		if be == nil {
+			events = append(events, eventInfo{eventType: "unknown"})
+			continue
+		}
+		events = append(events, eventInfo{
+			eventType: bepEventType(be),
+			bepEvent:  be,
+		})
+	}
+	return events
+}
+
+func parseBEP(a *anypb.Any) *bep.BuildEvent {
+	var be bep.BuildEvent
+	if err := proto.Unmarshal(a.GetValue(), &be); err != nil {
+		return nil
+	}
+	return &be
+}
+
+func bepEventType(be *bep.BuildEvent) string {
+	id := be.GetId()
+	if id == nil {
+		return "no_id"
+	}
+	switch v := id.Id.(type) {
+	case *bep.BuildEventId_Started:
+		return "Started"
+	case *bep.BuildEventId_UnstructuredCommandLine:
+		return "UnstructuredCommandLine"
+	case *bep.BuildEventId_StructuredCommandLine:
+		return fmt.Sprintf("StructuredCommandLine(%s)", v.StructuredCommandLine.GetCommandLineLabel())
+	case *bep.BuildEventId_WorkspaceStatus:
+		return "WorkspaceStatus"
+	case *bep.BuildEventId_OptionsParsed:
+		return "OptionsParsed"
+	case *bep.BuildEventId_Configuration:
+		return "Configuration"
+	case *bep.BuildEventId_Pattern:
+		return "Pattern"
+	case *bep.BuildEventId_TargetConfigured:
+		return fmt.Sprintf("TargetConfigured(%s)", v.TargetConfigured.GetLabel())
+	case *bep.BuildEventId_TargetCompleted:
+		return fmt.Sprintf("TargetCompleted(%s)", v.TargetCompleted.GetLabel())
+	case *bep.BuildEventId_ActionCompleted:
+		return fmt.Sprintf("ActionCompleted(%s)", v.ActionCompleted.GetLabel())
+	case *bep.BuildEventId_TestResult:
+		return fmt.Sprintf("TestResult(%s,run=%d,shard=%d,attempt=%d)",
+			v.TestResult.GetLabel(), v.TestResult.GetRun(), v.TestResult.GetShard(), v.TestResult.GetAttempt())
+	case *bep.BuildEventId_TestSummary:
+		return fmt.Sprintf("TestSummary(%s)", v.TestSummary.GetLabel())
+	case *bep.BuildEventId_BuildFinished:
+		return "BuildFinished"
+	case *bep.BuildEventId_BuildMetrics:
+		return "BuildMetrics"
+	case *bep.BuildEventId_Progress:
+		return fmt.Sprintf("Progress(%d)", v.Progress.GetOpaqueCount())
+	case *bep.BuildEventId_NamedSet:
+		return fmt.Sprintf("NamedSet(%s)", v.NamedSet.GetId())
+	case *bep.BuildEventId_Fetch:
+		return fmt.Sprintf("Fetch(%s)", v.Fetch.GetUrl())
+	case *bep.BuildEventId_BuildToolLogs:
+		return "BuildToolLogs"
+	default:
+		return fmt.Sprintf("other(%T)", id.Id)
+	}
+}
+
+func countTypes(events []eventInfo) map[string]int {
+	counts := make(map[string]int)
+	for _, e := range events {
+		counts[e.eventType]++
+	}
+	return counts
+}
+
+func loadStream(path string) ([]*pb.PublishBuildToolEventStreamRequest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return besio.ReadStream(f)
+}


### PR DESCRIPTION
## Summary
- Adds `cmd/besdiff`, a CLI tool that decodes two `.besstream` files and compares their BEP event types structurally, ignoring ephemeral fields (UUIDs, timestamps, hashes).
- Reports event type counts with deltas, and positional ordering differences.
- Useful for diagnosing whether a re-recorded fixture contains new/missing events or just non-deterministic reordering.

## Test plan
- [x] `go vet ./cmd/besdiff/` passes
- [x] `go run ./cmd/besdiff <file1> <file2>` with identical files reports no structural differences
- [x] `go run ./cmd/besdiff <file1> <file2>` with different recordings of the same build reports ordering differences only

🤖 Generated with [Claude Code](https://claude.com/claude-code)