### PR TITLE
docs(readme): add build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # besreceiver
 
+[![CI](https://github.com/chagui/besreceiver/actions/workflows/ci.yml/badge.svg)](https://github.com/chagui/besreceiver/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/chagui/besreceiver.svg)](https://pkg.go.dev/github.com/chagui/besreceiver)
+[![Go Report Card](https://goreportcard.com/badge/github.com/chagui/besreceiver)](https://goreportcard.com/report/github.com/chagui/besreceiver)
 ![Stability: Alpha](https://img.shields.io/badge/stability-alpha-orange)
-![Go](https://img.shields.io/badge/Go-1.26-blue)
 
 An OpenTelemetry Collector custom receiver designed to receive [Bazel Build Event Protocol (BEP)](https://bazel.build/remote/bep) streams via the BES gRPC API and converts them into the OpenTelemetry trace model. Bazel builds become trace flamegraphs in Datadog, Tempo, Jaeger, or any OTLP backend.
 


### PR DESCRIPTION
## Summary

- Add live CI status, Go Reference, and Go Report Card badges to the README
- Replace the static Go version badge — the Go Reference badge links to pkg.go.dev docs and is more useful
- Keep the existing stability badge for OTel component maturity signaling

## Test plan

- [x] Verify badge URLs render correctly on the PR diff preview
- [x] Confirm CI badge links to the correct workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)