### PR TITLE
Reduce test cyclomatic complexity for Go Report Card

### DIFF
--- a/receiver/besreceiver/receiver_test.go
+++ b/receiver/besreceiver/receiver_test.go
@@ -236,7 +236,7 @@ func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 	defer tb.Stop()
 	ctx := context.Background()
 
-	processEvents(t, tb, ctx,
+	processEvents(ctx, t, tb,
 		makeBuildStartedOBE(t, "inv-tc", "uuid-target", "build", 1),
 		makeTargetConfiguredOBE(t, "inv-tc", "//pkg:lib", 2),
 	)
@@ -244,7 +244,7 @@ func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 	// Spans are batched — nothing emitted yet.
 	require.Equal(t, 0, sink.SpanCount(), "expected 0 spans (batched)")
 
-	processEvents(t, tb, ctx,
+	processEvents(ctx, t, tb,
 		makeActionOBE(t, "inv-tc", "//pkg:lib", "Javac", 3, true),
 		// BuildFinished — flushes the batch.
 		makeBuildFinishedOBE(t, "inv-tc", 4, 0, "SUCCESS"),

--- a/receiver/besreceiver/receiver_test.go
+++ b/receiver/besreceiver/receiver_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -234,31 +236,22 @@ func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 	defer tb.Stop()
 	ctx := context.Background()
 
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-tc", "uuid-target", "build", 1)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeTargetConfiguredOBE(t, "inv-tc", "//pkg:lib", 2)); err != nil {
-		t.Fatal(err)
-	}
+	processEvents(t, tb, ctx,
+		makeBuildStartedOBE(t, "inv-tc", "uuid-target", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-tc", "//pkg:lib", 2),
+	)
 
 	// Spans are batched — nothing emitted yet.
-	if sink.SpanCount() != 0 {
-		t.Fatalf("expected 0 spans (batched), got %d", sink.SpanCount())
-	}
+	require.Equal(t, 0, sink.SpanCount(), "expected 0 spans (batched)")
 
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeActionOBE(t, "inv-tc", "//pkg:lib", "Javac", 3, true)); err != nil {
-		t.Fatal(err)
-	}
-
-	// BuildFinished — flushes the batch.
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-tc", 4, 0, "SUCCESS")); err != nil {
-		t.Fatal(err)
-	}
+	processEvents(t, tb, ctx,
+		makeActionOBE(t, "inv-tc", "//pkg:lib", "Javac", 3, true),
+		// BuildFinished — flushes the batch.
+		makeBuildFinishedOBE(t, "inv-tc", 4, 0, "SUCCESS"),
+	)
 
 	// 3 spans in one batch: target + action + root.
-	if sink.SpanCount() != 3 {
-		t.Fatalf("expected 3 spans, got %d", sink.SpanCount())
-	}
+	require.Equal(t, 3, sink.SpanCount(), "expected 3 spans")
 
 	// Find spans by name in the batched output.
 	spans := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
@@ -272,27 +265,19 @@ func TestTraceBuilder_TargetConfiguredEmitsSpan(t *testing.T) {
 		}
 	}
 
-	if targetSpan.Name() != "bazel.target" {
-		t.Fatal("expected to find bazel.target span in batch")
-	}
+	require.Equal(t, "bazel.target", targetSpan.Name(), "expected to find bazel.target span in batch")
 
 	label, ok := targetSpan.Attributes().Get("bazel.target.label")
-	if !ok || label.Str() != "//pkg:lib" {
-		t.Errorf("expected bazel.target.label=//pkg:lib, got %v", label)
-	}
+	assert.True(t, ok, "missing bazel.target.label attribute")
+	assert.Equal(t, "//pkg:lib", label.Str())
 
 	ruleKind, ok := targetSpan.Attributes().Get("bazel.target.rule_kind")
-	if !ok || ruleKind.Str() != "java_library rule" {
-		t.Errorf("expected bazel.target.rule_kind='java_library rule', got %v", ruleKind)
-	}
+	assert.True(t, ok, "missing bazel.target.rule_kind attribute")
+	assert.Equal(t, "java_library rule", ruleKind.Str())
 
 	// Verify the target's spanID is used as parent for the action.
-	if actionSpan.Name() != "bazel.action Javac" {
-		t.Fatal("expected to find 'bazel.action Javac' span in batch")
-	}
-	if actionSpan.ParentSpanID() != targetSpan.SpanID() {
-		t.Errorf("expected action parent to be target span %v, got %v", targetSpan.SpanID(), actionSpan.ParentSpanID())
-	}
+	require.Equal(t, "bazel.action Javac", actionSpan.Name(), "expected to find action span in batch")
+	assert.Equal(t, targetSpan.SpanID(), actionSpan.ParentSpanID(), "action parent should be target span")
 }
 
 func TestTraceBuilder_BuildFinishedWithFailure(t *testing.T) {
@@ -348,74 +333,49 @@ func TestIntegration_RealGRPCServer(t *testing.T) {
 	}
 
 	host := componenttest.NewNopHost()
-	if err := recv.Start(ctx, host); err != nil {
-		t.Fatalf("failed to start receiver: %v", err)
-	}
+	require.NoError(t, recv.Start(ctx, host), "failed to start receiver")
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := recv.Shutdown(shutdownCtx); err != nil {
-			t.Errorf("shutdown error: %v", err)
-		}
+		assert.NoError(t, recv.Shutdown(shutdownCtx), "shutdown error")
 	}()
 
 	// Dial the actual address the OS assigned.
 	actualAddr := recv.Addr().String()
 	conn, err := grpc.NewClient(actualAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("failed to dial gRPC: %v", err)
-	}
+	require.NoError(t, err, "failed to dial gRPC")
 	defer func() {
-		if err := conn.Close(); err != nil {
-			t.Errorf("failed to close connection: %v", err)
-		}
+		assert.NoError(t, conn.Close(), "failed to close connection")
 	}()
 
 	client := pb.NewPublishBuildEventClient(conn)
 
 	stream, err := client.PublishBuildToolEventStream(ctx)
-	if err != nil {
-		t.Fatalf("failed to open stream: %v", err)
-	}
+	require.NoError(t, err, "failed to open stream")
 
 	sendAndACK(t, stream, makeBuildStartedReq(t, "inv-integration", "uuid-integration", "build", 1), 1)
 	sendAndACK(t, stream, makeBuildFinishedReq(t, "inv-integration", 2, 0, "SUCCESS"), 2)
 	sendAndACK(t, stream, makeBuildMetricsReq(t, "inv-integration", 3, 10000, 5000), 3)
 
-	if err := stream.CloseSend(); err != nil {
-		t.Fatalf("failed to close stream: %v", err)
-	}
+	require.NoError(t, stream.CloseSend(), "failed to close stream")
 
 	t.Run("traces", func(t *testing.T) {
-		if tracesSink.SpanCount() != 2 {
-			t.Fatalf("expected 2 spans, got %d", tracesSink.SpanCount())
-		}
+		require.Equal(t, 2, tracesSink.SpanCount(), "expected 2 spans")
 
 		span := tracesSink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-		if span.Name() != "bazel.build build" {
-			t.Errorf("expected span name 'bazel.build build', got %s", span.Name())
-		}
+		assert.Equal(t, "bazel.build build", span.Name())
 		cmd, ok := span.Attributes().Get("bazel.command")
-		if !ok || cmd.Str() != "build" {
-			t.Errorf("expected bazel.command=build, got %v", cmd)
-		}
+		assert.True(t, ok, "missing bazel.command attribute")
+		assert.Equal(t, "build", cmd.Str())
 	})
 
 	t.Run("metrics", func(t *testing.T) {
 		allMetrics := metricsSink.AllMetrics()
-		if len(allMetrics) != 1 {
-			t.Fatalf("expected 1 ConsumeMetrics call, got %d", len(allMetrics))
-		}
+		require.Len(t, allMetrics, 1, "expected 1 ConsumeMetrics call")
 
 		md := allMetrics[0]
-		if md.MetricCount() == 0 {
-			t.Fatal("expected metrics from BuildMetrics event, got 0")
-		}
-		if !hasMetricNamed(md, "bazel.invocation.wall_time") {
-			t.Error("expected bazel.invocation.wall_time gauge in metrics")
-		}
-		if !hasMetricNamed(md, "bazel.invocation.count") {
-			t.Error("expected bazel.invocation.count counter in metrics")
-		}
+		assert.NotZero(t, md.MetricCount(), "expected metrics from BuildMetrics event")
+		assert.True(t, hasMetricNamed(md, "bazel.invocation.wall_time"), "expected wall_time gauge")
+		assert.True(t, hasMetricNamed(md, "bazel.invocation.count"), "expected invocation count counter")
 	})
 }

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -228,7 +228,7 @@ func hasMetricNamed(md pmetric.Metrics, name string) bool {
 
 // processEvents feeds a sequence of ordered build events into the trace builder,
 // failing the test on the first error.
-func processEvents(t testing.TB, tb *TraceBuilder, ctx context.Context, events ...*pb.OrderedBuildEvent) {
+func processEvents(ctx context.Context, t testing.TB, tb *TraceBuilder, events ...*pb.OrderedBuildEvent) {
 	t.Helper()
 	for _, e := range events {
 		require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, e))

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
 	"google.golang.org/grpc"
@@ -223,6 +224,33 @@ func hasMetricNamed(md pmetric.Metrics, name string) bool {
 		}
 	}
 	return false
+}
+
+// processEvents feeds a sequence of ordered build events into the trace builder,
+// failing the test on the first error.
+func processEvents(t testing.TB, tb *TraceBuilder, ctx context.Context, events ...*pb.OrderedBuildEvent) {
+	t.Helper()
+	for _, e := range events {
+		require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, e))
+	}
+}
+
+// findMetricIntValue searches a Metrics payload for a metric by name and returns
+// the first data point's int value. Returns (0, false) if the metric is not found.
+func findMetricIntValue(md pmetric.Metrics, name string) (int64, bool) {
+	for i := range md.ResourceMetrics().Len() {
+		rm := md.ResourceMetrics().At(i)
+		for j := range rm.ScopeMetrics().Len() {
+			sm := rm.ScopeMetrics().At(j)
+			for k := range sm.Metrics().Len() {
+				m := sm.Metrics().At(k)
+				if m.Name() == name && m.Sum().DataPoints().Len() > 0 {
+					return m.Sum().DataPoints().At(0).IntValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
 }
 
 // --- BES request helpers (used by receiver stream tests) ---

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -670,7 +670,7 @@ func TestTraceBuilder_LogsEmitted(t *testing.T) {
 	ctx := context.Background()
 
 	// Full lifecycle: Started → TargetConfigured → Action → TestResult → Finished → Metrics.
-	processEvents(t, tb, ctx,
+	processEvents(ctx, t, tb,
 		makeBuildStartedOBE(t, "inv-log", "uuid-log", "test", 1),
 		makeTargetConfiguredOBE(t, "inv-log", "//pkg:lib", 2),
 		makeActionOBE(t, "inv-log", "//pkg:lib", "Javac", 3, true),
@@ -1012,14 +1012,14 @@ func TestTraceBuilder_CumulativeCountersAcrossInvocations(t *testing.T) {
 	ctx := context.Background()
 
 	// First invocation.
-	processEvents(t, tb, ctx,
+	processEvents(ctx, t, tb,
 		makeBuildStartedOBE(t, "inv-c1", "uuid-c1", "build", 1),
 		makeBuildFinishedOBE(t, "inv-c1", 2, 0, "SUCCESS"),
 		makeBuildMetricsOBE(t, "inv-c1", 3, 10000, 5000),
 	)
 
 	// Second invocation.
-	processEvents(t, tb, ctx,
+	processEvents(ctx, t, tb,
 		makeBuildStartedOBE(t, "inv-c2", "uuid-c2", "test", 1),
 		makeBuildFinishedOBE(t, "inv-c2", 2, 0, "SUCCESS"),
 		makeBuildMetricsOBE(t, "inv-c2", 3, 20000, 8000),

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -670,29 +670,17 @@ func TestTraceBuilder_LogsEmitted(t *testing.T) {
 	ctx := context.Background()
 
 	// Full lifecycle: Started → TargetConfigured → Action → TestResult → Finished → Metrics.
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-log", "uuid-log", "test", 1)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeTargetConfiguredOBE(t, "inv-log", "//pkg:lib", 2)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeActionOBE(t, "inv-log", "//pkg:lib", "Javac", 3, true)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeTestResultOBE(t, "inv-log", "//pkg:test", 4, bep.TestStatus_PASSED)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-log", 5, 0, "SUCCESS")); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildMetricsOBE(t, "inv-log", 6, 10000, 5000)); err != nil {
-		t.Fatal(err)
-	}
+	processEvents(t, tb, ctx,
+		makeBuildStartedOBE(t, "inv-log", "uuid-log", "test", 1),
+		makeTargetConfiguredOBE(t, "inv-log", "//pkg:lib", 2),
+		makeActionOBE(t, "inv-log", "//pkg:lib", "Javac", 3, true),
+		makeTestResultOBE(t, "inv-log", "//pkg:test", 4, bep.TestStatus_PASSED),
+		makeBuildFinishedOBE(t, "inv-log", 5, 0, "SUCCESS"),
+		makeBuildMetricsOBE(t, "inv-log", 6, 10000, 5000),
+	)
 
 	// 6 events → 6 log records.
-	if logsSink.LogRecordCount() != 6 {
-		t.Fatalf("expected 6 log records, got %d", logsSink.LogRecordCount())
-	}
+	require.Equal(t, 6, logsSink.LogRecordCount(), "expected 6 log records")
 
 	// Verify event names in order.
 	expectedEvents := []string{
@@ -703,46 +691,33 @@ func TestTraceBuilder_LogsEmitted(t *testing.T) {
 		"bazel.build.finished",
 		"bazel.build.metrics",
 	}
+	expectedTraceID := traceIDFromUUID("uuid-log")
 	for i, logs := range logsSink.AllLogs() {
 		lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+
 		eventName, ok := lr.Attributes().Get("event.name")
-		if !ok {
-			t.Errorf("log record %d: missing event.name attribute", i)
-			continue
-		}
-		if eventName.Str() != expectedEvents[i] {
-			t.Errorf("log record %d: expected event.name=%q, got %q", i, expectedEvents[i], eventName.Str())
-		}
+		require.True(t, ok, "log record %d: missing event.name attribute", i)
+		assert.Equal(t, expectedEvents[i], eventName.Str(), "log record %d: event.name", i)
 
 		// All log records should have the invocation ID.
 		invID, ok := lr.Attributes().Get("bazel.invocation_id")
-		if !ok || invID.Str() != "inv-log" {
-			t.Errorf("log record %d: expected bazel.invocation_id=inv-log, got %v", i, invID)
-		}
+		assert.True(t, ok, "log record %d: missing bazel.invocation_id", i)
+		assert.Equal(t, "inv-log", invID.Str(), "log record %d: bazel.invocation_id", i)
 
 		// All log records should have the trace ID for correlation.
-		expectedTraceID := traceIDFromUUID("uuid-log")
-		if lr.TraceID() != expectedTraceID {
-			t.Errorf("log record %d: expected traceID %v, got %v", i, expectedTraceID, lr.TraceID())
-		}
+		assert.Equal(t, expectedTraceID, lr.TraceID(), "log record %d: traceID", i)
 
 		// Resource should have service.name=bazel.
 		svc, ok := logs.ResourceLogs().At(0).Resource().Attributes().Get("service.name")
-		if !ok || svc.Str() != "bazel" {
-			t.Errorf("log record %d: expected service.name=bazel, got %v", i, svc)
-		}
+		assert.True(t, ok, "log record %d: missing service.name", i)
+		assert.Equal(t, "bazel", svc.Str(), "log record %d: service.name", i)
 
 		// Scope should be besreceiver.
-		scope := logs.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name()
-		if scope != "besreceiver" {
-			t.Errorf("log record %d: expected scope=besreceiver, got %q", i, scope)
-		}
+		assert.Equal(t, "besreceiver", logs.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name(), "log record %d: scope", i)
 	}
 
 	// Traces should also be emitted normally.
-	if tracesSink.SpanCount() == 0 {
-		t.Error("expected traces to be emitted alongside logs")
-	}
+	assert.NotZero(t, tracesSink.SpanCount(), "expected traces to be emitted alongside logs")
 }
 
 func TestTraceBuilder_LogsOnly(t *testing.T) {
@@ -1037,60 +1012,32 @@ func TestTraceBuilder_CumulativeCountersAcrossInvocations(t *testing.T) {
 	ctx := context.Background()
 
 	// First invocation.
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-c1", "uuid-c1", "build", 1)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-c1", 2, 0, "SUCCESS")); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildMetricsOBE(t, "inv-c1", 3, 10000, 5000)); err != nil {
-		t.Fatal(err)
-	}
+	processEvents(t, tb, ctx,
+		makeBuildStartedOBE(t, "inv-c1", "uuid-c1", "build", 1),
+		makeBuildFinishedOBE(t, "inv-c1", 2, 0, "SUCCESS"),
+		makeBuildMetricsOBE(t, "inv-c1", 3, 10000, 5000),
+	)
 
 	// Second invocation.
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-c2", "uuid-c2", "test", 1)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-c2", 2, 0, "SUCCESS")); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildMetricsOBE(t, "inv-c2", 3, 20000, 8000)); err != nil {
-		t.Fatal(err)
-	}
+	processEvents(t, tb, ctx,
+		makeBuildStartedOBE(t, "inv-c2", "uuid-c2", "test", 1),
+		makeBuildFinishedOBE(t, "inv-c2", 2, 0, "SUCCESS"),
+		makeBuildMetricsOBE(t, "inv-c2", 3, 20000, 8000),
+	)
 
 	// Should have 2 ConsumeMetrics calls (one per BuildMetrics event).
 	allMetrics := metricsSink.AllMetrics()
-	if len(allMetrics) != 2 {
-		t.Fatalf("expected 2 ConsumeMetrics calls, got %d", len(allMetrics))
-	}
+	require.Len(t, allMetrics, 2, "expected 2 ConsumeMetrics calls")
 
 	// Find the cumulative invocation count in the second batch — should be 2.
 	lastMD := allMetrics[1]
-	found := false
-	for i := range lastMD.ResourceMetrics().Len() {
-		rm := lastMD.ResourceMetrics().At(i)
-		for j := range rm.ScopeMetrics().Len() {
-			sm := rm.ScopeMetrics().At(j)
-			for k := range sm.Metrics().Len() {
-				m := sm.Metrics().At(k)
-				if m.Name() == "bazel.invocation.count" {
-					found = true
-					dp := m.Sum().DataPoints().At(0)
-					if dp.IntValue() != 2 {
-						t.Errorf("expected invocation count=2 after two builds, got %d", dp.IntValue())
-					}
-				}
-				if m.Name() == "bazel.invocation.wall_time.total" {
-					dp := m.Sum().DataPoints().At(0)
-					if dp.IntValue() != 30000 {
-						t.Errorf("expected total wall_time=30000, got %d", dp.IntValue())
-					}
-				}
-			}
-		}
-	}
-	if !found {
-		t.Error("expected to find bazel.invocation.count metric in second batch")
+
+	invCount, found := findMetricIntValue(lastMD, "bazel.invocation.count")
+	require.True(t, found, "expected to find bazel.invocation.count metric in second batch")
+	assert.Equal(t, int64(2), invCount, "expected invocation count=2 after two builds")
+
+	if wallTime, found := findMetricIntValue(lastMD, "bazel.invocation.wall_time.total"); found {
+		assert.Equal(t, int64(30000), wallTime, "expected total wall_time=30000")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace verbose `if err != nil { t.Fatal }` patterns with testify `require`/`assert` in 4 test functions that exceeded the gocyclo >15 threshold
- Extract `processEvents` and `findMetricIntValue` test helpers to consolidate repeated logic

## Why

[Go Report Card](https://goreportcard.com/report/github.com/chagui/besreceiver) gocyclo check flags functions with cyclomatic complexity >15. Four test functions exceeded this:

| Function | Before | After |
|---|---|---|
| `TestTraceBuilder_LogsEmitted` | 18 | 2 |
| `TestTraceBuilder_TargetConfiguredEmitsSpan` | 17 | 4 |
| `TestTraceBuilder_CumulativeCountersAcrossInvocations` | 16 | 3 |
| `TestIntegration_RealGRPCServer` | 16 | 4 |

No behavioral changes — same assertions, same coverage.

## Test plan

- [x] `go test -race ./receiver/besreceiver/` passes
- [x] `gocyclo -over 15 ./receiver/besreceiver/` returns no results
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)