### PR TITLE
chore(config): harden example collector configs

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -1,10 +1,17 @@
 extensions:
   health_check:
-    endpoint: "0.0.0.0:13133"
+    endpoint: "localhost:13133"
 
 receivers:
   bes:
-    endpoint: "0.0.0.0:8082"
+    endpoint: "localhost:8082"
+    # Uncomment to enable mutual TLS on the BES gRPC endpoint.
+    # Bazel clients must be pointed at --bes_backend=grpcs://... and configured
+    # with a matching client certificate when client_ca_file is set.
+    # tls:
+    #   cert_file: /etc/otelcol/certs/server.crt
+    #   key_file: /etc/otelcol/certs/server.key
+    #   client_ca_file: /etc/otelcol/certs/ca.crt
 
 processors:
   memory_limiter:
@@ -43,7 +50,7 @@ service:
         - pull:
             exporter:
               prometheus:
-                host: "0.0.0.0"
+                host: "localhost"
                 port: 8888
   pipelines:
     traces:

--- a/examples/custom-collector/collector-config.yaml
+++ b/examples/custom-collector/collector-config.yaml
@@ -1,12 +1,16 @@
 extensions:
   health_check:
-    endpoint: "0.0.0.0:13133"
+    endpoint: "localhost:13133"
 
 receivers:
   bes:
-    endpoint: "0.0.0.0:8082"
+    endpoint: "localhost:8082"
 
 processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
   batch:
     send_batch_size: 8192
     timeout: 200ms
@@ -24,9 +28,9 @@ service:
   pipelines:
     traces:
       receivers: [bes]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [debug]
     logs:
       receivers: [bes]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [debug]

--- a/examples/datadog/collector-config.yaml
+++ b/examples/datadog/collector-config.yaml
@@ -1,9 +1,12 @@
 extensions:
   health_check:
+    # Bound to 0.0.0.0 so the kubelet / sidecar probe can reach it from the pod network.
     endpoint: "0.0.0.0:13133"
 
 receivers:
   bes:
+    # Bound to 0.0.0.0 so Bazel clients outside the pod (or sibling containers)
+    # can reach the BES gRPC endpoint. For local development, prefer "localhost:8082".
     endpoint: "0.0.0.0:8082"
 
 processors:
@@ -43,6 +46,8 @@ service:
         - pull:
             exporter:
               prometheus:
+                # Bound to 0.0.0.0 so the Datadog Agent (or any in-cluster scraper)
+                # can pull metrics across the pod network.
                 host: "0.0.0.0"
                 port: 8888
   pipelines:


### PR DESCRIPTION
Closes #23.

Hardens the example collector configs against OTel security best practices. The root and custom-collector configs bind the BES receiver, health check, and Prometheus to localhost instead of overriding the factory default with 0.0.0.0. The root config grows a commented mutual-TLS template for the BES endpoint. The custom-collector example gains a memory_limiter processor wired ahead of batch on both pipelines (512 MiB / 128 MiB spike, matching the root config). The Datadog example stays on 0.0.0.0 since it targets pod-network deployments — now with inline comments explaining why.