### PR TITLE
feat(besreceiver): derive SpanIDs deterministically from event identity

### DIFF
--- a/docs/adr/0001-deterministic-span-ids.md
+++ b/docs/adr/0001-deterministic-span-ids.md
@@ -1,0 +1,59 @@
+# 0001. Deterministic SpanIDs
+
+## Status
+
+Accepted — 2026-04-19
+
+## Context
+
+TraceID is derived deterministically from the Bazel invocation UUID
+(`SHA-256(uuid)[0:16]`), so replaying the same build through the receiver
+always yields the same TraceID. SpanIDs, however, were generated from
+`crypto/rand`, so the same event sequence produced a different span tree
+on every run.
+
+This makes trace-diffing between builds infeasible. Questions like "what
+new span appeared between this green build and yesterday's red one?" require
+stable IDs on both sides. They also make the emitted trace non-reproducible,
+which hurts debugging when the same BEP fixture is replayed through tests
+or the E2E harness.
+
+## Decision
+
+Derive each SpanID from a per-span identity tuple rather than randomness:
+
+    spanID = SHA-256(strings.Join(parts, "\x00"))[16:24]
+
+The identity tuple is the invocation UUID plus a role discriminator and the
+stable fields from the owning BEP event:
+
+| Span            | Identity parts                                     |
+|-----------------|----------------------------------------------------|
+| `bazel.build`   | uuid, "root"                                       |
+| `bazel.target`  | uuid, "target", label                              |
+| `bazel.action`  | uuid, "action", label, mnemonic, primary_output    |
+| `bazel.test`    | uuid, "test", label, run, shard, attempt           |
+| `bazel.metrics` | uuid, "metrics"                                    |
+
+Bytes [16:24] are used so SpanIDs never overlap with the TraceID prefix
+at [0:16] — a defensive choice against accidental collisions across the
+two IDs.
+
+## Consequences
+
+The same BEP event stream replayed with the same invocation UUID now yields
+a byte-identical span tree. Trace-diffing across runs becomes a deep equality
+check on the (name, spanID, parentSpanID) triples. The E2E replay tests can
+assert exact span-ID equality, catching regressions in parent-child
+resolution that previously were invisible.
+
+SpanIDs are 64 bits; the birthday-bound collision probability hits ~50%
+around 2^32 ≈ 4.3B spans. Within a single invocation (thousands to low
+millions of spans), collisions are statistically negligible; cross-invocation
+collisions are harmless because TraceIDs differ.
+
+Identity stability depends on BEP fields that Bazel treats as stable:
+rename a mnemonic (`Javac` → `JavaCompile`) or change how primary outputs
+are spelled, and the same build across Bazel versions produces different
+SpanIDs. This is acceptable — trace-diffing across Bazel upgrades is not a
+supported use case, and TraceID already carries the same implicit contract.

--- a/receiver/besreceiver/benchmark_test.go
+++ b/receiver/besreceiver/benchmark_test.go
@@ -101,7 +101,7 @@ func BenchmarkResolveTargetSpan(b *testing.B) {
 	}
 	for i := range 100 {
 		label := fmt.Sprintf("//pkg:target-%d", i)
-		state.targets[targetKey(label, fmt.Sprintf("cfg-%d", i))] = newSpanID()
+		state.targets[targetKey(label, fmt.Sprintf("cfg-%d", i))] = spanIDFromIdentity("bench", "target", label)
 	}
 
 	b.Run("exact_match", func(b *testing.B) {

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -1,6 +1,7 @@
 package besreceiver
 
 import (
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -32,6 +33,7 @@ import (
 type invocationState struct {
 	traceID       pcommon.TraceID
 	rootSpanID    pcommon.SpanID
+	uuid          string                    // Bazel invocation UUID, used to seed span-identity strings
 	targets       map[string]pcommon.SpanID // "label\x00configID" → spanID
 	started       *bep.BuildStarted         // buffered for deferred root span emission
 	createdAt     time.Time
@@ -50,6 +52,7 @@ func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, star
 	return &invocationState{
 		traceID:       traceID,
 		rootSpanID:    rootSpanID,
+		uuid:          started.GetUuid(),
 		targets:       make(map[string]pcommon.SpanID),
 		started:       started,
 		createdAt:     now,
@@ -74,7 +77,7 @@ func (s *invocationState) addTarget(label, ruleKind string) {
 		return
 	}
 
-	spanID := newSpanID()
+	spanID := spanIDFromIdentity(s.uuid, "target", label)
 	s.targets[targetKey(label, "")] = spanID
 
 	span := s.appendSpan()
@@ -92,7 +95,7 @@ func (s *invocationState) addTarget(label, ruleKind string) {
 	s.reparentOrphans(label, spanID)
 }
 
-func (s *invocationState) addAction(label, configID string, action *bep.ActionExecuted) {
+func (s *invocationState) addAction(label, configID, primaryOutput string, action *bep.ActionExecuted) {
 	if s.flushed {
 		return
 	}
@@ -101,7 +104,7 @@ func (s *invocationState) addAction(label, configID string, action *bep.ActionEx
 
 	spanIdx := s.scopeSpans.Spans().Len()
 	span := s.appendSpan()
-	span.SetSpanID(newSpanID())
+	span.SetSpanID(spanIDFromIdentity(s.uuid, "action", label, action.GetType(), primaryOutput))
 
 	// If the target hasn't been configured yet, record this span for
 	// deferred reparenting when addTarget is called.
@@ -145,7 +148,11 @@ func (s *invocationState) addTestResult(label, configID string, tr *bep.BuildEve
 
 	spanIdx := s.scopeSpans.Spans().Len()
 	span := s.appendSpan()
-	span.SetSpanID(newSpanID())
+	span.SetSpanID(spanIDFromIdentity(s.uuid, "test", label,
+		strconv.Itoa(int(tr.GetRun())),
+		strconv.Itoa(int(tr.GetShard())),
+		strconv.Itoa(int(tr.GetAttempt())),
+	))
 
 	if !resolved && label != "" {
 		s.recordOrphan(label, spanIdx)
@@ -233,7 +240,7 @@ func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) ptrace.Tra
 
 	span := ss.Spans().AppendEmpty()
 	span.SetTraceID(s.traceID)
-	span.SetSpanID(newSpanID())
+	span.SetSpanID(spanIDFromIdentity(s.uuid, "metrics"))
 	span.SetParentSpanID(s.rootSpanID)
 	span.SetName("bazel.metrics")
 	span.SetKind(ptrace.SpanKindInternal)

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -2,10 +2,10 @@ package besreceiver
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -249,7 +249,7 @@ func eventTypeName(event *bep.BuildEvent) string {
 
 func (tb *TraceBuilder) handleBuildStarted(ctx context.Context, invocations map[string]*invocationState, invocationID string, started *bep.BuildStarted) error {
 	traceID := traceIDFromUUID(started.GetUuid())
-	rootSpanID := newSpanID()
+	rootSpanID := spanIDFromIdentity(started.GetUuid(), "root")
 	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now())
 	tb.activeInvocations.Add(ctx, 1)
 
@@ -316,12 +316,14 @@ func (tb *TraceBuilder) handleActionExecuted(ctx context.Context, invocations ma
 	ac := eventID.GetActionCompleted()
 	label := ""
 	configID := ""
+	primaryOutput := ""
 	if ac != nil {
 		label = ac.GetLabel()
 		configID = ac.GetConfiguration().GetId()
+		primaryOutput = ac.GetPrimaryOutput()
 	}
 
-	state.addAction(label, configID, action)
+	state.addAction(label, configID, primaryOutput, action)
 
 	severity := plog.SeverityNumberInfo
 	body := fmt.Sprintf("Action completed: %s %s", action.GetType(), label)
@@ -558,9 +560,13 @@ func traceIDFromUUID(uuid string) pcommon.TraceID {
 	return tid
 }
 
-func newSpanID() pcommon.SpanID {
+// spanIDFromIdentity deterministically derives a SpanID from the given identity parts.
+// Parts are joined with a NUL separator and SHA-256'd; bytes [16:24] are used so
+// SpanIDs never overlap with TraceID bytes (which use [0:16]).
+func spanIDFromIdentity(parts ...string) pcommon.SpanID {
+	h := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
 	var sid pcommon.SpanID
-	_, _ = rand.Read(sid[:])
+	copy(sid[:], h[16:24])
 	return sid
 }
 

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -571,12 +572,12 @@ func TestReapStale(t *testing.T) {
 	// Build invocation state directly with pending spans.
 	state := newInvocationState(
 		traceIDFromUUID("uuid-stale"),
-		newSpanID(),
+		spanIDFromIdentity("uuid-stale", "root"),
 		&bep.BuildStarted{Uuid: "uuid-stale", Command: "build"},
 		time.Now().Add(-time.Hour),
 	)
 	span := state.appendSpan()
-	span.SetSpanID(newSpanID())
+	span.SetSpanID(spanIDFromIdentity("uuid-stale", "action", "//pkg:lib", "Javac", ""))
 	span.SetName("bazel.action")
 
 	invocations := map[string]*invocationState{
@@ -607,6 +608,132 @@ func TestTraceIDFromUUID_NoCollisions(t *testing.T) {
 		}
 		seen[tid] = uuid
 	}
+}
+
+func TestSpanIDFromIdentity_Deterministic(t *testing.T) {
+	cases := []struct {
+		name     string
+		partsA   []string
+		partsB   []string
+		wantSame bool
+	}{
+		{"same parts produce same ID", []string{"u", "root"}, []string{"u", "root"}, true},
+		{"different role differs", []string{"u", "root"}, []string{"u", "target"}, false},
+		{"different uuid differs", []string{"u1", "root"}, []string{"u2", "root"}, false},
+		{"different label differs",
+			[]string{"u", "target", "//a:b"},
+			[]string{"u", "target", "//a:c"},
+			false,
+		},
+		{"action identity differs by primary output",
+			[]string{"u", "action", "//a:b", "Javac", "bazel-out/x"},
+			[]string{"u", "action", "//a:b", "Javac", "bazel-out/y"},
+			false,
+		},
+		{"test identity differs by attempt",
+			[]string{"u", "test", "//a:b", "1", "0", "1"},
+			[]string{"u", "test", "//a:b", "1", "0", "2"},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := spanIDFromIdentity(tc.partsA...)
+			b := spanIDFromIdentity(tc.partsB...)
+			if tc.wantSame && a != b {
+				t.Errorf("expected identical span IDs, got %x and %x", a, b)
+			}
+			if !tc.wantSame && a == b {
+				t.Errorf("expected different span IDs, both were %x", a)
+			}
+		})
+	}
+}
+
+func TestSpanIDFromIdentity_NoCollisions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping collision test in short mode")
+	}
+
+	seen := make(map[pcommon.SpanID]string, 10000)
+	for i := range 10000 {
+		identity := fmt.Sprintf("uuid-%d\x00role\x00label", i)
+		sid := spanIDFromIdentity(identity)
+		if prev, ok := seen[sid]; ok {
+			t.Fatalf("collision: %q and %q both map to %x", prev, identity, sid)
+		}
+		seen[sid] = identity
+	}
+}
+
+// TestSpanIDs_ReplayDeterministic replays an identical event stream through two
+// independent TraceBuilders and asserts that every emitted span has the same
+// name, SpanID, and ParentSpanID in both runs.
+func TestSpanIDs_ReplayDeterministic(t *testing.T) {
+	collect := func() []spanTuple {
+		sink := new(consumertest.TracesSink)
+		tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+		tb.Start()
+		defer tb.Stop()
+		ctx := context.Background()
+		processEvents(ctx, t, tb,
+			makeBuildStartedOBE(t, "inv-1", "uuid-xyz", "build", 1),
+			makeTargetConfiguredOBE(t, "inv-1", "//pkg:lib", 2),
+			makeActionOBE(t, "inv-1", "//pkg:lib", "Javac", 3, true),
+			makeTestResultOBE(t, "inv-1", "//pkg:lib", 4, bep.TestStatus_PASSED),
+			makeBuildFinishedOBE(t, "inv-1", 5, 0, "SUCCESS"),
+			makeBuildMetricsOBE(t, "inv-1", 6, 100, 50),
+		)
+		return collectSpanTuples(sink)
+	}
+
+	run1 := collect()
+	run2 := collect()
+
+	if len(run1) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	if len(run1) != len(run2) {
+		t.Fatalf("span count mismatch: %d vs %d", len(run1), len(run2))
+	}
+	for i := range run1 {
+		if run1[i] != run2[i] {
+			t.Errorf("span %d mismatch:\n  run1: %+v\n  run2: %+v", i, run1[i], run2[i])
+		}
+	}
+}
+
+type spanTuple struct {
+	name     string
+	spanID   pcommon.SpanID
+	parentID pcommon.SpanID
+}
+
+func collectSpanTuples(sink *consumertest.TracesSink) []spanTuple {
+	var out []spanTuple
+	for _, traces := range sink.AllTraces() {
+		for i := range traces.ResourceSpans().Len() {
+			rs := traces.ResourceSpans().At(i)
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					s := ss.Spans().At(k)
+					out = append(out, spanTuple{
+						name:     s.Name(),
+						spanID:   s.SpanID(),
+						parentID: s.ParentSpanID(),
+					})
+				}
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].name != out[j].name {
+			return out[i].name < out[j].name
+		}
+		return fmt.Sprintf("%x", out[i].spanID) < fmt.Sprintf("%x", out[j].spanID)
+	})
+	return out
 }
 
 func TestTargetKey_Uniqueness(t *testing.T) {


### PR DESCRIPTION
Closes #12.

Makes SpanIDs deterministic — the same event sequence with the same invocation UUID now produces a byte-identical span tree across runs. Extends to span level the invariant that already held for TraceID (SHA-256 of UUID), making trace-diffing between builds tractable: "what changed between this green build and that red build?".

Each span's identity is a NUL-joined tuple of (uuid, role, discriminators). Roles are root, target, action, test, and metrics; discriminators are the stable fields on each BEP event (label, mnemonic, primary output, run/shard/attempt). The helper SHA-256s the tuple and takes bytes [16:24] so SpanIDs never overlap with the TraceID prefix at [0:16].

The decision and its trade-offs (64-bit collision space, identity stability across Bazel versions) are captured in `docs/adr/0001-deterministic-span-ids.md`.

Stacked on #39.