### PR TITLE
feat(besreceiver): handle Aborted BEP events on the root span

### DIFF
--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -2,6 +2,7 @@ package besreceiver
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -45,6 +46,13 @@ type invocationState struct {
 	// Keyed by label, each entry is a list of span indices (into scopeSpans.Spans())
 	// that should be reparented when addTarget is called for that label.
 	orphanedSpans map[string][]int
+
+	// abortRecorded is set on the first Aborted event. Subsequent aborts are
+	// logged but do not overwrite the original reason / description, which are
+	// preserved as the root-cause signal on the root span.
+	abortRecorded    bool
+	abortReason      string
+	abortDescription string
 }
 
 func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time) *invocationState {
@@ -193,6 +201,23 @@ func (s *invocationState) finalize(finished *bep.BuildFinished) (ptrace.Traces, 
 		return ptrace.Traces{}, false
 	}
 
+	s.writeRootSpan(finished)
+
+	s.flushed = true
+	s.orphanedSpans = nil
+	return s.pendingTraces, true
+}
+
+// writeRootSpan appends the root bazel.build span to the pending traces batch.
+// finished may be nil when the root span is emitted without BuildFinished
+// (e.g. the reaper flushing an aborted build that never sent BuildFinished).
+//
+// When abortRecorded is true, abort attributes are written alongside any
+// existing exit-code attributes and the status message is set to
+// "aborted: <reason>: <description>". Abort is the root cause, so its
+// status takes precedence; the exit code is the consequence and its
+// attributes remain for observability.
+func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 	span := s.appendSpan()
 	span.SetSpanID(s.rootSpanID)
 	// command is a free-form string in the proto, but in practice bounded to
@@ -208,7 +233,7 @@ func (s *invocationState) finalize(finished *bep.BuildFinished) (ptrace.Traces, 
 	if s.started != nil && s.started.GetStartTime() != nil {
 		span.SetStartTimestamp(pcommon.NewTimestampFromTime(s.started.GetStartTime().AsTime()))
 	}
-	if finished.GetFinishTime() != nil {
+	if finished != nil && finished.GetFinishTime() != nil {
 		span.SetEndTimestamp(pcommon.NewTimestampFromTime(finished.GetFinishTime().AsTime()))
 	}
 
@@ -219,18 +244,44 @@ func (s *invocationState) finalize(finished *bep.BuildFinished) (ptrace.Traces, 
 		span.Attributes().PutStr("bazel.workspace_directory", s.started.GetWorkspaceDirectory())
 	}
 
-	exitCode := finished.GetExitCode()
-	span.Attributes().PutStr("bazel.exit_code.name", exitCode.GetName())
-	span.Attributes().PutInt("bazel.exit_code.code", int64(exitCode.GetCode()))
+	if finished != nil {
+		exitCode := finished.GetExitCode()
+		span.Attributes().PutStr("bazel.exit_code.name", exitCode.GetName())
+		span.Attributes().PutInt("bazel.exit_code.code", int64(exitCode.GetCode()))
 
-	if exitCode.GetCode() != 0 {
-		span.Status().SetCode(ptrace.StatusCodeError)
-		span.Status().SetMessage(exitCode.GetName())
+		if exitCode.GetCode() != 0 {
+			span.Status().SetCode(ptrace.StatusCodeError)
+			span.Status().SetMessage(exitCode.GetName())
+		}
 	}
 
-	s.flushed = true
-	s.orphanedSpans = nil
-	return s.pendingTraces, true
+	if s.abortRecorded {
+		span.Attributes().PutStr("bazel.abort.reason", s.abortReason)
+		span.Attributes().PutStr("bazel.abort.description", s.abortDescription)
+		span.Status().SetCode(ptrace.StatusCodeError)
+		span.Status().SetMessage("aborted: " + s.abortReason + ": " + s.abortDescription)
+	}
+}
+
+// recordAbort stores the first abort reason and description on the invocation
+// state. Subsequent calls are no-ops — the root cause is preserved and later
+// aborts are consequences that the caller logs but does not propagate here.
+// Returns true only on the first call.
+func (s *invocationState) recordAbort(a *bep.Aborted) bool {
+	if s.abortRecorded {
+		return false
+	}
+	s.abortRecorded = true
+	s.abortReason = abortReasonString(a.GetReason())
+	s.abortDescription = a.GetDescription()
+	return true
+}
+
+// abortReasonString returns the lowercased BEP enum name for an abort reason.
+// Stable identifier for downstream queries; new enum values added by future
+// Bazel versions are handled automatically via the generated String() method.
+func abortReasonString(r bep.Aborted_AbortReason) string {
+	return strings.ToLower(r.String())
 }
 
 // buildMetricsSpan creates a standalone Traces payload for BuildMetrics.
@@ -261,9 +312,20 @@ func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) ptrace.Tra
 
 // flushOrphaned returns pending traces for invocations that were never finished.
 // Used by the reaper to flush spans before deleting stale state.
+//
+// When an abort was recorded but BuildFinished never arrived, also emit the
+// root span (stamped with abort attrs via writeRootSpan) so the abort signal
+// is preserved. Otherwise the existing pending spans are flushed as-is,
+// matching prior behavior for timed-out but non-aborted invocations.
 func (s *invocationState) flushOrphaned() (ptrace.Traces, bool) {
-	if s.flushed || s.pendingTraces.SpanCount() == 0 {
+	if s.flushed {
 		return ptrace.Traces{}, false
+	}
+	if !s.abortRecorded && s.pendingTraces.SpanCount() == 0 {
+		return ptrace.Traces{}, false
+	}
+	if s.abortRecorded {
+		s.writeRootSpan(nil)
 	}
 	s.flushed = true
 	return s.pendingTraces, true

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -112,6 +112,29 @@ func makeBuildFinishedOBE(t testing.TB, invID string, seqNum int64, code int32, 
 	})
 }
 
+// makeAbortedOBE builds an OrderedBuildEvent for an Aborted payload. Aborted
+// events can ride on any BuildEventId; this helper uses BuildFinished by
+// default to exercise the "aborts replace another event ID" path. Pass a
+// non-nil overrideID to use a different event id shape.
+func makeAbortedOBE(t testing.TB, invID string, seqNum int64, reason bep.Aborted_AbortReason, description string, overrideID *bep.BuildEventId) *pb.OrderedBuildEvent {
+	t.Helper()
+	id := overrideID
+	if id == nil {
+		id = &bep.BuildEventId{
+			Id: &bep.BuildEventId_BuildFinished{BuildFinished: &bep.BuildEventId_BuildFinishedId{}},
+		}
+	}
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: id,
+		Payload: &bep.BuildEvent_Aborted{
+			Aborted: &bep.Aborted{
+				Reason:      reason,
+				Description: description,
+			},
+		},
+	})
+}
+
 func makeActionOBE(t testing.TB, invID, label, mnemonic string, seqNum int64, success bool) *pb.OrderedBuildEvent {
 	t.Helper()
 	exitCode := int32(0)

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -184,6 +184,7 @@ func (tb *TraceBuilder) ProcessOrderedBuildEvent(ctx context.Context, obe *pb.Or
 	}
 }
 
+//nolint:gocyclo // Flat payload dispatch: grows as the receiver handles more BEP event types. Splitting by payload family would hurt discoverability.
 func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string]*invocationState, invocationID string, event *bep.BuildEvent) error {
 	tb.eventsProcessed.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("event_type", eventTypeName(event)),
@@ -223,6 +224,11 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 			return nil
 		}
 		return tb.handleBuildMetrics(ctx, invocations, invocationID, p.BuildMetrics)
+	case *bep.BuildEvent_Aborted:
+		if p.Aborted == nil {
+			return nil
+		}
+		return tb.handleAborted(ctx, invocations, invocationID, p.Aborted)
 	}
 	return nil
 }
@@ -242,6 +248,8 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "finished"
 	case *bep.BuildEvent_BuildMetrics:
 		return "build_metrics"
+	case *bep.BuildEvent_Aborted:
+		return "aborted"
 	default:
 		return "other"
 	}
@@ -419,6 +427,49 @@ func (tb *TraceBuilder) handleBuildFinished(ctx context.Context, invocations map
 	// Don't delete state yet — BuildMetrics may arrive after BuildFinished.
 	// State cleanup is handled by handleBuildMetrics or the stale invocation reaper.
 	return tb.consumeAndRecord(ctx, traces)
+}
+
+// handleAborted records the first abort reason + description on the invocation
+// state. Abort attributes are stamped on the root span at finalize time (or
+// flushOrphaned for reaped invocations). Subsequent aborts are logged at Warn
+// but do not overwrite the original root cause.
+func (tb *TraceBuilder) handleAborted(ctx context.Context, invocations map[string]*invocationState, invocationID string, aborted *bep.Aborted) error {
+	state := invocations[invocationID]
+	if state == nil {
+		tb.logger.Debug("Aborted event dropped — no invocation state",
+			zap.String("invocation_id", invocationID),
+		)
+		return nil
+	}
+
+	reason := abortReasonString(aborted.GetReason())
+	description := aborted.GetDescription()
+	first := state.recordAbort(aborted)
+
+	if first {
+		tb.logger.Debug("Build aborted",
+			zap.String("invocation_id", invocationID),
+			zap.String("reason", reason),
+			zap.String("description", description),
+		)
+	} else {
+		tb.logger.Warn("Additional abort event received; keeping first reason",
+			zap.String("invocation_id", invocationID),
+			zap.String("first_reason", state.abortReason),
+			zap.String("new_reason", reason),
+		)
+	}
+
+	tb.emitLog(ctx, state, invocationID, "bazel.build.aborted",
+		fmt.Sprintf("Build aborted: %s: %s", reason, description),
+		plog.SeverityNumberError, time.Time{},
+		map[string]string{
+			"bazel.abort.reason":      reason,
+			"bazel.abort.description": description,
+		},
+	)
+
+	return nil
 }
 
 func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[string]*invocationState, invocationID string, metrics *bep.BuildMetrics) error {

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1250,4 +1251,190 @@ func TestTestResultBeforeTarget(t *testing.T) {
 
 	assert.Equal(t, targetSpan.SpanID, testSpan.ParentSpanID,
 		"test should be child of target even when test result arrives first")
+}
+
+// --- Aborted event tests (issue #20) ---
+
+// findRootSpan returns the single bazel.build span from a sink, failing the
+// test if zero or more than one match.
+func findRootSpan(t *testing.T, sink *consumertest.TracesSink) ptrace.Span {
+	t.Helper()
+	var match ptrace.Span
+	var found int
+	for _, tr := range sink.AllTraces() {
+		for i := range tr.ResourceSpans().Len() {
+			rs := tr.ResourceSpans().At(i)
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					s := ss.Spans().At(k)
+					if s.Name() == "bazel.build" || strings.HasPrefix(s.Name(), "bazel.build ") {
+						match = s
+						found++
+					}
+				}
+			}
+		}
+	}
+	require.Equal(t, 1, found, "expected exactly one bazel.build span")
+	return match
+}
+
+func TestTraceBuilder_Aborted_StampsRootSpan(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-abort-1", "uuid-abort-1", "build", 1),
+		makeAbortedOBE(t, "inv-abort-1", 2, bep.Aborted_USER_INTERRUPTED, "ctrl-c", nil),
+		makeBuildFinishedOBE(t, "inv-abort-1", 3, 8, "INTERRUPTED"),
+	)
+
+	span := findRootSpan(t, sink)
+
+	reason, ok := span.Attributes().Get("bazel.abort.reason")
+	require.True(t, ok, "missing bazel.abort.reason")
+	assert.Equal(t, "user_interrupted", reason.Str())
+
+	description, ok := span.Attributes().Get("bazel.abort.description")
+	require.True(t, ok, "missing bazel.abort.description")
+	assert.Equal(t, "ctrl-c", description.Str())
+
+	exitName, ok := span.Attributes().Get("bazel.exit_code.name")
+	require.True(t, ok, "missing bazel.exit_code.name")
+	assert.Equal(t, "INTERRUPTED", exitName.Str(), "exit code attrs preserved alongside abort")
+
+	assert.Equal(t, ptrace.StatusCodeError, span.Status().Code())
+	assert.Equal(t, "aborted: user_interrupted: ctrl-c", span.Status().Message())
+}
+
+func TestTraceBuilder_Aborted_OnlyFirstRecorded(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-abort-2", "uuid-abort-2", "build", 1),
+		makeAbortedOBE(t, "inv-abort-2", 2, bep.Aborted_OUT_OF_MEMORY, "heap", nil),
+		makeAbortedOBE(t, "inv-abort-2", 3, bep.Aborted_INTERNAL, "crash", nil),
+		makeBuildFinishedOBE(t, "inv-abort-2", 4, 37, "OOM_ERROR"),
+	)
+
+	span := findRootSpan(t, sink)
+
+	reason, _ := span.Attributes().Get("bazel.abort.reason")
+	assert.Equal(t, "out_of_memory", reason.Str(), "first abort reason preserved")
+
+	description, _ := span.Attributes().Get("bazel.abort.description")
+	assert.Equal(t, "heap", description.Str(), "first abort description preserved")
+}
+
+func TestTraceBuilder_Aborted_WithoutBuildFinished(t *testing.T) {
+	// Exercise the reaper path directly: an invocation that recorded an
+	// abort but never saw BuildFinished must still emit the root span when
+	// flushOrphaned is invoked.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		InvocationTimeout: time.Nanosecond,
+	})
+
+	state := newInvocationState(
+		traceIDFromUUID("uuid-abort-3"),
+		spanIDFromIdentity("uuid-abort-3", "root"),
+		&bep.BuildStarted{Uuid: "uuid-abort-3", Command: "build"},
+		time.Now().Add(-time.Hour),
+	)
+	state.recordAbort(&bep.Aborted{Reason: bep.Aborted_TIME_OUT, Description: "deadline"})
+
+	invocations := map[string]*invocationState{"inv-abort-3": state}
+	tb.reapStale(invocations, time.Now())
+
+	assert.Empty(t, invocations, "expected invocation to be reaped")
+
+	span := findRootSpan(t, sink)
+	reason, ok := span.Attributes().Get("bazel.abort.reason")
+	require.True(t, ok, "missing bazel.abort.reason on reaped aborted invocation")
+	assert.Equal(t, "time_out", reason.Str())
+
+	_, hasExit := span.Attributes().Get("bazel.exit_code.name")
+	assert.False(t, hasExit, "exit code should not be present without BuildFinished")
+
+	assert.Equal(t, ptrace.StatusCodeError, span.Status().Code())
+}
+
+func TestTraceBuilder_BuildFinished_NonAborted_NoAbortAttrs(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-no-abort", "uuid-no-abort", "build", 1),
+		makeBuildFinishedOBE(t, "inv-no-abort", 2, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+
+	_, hasReason := span.Attributes().Get("bazel.abort.reason")
+	assert.False(t, hasReason, "non-aborted build should not have abort reason")
+	_, hasDesc := span.Attributes().Get("bazel.abort.description")
+	assert.False(t, hasDesc, "non-aborted build should not have abort description")
+	assert.Equal(t, ptrace.StatusCodeUnset, span.Status().Code())
+}
+
+func TestTraceBuilder_Aborted_OnArbitraryEventID(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Abort rides on a TargetConfigured event ID instead of BuildFinished.
+	targetID := &bep.BuildEventId{
+		Id: &bep.BuildEventId_TargetConfigured{
+			TargetConfigured: &bep.BuildEventId_TargetConfiguredId{Label: "//pkg:lib"},
+		},
+	}
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-abort-4", "uuid-abort-4", "build", 1),
+		makeAbortedOBE(t, "inv-abort-4", 2, bep.Aborted_LOADING_FAILURE, "bad BUILD file", targetID),
+		makeBuildFinishedOBE(t, "inv-abort-4", 3, 1, "FAILURE"),
+	)
+
+	span := findRootSpan(t, sink)
+	reason, ok := span.Attributes().Get("bazel.abort.reason")
+	require.True(t, ok)
+	assert.Equal(t, "loading_failure", reason.Str())
+}
+
+func TestAbortReasonString_AllEnumValues(t *testing.T) {
+	cases := []struct {
+		reason bep.Aborted_AbortReason
+		want   string
+	}{
+		{bep.Aborted_UNKNOWN, "unknown"},
+		{bep.Aborted_USER_INTERRUPTED, "user_interrupted"},
+		{bep.Aborted_NO_ANALYZE, "no_analyze"},
+		{bep.Aborted_NO_BUILD, "no_build"},
+		{bep.Aborted_TIME_OUT, "time_out"},
+		{bep.Aborted_REMOTE_ENVIRONMENT_FAILURE, "remote_environment_failure"},
+		{bep.Aborted_INTERNAL, "internal"},
+		{bep.Aborted_LOADING_FAILURE, "loading_failure"},
+		{bep.Aborted_ANALYSIS_FAILURE, "analysis_failure"},
+		{bep.Aborted_SKIPPED, "skipped"},
+		{bep.Aborted_INCOMPLETE, "incomplete"},
+		{bep.Aborted_OUT_OF_MEMORY, "out_of_memory"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, abortReasonString(tc.reason))
+		})
+	}
 }


### PR DESCRIPTION
Closes #20.

When Bazel aborts a build (Ctrl-C, OOM, timeout, remote execution failure, analysis failure), the root bazel.build span now carries structured abort context: bazel.abort.reason (lowercased BEP enum — user_interrupted, out_of_memory, time_out, etc.), bazel.abort.description, and an ERROR status message of "aborted: <reason>: <description>". Makes "show me all builds aborted due to OOM in the last 24h" answerable directly from the trace backend instead of requiring Bazel-log correlation.

Aborted events can ride on any BEP event ID and multiple can arrive per invocation. Only the first is recorded (the root cause); subsequent ones log at Warn but don't overwrite state. Exit-code attributes from BuildFinished coexist with abort attributes — abort status takes precedence as the authoritative signal while exit-code attrs stay for observability.

The reaper path also emits the root span when an abort arrived but BuildFinished never did, so the abort signal survives when the BES stream drops mid-build.

Stacked on #40.