### PR TITLE
feat(besreceiver): attach workspace status and build metadata to root span

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1,0 +1,160 @@
+# Attribute reference
+
+This page lists every span attribute the `besreceiver` emits, grouped by
+span type, alongside the BEP field it's derived from. Downstream log and
+metric attributes are summarized at the end. Keep this in sync with
+`receiver/besreceiver/invocation.go` and `metricsbuilder.go` when adding or
+renaming attributes.
+
+## Span hierarchy
+
+Every invocation produces one trace (TraceID = `SHA-256(uuid)[0:16]`) with
+the following span tree. Every span's TraceID matches the root; SpanIDs are
+deterministic per [ADR 0001](adr/0001-deterministic-span-ids.md).
+
+```
+bazel.build (root)
+├── bazel.target
+│   ├── bazel.action
+│   └── bazel.action
+├── bazel.target
+│   ├── bazel.test
+│   └── bazel.test
+└── bazel.metrics
+```
+
+## `bazel.build` (root)
+
+Emitted from `BuildStarted` (start timestamp, common attrs) and
+`BuildFinished` (end timestamp, exit-code attrs) or, on an aborted build
+without `BuildFinished`, from the reaper path.
+
+| Attribute                  | Type   | Source                                                         |
+|----------------------------|--------|----------------------------------------------------------------|
+| `bazel.command`            | string | `BuildStarted.command`                                         |
+| `bazel.uuid`               | string | `BuildStarted.uuid`                                            |
+| `bazel.build_tool_version` | string | `BuildStarted.build_tool_version`                              |
+| `bazel.workspace_directory`| string | `BuildStarted.workspace_directory`                             |
+| `bazel.exit_code.name`     | string | `BuildFinished.exit_code.name` (absent on abort-only finalize) |
+| `bazel.exit_code.code`     | int    | `BuildFinished.exit_code.code`                                 |
+| `bazel.abort.reason`       | string | `Aborted.reason` — lowercased enum; first abort wins           |
+| `bazel.abort.description`  | string | `Aborted.description`                                          |
+| `bazel.workspace.<key>`    | string | `WorkspaceStatus.item[*]` — keys sanitized, capped at 30       |
+| `bazel.metadata.<key>`     | string | `BuildMetadata.metadata` — keys sanitized, capped at 20        |
+
+Key sanitization for `bazel.workspace.*` and `bazel.metadata.*`: lowercase,
+collapse whitespace to `_`, strip characters outside `[a-z0-9_.]`, trim
+leading/trailing `_` and `.`. Values are truncated to 256 bytes at a UTF-8
+rune boundary. Metadata keys are sorted alphabetically before the cap so
+which entries survive truncation is deterministic.
+
+Status is set to `ERROR` when `exit_code.code != 0`. An abort overrides the
+status message to `"aborted: <reason>: <description>"` but does not remove
+the exit-code attributes — abort is the root cause, exit code is the
+consequence.
+
+## `bazel.target`
+
+One span per configured target, emitted from `TargetConfigured`. Structural
+parent for `bazel.action` and `bazel.test` spans belonging to the target.
+
+| Attribute                | Type   | Source                                |
+|--------------------------|--------|---------------------------------------|
+| `bazel.target.label`     | string | Target label from `TargetConfiguredId`|
+| `bazel.target.rule_kind` | string | `TargetConfigured.target_kind`        |
+
+## `bazel.action`
+
+One span per executed action, emitted from `ActionExecuted`. Name is
+`bazel.action <mnemonic>` when the mnemonic is present, otherwise
+`bazel.action`. Timestamps come from `ActionExecuted.start_time` /
+`end_time`.
+
+| Attribute               | Type   | Source                           |
+|-------------------------|--------|----------------------------------|
+| `bazel.action.mnemonic` | string | `ActionExecuted.type`            |
+| `bazel.action.exit_code`| int    | `ActionExecuted.exit_code`       |
+| `bazel.action.success`  | bool   | `ActionExecuted.success`         |
+| `bazel.target.label`    | string | Owning target label (when known) |
+
+Status is `ERROR` with message `"action failed"` when
+`ActionExecuted.success` is false.
+
+## `bazel.test`
+
+One span per test attempt, emitted from `TestResult`. Name is `bazel.test`.
+Start timestamp from `TestResult.test_attempt_start`; end timestamp is
+start plus `test_attempt_duration` when set.
+
+| Attribute             | Type   | Source                      |
+|-----------------------|--------|-----------------------------|
+| `bazel.test.status`   | string | `TestResult.status` (enum)  |
+| `bazel.test.run`      | int    | `TestResultId.run`          |
+| `bazel.test.shard`    | int    | `TestResultId.shard`        |
+| `bazel.test.attempt`  | int    | `TestResultId.attempt`      |
+| `bazel.target.label`  | string | Owning target label         |
+
+Status is `ERROR` with the enum name as the message when the status is
+anything other than `PASSED`.
+
+## `bazel.metrics`
+
+One span per invocation, emitted from `BuildMetrics`. Carries timing and
+action-summary aggregates for the whole build.
+
+| Attribute                                | Type | Source                                    |
+|------------------------------------------|------|-------------------------------------------|
+| `bazel.metrics.wall_time_ms`             | int  | `TimingMetrics.wall_time_in_ms`           |
+| `bazel.metrics.cpu_time_ms`              | int  | `TimingMetrics.cpu_time_in_ms`            |
+| `bazel.metrics.analysis_phase_time_ms`   | int  | `TimingMetrics.analysis_phase_time_in_ms` |
+| `bazel.metrics.execution_phase_time_ms`  | int  | `TimingMetrics.execution_phase_time_in_ms`|
+| `bazel.metrics.actions_created`          | int  | `ActionSummary.actions_created`           |
+| `bazel.metrics.actions_executed`         | int  | `ActionSummary.actions_executed`          |
+
+## Use cases
+
+A few queries you can run directly against the emitted attributes, assuming
+a backend that accepts span-attribute filters (Datadog, Tempo, Jaeger,
+Honeycomb, etc.):
+
+**Which builds were OOM-killed in the last 24h?**
+Filter root spans where `bazel.abort.reason = "out_of_memory"`. The
+`bazel.abort.description` attribute carries Bazel's message for
+additional context.
+
+**Show every build on the `main` branch.**
+Filter root spans where `bazel.workspace.stable_git_branch = "main"`.
+Requires `--workspace_status_command` to emit `STABLE_GIT_BRANCH`.
+
+**Traces for a specific CI pipeline run.**
+Filter root spans where `bazel.metadata.ci_pipeline_id = "<id>"`.
+Requires the CI system to pass `--build_metadata=ci_pipeline_id=<id>`.
+
+**How often do developers interrupt a build vs. Bazel failing it?**
+Group root spans by `bazel.abort.reason`; `user_interrupted` tells you
+Ctrl-C, any of the other eleven enum values tells you Bazel aborted.
+
+**Median wall time for successful `bazel test` runs this week.**
+Filter where `bazel.command = "test"` and `bazel.exit_code.code = 0`,
+aggregate `bazel.metrics.wall_time_ms` with a p50.
+
+**Correlate a trace with its Bazel invocation ID.**
+`bazel.uuid` on the root span matches the `--invocation_id` shown in
+Bazel's terminal output, making it easy to pivot from a CI log line
+("Invocation ID: abc-123") to the full trace.
+
+## Logs
+
+Each handled BEP event also emits a log record with common attributes
+`bazel.invocation_id` and event-specific key/value pairs. The log body is
+a short human-readable summary (e.g. `"Build finished: SUCCESS"`). Severity
+is `Info` for successful events, `Error` for failures and aborts. Log
+records carry the invocation's TraceID so they correlate with the trace
+emitted for the same invocation.
+
+## Metrics
+
+Per-invocation gauges (`bazel.invocation.*`) and cross-invocation
+cumulative counters are emitted from `BuildMetrics` with
+`bazel.invocation_id` and `bazel.command` as attributes. See
+`metricsbuilder.go` for the full set.

--- a/receiver/besreceiver/attrs.go
+++ b/receiver/besreceiver/attrs.go
@@ -1,0 +1,52 @@
+package besreceiver
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	maxWorkspaceItems       = 30
+	maxBuildMetadataEntries = 20
+	maxAttrValueLen         = 256
+)
+
+// sanitizeAttrKey normalizes a user-supplied key so it is safe to use as an
+// OTel attribute suffix. Rules: lowercase, collapse whitespace to single '_',
+// drop characters outside [a-z0-9_.], trim leading/trailing '_' and '.'.
+// Returns "" for keys that reduce to empty; callers should skip those.
+func sanitizeAttrKey(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	prevUnderscore := false
+	for _, r := range s {
+		switch {
+		case unicode.IsSpace(r):
+			if !prevUnderscore {
+				b.WriteByte('_')
+				prevUnderscore = true
+			}
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '.':
+			b.WriteRune(r)
+			prevUnderscore = r == '_'
+		default:
+			// drop
+		}
+	}
+	return strings.Trim(b.String(), "_.")
+}
+
+// truncateAttrValue returns v bounded to maxAttrValueLen bytes, backing off to
+// the nearest rune boundary so we never emit an invalid UTF-8 attribute.
+func truncateAttrValue(v string) string {
+	if len(v) <= maxAttrValueLen {
+		return v
+	}
+	end := maxAttrValueLen
+	for end > 0 && !utf8.RuneStart(v[end]) {
+		end--
+	}
+	return v[:end]
+}

--- a/receiver/besreceiver/attrs_test.go
+++ b/receiver/besreceiver/attrs_test.go
@@ -1,0 +1,60 @@
+package besreceiver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeAttrKey(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"BUILD_SCM_REVISION", "build_scm_revision"},
+		{"STABLE_GIT_BRANCH", "stable_git_branch"},
+		{"My Key", "my_key"},
+		{"CI Run #42", "ci_run_42"},
+		{"weird!@#key", "weirdkey"},
+		{"already_lower.case", "already_lower.case"},
+		{"___", ""},
+		{"", ""},
+		{"  spaces  ", "spaces"},
+		{"multiple   spaces", "multiple_spaces"},
+		{".leading.dot", "leading.dot"},
+		{"trailing.", "trailing"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, sanitizeAttrKey(tc.in))
+		})
+	}
+}
+
+func TestTruncateAttrValue(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t, "", truncateAttrValue(""))
+	})
+	t.Run("under limit", func(t *testing.T) {
+		v := strings.Repeat("a", 100)
+		assert.Equal(t, v, truncateAttrValue(v))
+	})
+	t.Run("exactly at limit", func(t *testing.T) {
+		v := strings.Repeat("a", maxAttrValueLen)
+		assert.Equal(t, v, truncateAttrValue(v))
+	})
+	t.Run("over limit truncates", func(t *testing.T) {
+		v := strings.Repeat("a", maxAttrValueLen+50)
+		got := truncateAttrValue(v)
+		assert.Len(t, got, maxAttrValueLen)
+	})
+	t.Run("multi-byte rune boundary", func(t *testing.T) {
+		// Build a string where the 256th byte falls inside a multi-byte rune.
+		// 'é' is 2 bytes in UTF-8. Place it so it straddles the cutoff.
+		prefix := strings.Repeat("a", maxAttrValueLen-1)
+		v := prefix + "é" + "tail"
+		got := truncateAttrValue(v)
+		assert.Len(t, got, maxAttrValueLen-1, "should back off to rune boundary")
+		assert.Equal(t, prefix, got)
+	})
+}

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -1,6 +1,7 @@
 package besreceiver
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -53,6 +54,13 @@ type invocationState struct {
 	abortRecorded    bool
 	abortReason      string
 	abortDescription string
+
+	// workspaceItems buffers sanitized WorkspaceStatus entries until the root
+	// span is emitted. Keys are pre-sanitized; values are pre-truncated.
+	workspaceItems map[string]string
+	// buildMetadata buffers sanitized --build_metadata entries until the root
+	// span is emitted. Keys are pre-sanitized; values are pre-truncated.
+	buildMetadata map[string]string
 }
 
 func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time) *invocationState {
@@ -244,6 +252,8 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 		span.Attributes().PutStr("bazel.workspace_directory", s.started.GetWorkspaceDirectory())
 	}
 
+	s.applyContextAttributes(span)
+
 	if finished != nil {
 		exitCode := finished.GetExitCode()
 		span.Attributes().PutStr("bazel.exit_code.name", exitCode.GetName())
@@ -282,6 +292,86 @@ func (s *invocationState) recordAbort(a *bep.Aborted) bool {
 // Bazel versions are handled automatically via the generated String() method.
 func abortReasonString(r bep.Aborted_AbortReason) string {
 	return strings.ToLower(r.String())
+}
+
+// addWorkspaceItems buffers a WorkspaceStatus payload for emission on the
+// root span. Items are kept in source order; the first maxWorkspaceItems
+// with non-empty sanitized keys are stored (later duplicates overwrite on
+// sanitization collision — documented trade-off).
+func (s *invocationState) addWorkspaceItems(items []*bep.WorkspaceStatus_Item) {
+	if s.flushed {
+		return
+	}
+	if s.workspaceItems == nil {
+		s.workspaceItems = make(map[string]string)
+	}
+	kept := len(s.workspaceItems)
+	for _, item := range items {
+		if kept >= maxWorkspaceItems {
+			break
+		}
+		key := sanitizeAttrKey(item.GetKey())
+		if key == "" {
+			continue
+		}
+		s.workspaceItems[key] = truncateAttrValue(item.GetValue())
+		kept = len(s.workspaceItems)
+	}
+}
+
+// addBuildMetadata buffers a BuildMetadata payload for emission on the root
+// span. BEP maps are unordered, so keys are sorted alphabetically before the
+// cap is applied to make truncation deterministic across reruns.
+func (s *invocationState) addBuildMetadata(md map[string]string) {
+	if s.flushed {
+		return
+	}
+	if s.buildMetadata == nil {
+		s.buildMetadata = make(map[string]string)
+	}
+	keys := make([]string, 0, len(md))
+	for k := range md {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	kept := len(s.buildMetadata)
+	for _, rawKey := range keys {
+		if kept >= maxBuildMetadataEntries {
+			break
+		}
+		key := sanitizeAttrKey(rawKey)
+		if key == "" {
+			continue
+		}
+		s.buildMetadata[key] = truncateAttrValue(md[rawKey])
+		kept = len(s.buildMetadata)
+	}
+}
+
+// applyContextAttributes writes buffered WorkspaceStatus + BuildMetadata
+// entries onto the root span. Keys are emitted in sorted order for
+// deterministic attribute listings across backends.
+func (s *invocationState) applyContextAttributes(span ptrace.Span) {
+	if len(s.workspaceItems) > 0 {
+		keys := make([]string, 0, len(s.workspaceItems))
+		for k := range s.workspaceItems {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			span.Attributes().PutStr("bazel.workspace."+k, s.workspaceItems[k])
+		}
+	}
+	if len(s.buildMetadata) > 0 {
+		keys := make([]string, 0, len(s.buildMetadata))
+		for k := range s.buildMetadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			span.Attributes().PutStr("bazel.metadata."+k, s.buildMetadata[k])
+		}
+	}
 }
 
 // buildMetricsSpan creates a standalone Traces payload for BuildMetrics.

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -3,6 +3,7 @@ package besreceiver
 import (
 	"context"
 	"io"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -108,6 +109,44 @@ func makeBuildFinishedOBE(t testing.TB, invID string, seqNum int64, code int32, 
 				ExitCode:   &bep.BuildFinished_ExitCode{Name: name, Code: code},
 				FinishTime: &timestamppb.Timestamp{Seconds: 1700000010},
 			},
+		},
+	})
+}
+
+func makeWorkspaceStatusOBE(t testing.TB, invID string, seqNum int64, items map[string]string) *pb.OrderedBuildEvent {
+	t.Helper()
+	wsItems := make([]*bep.WorkspaceStatus_Item, 0, len(items))
+	// Sort by key for deterministic wire-level order (BEP carries a repeated field).
+	keys := make([]string, 0, len(items))
+	for k := range items {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		wsItems = append(wsItems, &bep.WorkspaceStatus_Item{Key: k, Value: items[k]})
+	}
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_WorkspaceStatus{
+				WorkspaceStatus: &bep.BuildEventId_WorkspaceStatusId{},
+			},
+		},
+		Payload: &bep.BuildEvent_WorkspaceStatus{
+			WorkspaceStatus: &bep.WorkspaceStatus{Item: wsItems},
+		},
+	})
+}
+
+func makeBuildMetadataOBE(t testing.TB, invID string, seqNum int64, entries map[string]string) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_BuildMetadata{
+				BuildMetadata: &bep.BuildEventId_BuildMetadataId{},
+			},
+		},
+		Payload: &bep.BuildEvent_BuildMetadata{
+			BuildMetadata: &bep.BuildMetadata{Metadata: entries},
 		},
 	})
 }

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -229,6 +229,16 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 			return nil
 		}
 		return tb.handleAborted(ctx, invocations, invocationID, p.Aborted)
+	case *bep.BuildEvent_WorkspaceStatus:
+		if p.WorkspaceStatus == nil {
+			return nil
+		}
+		return tb.handleWorkspaceStatus(ctx, invocations, invocationID, p.WorkspaceStatus)
+	case *bep.BuildEvent_BuildMetadata:
+		if p.BuildMetadata == nil {
+			return nil
+		}
+		return tb.handleBuildMetadata(ctx, invocations, invocationID, p.BuildMetadata)
 	}
 	return nil
 }
@@ -250,6 +260,10 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "build_metrics"
 	case *bep.BuildEvent_Aborted:
 		return "aborted"
+	case *bep.BuildEvent_WorkspaceStatus:
+		return "workspace_status"
+	case *bep.BuildEvent_BuildMetadata:
+		return "build_metadata"
 	default:
 		return "other"
 	}
@@ -469,6 +483,36 @@ func (tb *TraceBuilder) handleAborted(ctx context.Context, invocations map[strin
 		},
 	)
 
+	return nil
+}
+
+// handleWorkspaceStatus buffers WorkspaceStatus items on the invocation state
+// for emission as bazel.workspace.* attributes on the root span.
+func (tb *TraceBuilder) handleWorkspaceStatus(_ context.Context, invocations map[string]*invocationState, invocationID string, ws *bep.WorkspaceStatus) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	state.addWorkspaceItems(ws.GetItem())
+	tb.logger.Debug("Workspace status received",
+		zap.String("invocation_id", invocationID),
+		zap.Int("items", len(ws.GetItem())),
+	)
+	return nil
+}
+
+// handleBuildMetadata buffers BuildMetadata entries on the invocation state
+// for emission as bazel.metadata.* attributes on the root span.
+func (tb *TraceBuilder) handleBuildMetadata(_ context.Context, invocations map[string]*invocationState, invocationID string, bm *bep.BuildMetadata) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	state.addBuildMetadata(bm.GetMetadata())
+	tb.logger.Debug("Build metadata received",
+		zap.String("invocation_id", invocationID),
+		zap.Int("entries", len(bm.GetMetadata())),
+	)
 	return nil
 }
 

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -1438,3 +1438,179 @@ func TestAbortReasonString_AllEnumValues(t *testing.T) {
 		})
 	}
 }
+
+// --- WorkspaceStatus + BuildMetadata tests (issue #22) ---
+
+func TestWorkspaceStatusAttributesOnRootSpan(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-ws-1", "uuid-ws-1", "build", 1),
+		makeWorkspaceStatusOBE(t, "inv-ws-1", 2, map[string]string{
+			"BUILD_SCM_REVISION": "abc123",
+			"STABLE_GIT_BRANCH":  "main",
+		}),
+		makeBuildFinishedOBE(t, "inv-ws-1", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+
+	rev, ok := span.Attributes().Get("bazel.workspace.build_scm_revision")
+	require.True(t, ok, "missing bazel.workspace.build_scm_revision")
+	assert.Equal(t, "abc123", rev.Str())
+
+	branch, ok := span.Attributes().Get("bazel.workspace.stable_git_branch")
+	require.True(t, ok, "missing bazel.workspace.stable_git_branch")
+	assert.Equal(t, "main", branch.Str())
+}
+
+func TestBuildMetadataAttributesOnRootSpan(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-md-1", "uuid-md-1", "build", 1),
+		makeBuildMetadataOBE(t, "inv-md-1", 2, map[string]string{
+			"ci_pipeline_id": "pipeline-42",
+			"PR Number":      "123",
+		}),
+		makeBuildFinishedOBE(t, "inv-md-1", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+
+	pipeline, ok := span.Attributes().Get("bazel.metadata.ci_pipeline_id")
+	require.True(t, ok)
+	assert.Equal(t, "pipeline-42", pipeline.Str())
+
+	pr, ok := span.Attributes().Get("bazel.metadata.pr_number")
+	require.True(t, ok, "expected sanitized 'PR Number' → pr_number")
+	assert.Equal(t, "123", pr.Str())
+}
+
+func TestWorkspaceItemsCappedAt30(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	items := make(map[string]string, 50)
+	for i := range 50 {
+		items[fmt.Sprintf("KEY_%03d", i)] = fmt.Sprintf("val-%d", i)
+	}
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-ws-cap", "uuid-ws-cap", "build", 1),
+		makeWorkspaceStatusOBE(t, "inv-ws-cap", 2, items),
+		makeBuildFinishedOBE(t, "inv-ws-cap", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	count := 0
+	span.Attributes().Range(func(k string, _ pcommon.Value) bool {
+		if strings.HasPrefix(k, "bazel.workspace.") {
+			count++
+		}
+		return true
+	})
+	assert.Equal(t, maxWorkspaceItems, count)
+}
+
+func TestBuildMetadataCappedAt20(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	entries := make(map[string]string, 40)
+	for i := range 40 {
+		entries[fmt.Sprintf("key_%03d", i)] = fmt.Sprintf("val-%d", i)
+	}
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-md-cap", "uuid-md-cap", "build", 1),
+		makeBuildMetadataOBE(t, "inv-md-cap", 2, entries),
+		makeBuildFinishedOBE(t, "inv-md-cap", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	count := 0
+	span.Attributes().Range(func(k string, _ pcommon.Value) bool {
+		if strings.HasPrefix(k, "bazel.metadata.") {
+			count++
+		}
+		return true
+	})
+	assert.Equal(t, maxBuildMetadataEntries, count)
+}
+
+func TestAttributeValueTruncatedAt256Chars(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	bigVal := strings.Repeat("x", 500)
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-trunc", "uuid-trunc", "build", 1),
+		makeWorkspaceStatusOBE(t, "inv-trunc", 2, map[string]string{"BIG": bigVal}),
+		makeBuildFinishedOBE(t, "inv-trunc", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	got, ok := span.Attributes().Get("bazel.workspace.big")
+	require.True(t, ok)
+	assert.Len(t, got.Str(), maxAttrValueLen)
+}
+
+func TestMissingWorkspaceAndMetadataEventsDoNotBreakTraces(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-nows", "uuid-nows", "build", 1),
+		makeBuildFinishedOBE(t, "inv-nows", 2, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+
+	// No bazel.workspace.* or bazel.metadata.* should be present.
+	span.Attributes().Range(func(k string, _ pcommon.Value) bool {
+		if strings.HasPrefix(k, "bazel.workspace.") || strings.HasPrefix(k, "bazel.metadata.") {
+			t.Errorf("unexpected context attribute on root span: %s", k)
+		}
+		return true
+	})
+}
+
+func TestWorkspaceEventArrivingAfterFinishedIsIgnored(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-post", "uuid-post", "build", 1),
+		makeBuildFinishedOBE(t, "inv-post", 2, 0, "SUCCESS"),
+		// WorkspaceStatus after finalize — should be ignored.
+		makeWorkspaceStatusOBE(t, "inv-post", 3, map[string]string{"LATE_KEY": "late_val"}),
+	)
+
+	span := findRootSpan(t, sink)
+	_, has := span.Attributes().Get("bazel.workspace.late_key")
+	assert.False(t, has, "workspace events after BuildFinished must not mutate the emitted root span")
+}


### PR DESCRIPTION
Closes #22.

VCS state (via --workspace_status_command) and user-defined tags (via --build_metadata=key=value) now surface on the root bazel.build span as bazel.workspace.<key> and bazel.metadata.<key> attributes. Enables filtering traces by branch, commit, CI pipeline, PR number, queue name, or any other tag the build infrastructure injects — without cross-referencing external systems.

Keys are sanitized (lowercase, whitespace → '_', strip non-[a-z0-9_.], trim) and values are truncated to 256 bytes at a UTF-8 rune boundary. Workspace items are capped at 30 (preserving BEP source order); metadata entries at 20 (sorted alphabetically before cap so truncation is deterministic). Emission iterates sorted keys so attribute listings are stable across backends.

Also introduces `docs/attributes.md` as the user-facing reference for every span attribute the receiver emits, seeded with the baseline attributes and this PR's additions. Downstream PRs in the stack (#41, future #21 and #14) extend the same file.

Stacked on #41.