### PR TITLE
feat(besreceiver): enrich target spans with TargetComplete and TestSummary

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -57,11 +57,29 @@ consequence.
 
 One span per configured target, emitted from `TargetConfigured`. Structural
 parent for `bazel.action` and `bazel.test` spans belonging to the target.
+`TargetComplete` and `TestSummary` arrive after `TargetConfigured` and
+enrich the existing span with outcome and aggregate-test attributes.
 
-| Attribute                | Type   | Source                                |
-|--------------------------|--------|---------------------------------------|
-| `bazel.target.label`     | string | Target label from `TargetConfiguredId`|
-| `bazel.target.rule_kind` | string | `TargetConfigured.target_kind`        |
+| Attribute                              | Type    | Source                                             |
+|----------------------------------------|---------|----------------------------------------------------|
+| `bazel.target.label`                   | string  | Target label from `TargetConfiguredId`             |
+| `bazel.target.rule_kind`               | string  | `TargetConfigured.target_kind`                     |
+| `bazel.target.success`                 | bool    | `TargetComplete.success`                           |
+| `bazel.target.test_timeout_s`          | float64 | `TargetComplete.test_timeout` (seconds)            |
+| `bazel.target.failure_detail`          | string  | `TargetComplete.failure_detail.message`            |
+| `bazel.target.output_group_count`      | int     | `len(TargetComplete.output_group)`                 |
+| `bazel.target.test.overall_status`     | string  | `TestSummary.overall_status` (enum)                |
+| `bazel.target.test.total_run_count`    | int     | `TestSummary.total_run_count`                      |
+| `bazel.target.test.shard_count`        | int     | `TestSummary.shard_count`                          |
+| `bazel.target.test.total_num_cached`   | int     | `TestSummary.total_num_cached`                     |
+| `bazel.target.test.total_run_duration_ms` | int  | `TestSummary.total_run_duration` (ms)              |
+
+Status is set to `ERROR` when `TargetComplete.success` is false — message
+is the `failure_detail.message` when present, otherwise `"target failed"`.
+`TargetComplete` and `TestSummary` are no-ops if no target span exists for
+the label (aborted or out-of-order), matching the silent-degradation
+pattern used elsewhere. Non-test targets receive no `bazel.target.test.*`
+attributes.
 
 ## `bazel.action`
 

--- a/receiver/besreceiver/benchmark_test.go
+++ b/receiver/besreceiver/benchmark_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -97,11 +98,14 @@ func BenchmarkTraceIDFromUUID(b *testing.B) {
 func BenchmarkResolveTargetSpan(b *testing.B) {
 	state := &invocationState{
 		rootSpanID: pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}),
-		targets:    make(map[string]pcommon.SpanID, 100),
+		targets:    make(map[string]ptrace.Span, 100),
 	}
+	scratch := ptrace.NewTraces().ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans()
 	for i := range 100 {
 		label := fmt.Sprintf("//pkg:target-%d", i)
-		state.targets[targetKey(label, fmt.Sprintf("cfg-%d", i))] = spanIDFromIdentity("bench", "target", label)
+		span := scratch.AppendEmpty()
+		span.SetSpanID(spanIDFromIdentity("bench", "target", label))
+		state.targets[targetKey(label, fmt.Sprintf("cfg-%d", i))] = span
 	}
 
 	b.Run("exact_match", func(b *testing.B) {

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -35,9 +35,9 @@ import (
 type invocationState struct {
 	traceID       pcommon.TraceID
 	rootSpanID    pcommon.SpanID
-	uuid          string                    // Bazel invocation UUID, used to seed span-identity strings
-	targets       map[string]pcommon.SpanID // "label\x00configID" → spanID
-	started       *bep.BuildStarted         // buffered for deferred root span emission
+	uuid          string                 // Bazel invocation UUID, used to seed span-identity strings
+	targets       map[string]ptrace.Span // "label\x00configID" → target span handle
+	started       *bep.BuildStarted      // buffered for deferred root span emission
 	createdAt     time.Time
 	pendingTraces ptrace.Traces     // batch of spans accumulated during the build
 	scopeSpans    ptrace.ScopeSpans // reference into pendingTraces for span appending
@@ -69,7 +69,7 @@ func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, star
 		traceID:       traceID,
 		rootSpanID:    rootSpanID,
 		uuid:          started.GetUuid(),
-		targets:       make(map[string]pcommon.SpanID),
+		targets:       make(map[string]ptrace.Span),
 		started:       started,
 		createdAt:     now,
 		pendingTraces: traces,
@@ -94,8 +94,6 @@ func (s *invocationState) addTarget(label, ruleKind string) {
 	}
 
 	spanID := spanIDFromIdentity(s.uuid, "target", label)
-	s.targets[targetKey(label, "")] = spanID
-
 	span := s.appendSpan()
 	span.SetSpanID(spanID)
 	span.SetParentSpanID(s.rootSpanID)
@@ -106,6 +104,10 @@ func (s *invocationState) addTarget(label, ruleKind string) {
 	if ruleKind != "" {
 		span.Attributes().PutStr("bazel.target.rule_kind", ruleKind)
 	}
+
+	// Store the span handle so later TargetComplete / TestSummary events can
+	// mutate attributes on the existing target span.
+	s.targets[targetKey(label, "")] = span
 
 	// Reparent any actions/tests that arrived before this target.
 	s.reparentOrphans(label, spanID)
@@ -348,6 +350,58 @@ func (s *invocationState) addBuildMetadata(md map[string]string) {
 	}
 }
 
+// completeTarget applies TargetComplete attributes to the target span stored
+// under the given label. No-op when the target span is missing (aborted build
+// or TargetComplete arriving before TargetConfigured — same silent-degradation
+// pattern as the action-before-target case) or when the state is already
+// flushed.
+func (s *invocationState) completeTarget(label string, tc *bep.TargetComplete) {
+	if s.flushed {
+		return
+	}
+	span, ok := s.targets[targetKey(label, "")]
+	if !ok {
+		return
+	}
+	span.Attributes().PutBool("bazel.target.success", tc.GetSuccess())
+	if tc.GetTestTimeout() != nil {
+		span.Attributes().PutDouble("bazel.target.test_timeout_s", tc.GetTestTimeout().AsDuration().Seconds())
+	}
+	failureDetail := tc.GetFailureDetail().GetMessage()
+	if failureDetail != "" {
+		span.Attributes().PutStr("bazel.target.failure_detail", failureDetail)
+	}
+	span.Attributes().PutInt("bazel.target.output_group_count", int64(len(tc.GetOutputGroup())))
+	if !tc.GetSuccess() {
+		span.Status().SetCode(ptrace.StatusCodeError)
+		msg := "target failed"
+		if failureDetail != "" {
+			msg = failureDetail
+		}
+		span.Status().SetMessage(msg)
+	}
+}
+
+// summarizeTarget applies TestSummary attributes to the target span. No-op
+// when the target span is missing (non-test target or out-of-order) or when
+// the state is already flushed.
+func (s *invocationState) summarizeTarget(label string, ts *bep.TestSummary) {
+	if s.flushed {
+		return
+	}
+	span, ok := s.targets[targetKey(label, "")]
+	if !ok {
+		return
+	}
+	span.Attributes().PutStr("bazel.target.test.overall_status", ts.GetOverallStatus().String())
+	span.Attributes().PutInt("bazel.target.test.total_run_count", int64(ts.GetTotalRunCount()))
+	span.Attributes().PutInt("bazel.target.test.shard_count", int64(ts.GetShardCount()))
+	span.Attributes().PutInt("bazel.target.test.total_num_cached", int64(ts.GetTotalNumCached()))
+	if ts.GetTotalRunDuration() != nil {
+		span.Attributes().PutInt("bazel.target.test.total_run_duration_ms", ts.GetTotalRunDuration().AsDuration().Milliseconds())
+	}
+}
+
 // applyContextAttributes writes buffered WorkspaceStatus + BuildMetadata
 // entries onto the root span. Keys are emitted in sorted order for
 // deterministic attribute listings across backends.
@@ -429,11 +483,11 @@ func (s *invocationState) flushOrphaned() (ptrace.Traces, bool) {
 // caller records the span as an orphan so that addTarget can reparent it
 // when the TargetConfigured event arrives. See recordOrphan / reparentOrphans.
 func (s *invocationState) resolveTargetSpan(label, configID string) (pcommon.SpanID, bool) {
-	if spanID, ok := s.targets[targetKey(label, configID)]; ok {
-		return spanID, true
+	if span, ok := s.targets[targetKey(label, configID)]; ok {
+		return span.SpanID(), true
 	}
-	if spanID, ok := s.targets[targetKey(label, "")]; ok {
-		return spanID, true
+	if span, ok := s.targets[targetKey(label, "")]; ok {
+		return span.SpanID(), true
 	}
 	return s.rootSpanID, false
 }

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -2,9 +2,11 @@ package besreceiver
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -13,9 +15,11 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+	"github.com/chagui/besreceiver/internal/bep/failuredetails"
 )
 
 // --- Mock gRPC stream ---
@@ -233,6 +237,49 @@ func makeTargetConfiguredOBE(t testing.TB, invID, label string, seqNum int64) *p
 		Payload: &bep.BuildEvent_Configured{
 			Configured: &bep.TargetConfigured{TargetKind: "java_library rule"},
 		},
+	})
+}
+
+func makeTargetCompleteOBE(t testing.TB, invID, label string, seqNum int64, success bool, testTimeout time.Duration, failureMsg string, outputGroupCount int) *pb.OrderedBuildEvent {
+	t.Helper()
+	tc := &bep.TargetComplete{Success: success}
+	if testTimeout > 0 {
+		tc.TestTimeout = durationpb.New(testTimeout)
+	}
+	if failureMsg != "" {
+		tc.FailureDetail = &failuredetails.FailureDetail{Message: failureMsg}
+	}
+	for i := range outputGroupCount {
+		tc.OutputGroup = append(tc.OutputGroup, &bep.OutputGroup{Name: fmt.Sprintf("group-%d", i)})
+	}
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_TargetCompleted{
+				TargetCompleted: &bep.BuildEventId_TargetCompletedId{Label: label},
+			},
+		},
+		Payload: &bep.BuildEvent_Completed{Completed: tc},
+	})
+}
+
+func makeTestSummaryOBE(t testing.TB, invID, label string, seqNum int64, status bep.TestStatus, totalRun, shards, cached int32, dur time.Duration) *pb.OrderedBuildEvent {
+	t.Helper()
+	ts := &bep.TestSummary{
+		OverallStatus:  status,
+		TotalRunCount:  totalRun,
+		ShardCount:     shards,
+		TotalNumCached: cached,
+	}
+	if dur > 0 {
+		ts.TotalRunDuration = durationpb.New(dur)
+	}
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_TestSummary{
+				TestSummary: &bep.BuildEventId_TestSummaryId{Label: label},
+			},
+		},
+		Payload: &bep.BuildEvent_TestSummary{TestSummary: ts},
 	})
 }
 

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -184,7 +185,7 @@ func (tb *TraceBuilder) ProcessOrderedBuildEvent(ctx context.Context, obe *pb.Or
 	}
 }
 
-//nolint:gocyclo // Flat payload dispatch: grows as the receiver handles more BEP event types. Splitting by payload family would hurt discoverability.
+//nolint:gocyclo,gocognit,cyclop // Flat payload dispatch: grows as the receiver handles more BEP event types. Splitting by payload family would hurt discoverability.
 func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string]*invocationState, invocationID string, event *bep.BuildEvent) error {
 	tb.eventsProcessed.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("event_type", eventTypeName(event)),
@@ -239,6 +240,16 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 			return nil
 		}
 		return tb.handleBuildMetadata(ctx, invocations, invocationID, p.BuildMetadata)
+	case *bep.BuildEvent_Completed:
+		if p.Completed == nil {
+			return nil
+		}
+		return tb.handleTargetComplete(ctx, invocations, invocationID, event.GetId(), p.Completed)
+	case *bep.BuildEvent_TestSummary:
+		if p.TestSummary == nil {
+			return nil
+		}
+		return tb.handleTestSummary(ctx, invocations, invocationID, event.GetId(), p.TestSummary)
 	}
 	return nil
 }
@@ -264,6 +275,10 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "workspace_status"
 	case *bep.BuildEvent_BuildMetadata:
 		return "build_metadata"
+	case *bep.BuildEvent_Completed:
+		return "target_complete"
+	case *bep.BuildEvent_TestSummary:
+		return "test_summary"
 	default:
 		return "other"
 	}
@@ -512,6 +527,61 @@ func (tb *TraceBuilder) handleBuildMetadata(_ context.Context, invocations map[s
 	tb.logger.Debug("Build metadata received",
 		zap.String("invocation_id", invocationID),
 		zap.Int("entries", len(bm.GetMetadata())),
+	)
+	return nil
+}
+
+// handleTargetComplete enriches an existing bazel.target span with outcome
+// attributes from TargetComplete. Arrives after TargetConfigured in practice;
+// no-op when the target span is missing (aborted or out-of-order).
+func (tb *TraceBuilder) handleTargetComplete(ctx context.Context, invocations map[string]*invocationState, invocationID string, eventID *bep.BuildEventId, tc *bep.TargetComplete) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	label := eventID.GetTargetCompleted().GetLabel()
+	if label == "" {
+		return nil
+	}
+	state.completeTarget(label, tc)
+
+	severity := plog.SeverityNumberInfo
+	body := fmt.Sprintf("Target completed: %s", label)
+	if !tc.GetSuccess() {
+		severity = plog.SeverityNumberError
+		body = fmt.Sprintf("Target failed: %s", label)
+	}
+	tb.emitLog(ctx, state, invocationID, "bazel.target.completed",
+		body, severity, time.Time{},
+		map[string]string{
+			"bazel.target.label":   label,
+			"bazel.target.success": strconv.FormatBool(tc.GetSuccess()),
+		},
+	)
+	return nil
+}
+
+// handleTestSummary enriches an existing bazel.target span with aggregate
+// test metrics from TestSummary. No-op for non-test targets (no summary
+// arrives) or when the target span is missing.
+func (tb *TraceBuilder) handleTestSummary(ctx context.Context, invocations map[string]*invocationState, invocationID string, eventID *bep.BuildEventId, ts *bep.TestSummary) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	label := eventID.GetTestSummary().GetLabel()
+	if label == "" {
+		return nil
+	}
+	state.summarizeTarget(label, ts)
+
+	tb.emitLog(ctx, state, invocationID, "bazel.target.test_summary",
+		fmt.Sprintf("Test summary: %s", label),
+		plog.SeverityNumberInfo, time.Time{},
+		map[string]string{
+			"bazel.target.label":               label,
+			"bazel.target.test.overall_status": ts.GetOverallStatus().String(),
+		},
 	)
 	return nil
 }

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -402,11 +402,19 @@ func TestResolveTargetSpan(t *testing.T) {
 	exactSpanID := pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2})
 	labelOnlySpanID := pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 3})
 
+	// Synthesize span handles with the desired IDs. Spans live inside a
+	// ptrace.Traces; append to a scratch SpanSlice so the handles are valid.
+	scratch := ptrace.NewTraces().ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans()
+	exactSpan := scratch.AppendEmpty()
+	exactSpan.SetSpanID(exactSpanID)
+	labelOnlySpan := scratch.AppendEmpty()
+	labelOnlySpan.SetSpanID(labelOnlySpanID)
+
 	state := &invocationState{
 		rootSpanID: rootSpanID,
-		targets: map[string]pcommon.SpanID{
-			targetKey("//pkg:lib", "cfg-1"): exactSpanID,
-			targetKey("//pkg:lib", ""):      labelOnlySpanID,
+		targets: map[string]ptrace.Span{
+			targetKey("//pkg:lib", "cfg-1"): exactSpan,
+			targetKey("//pkg:lib", ""):      labelOnlySpan,
 		},
 	}
 
@@ -1613,4 +1621,232 @@ func TestWorkspaceEventArrivingAfterFinishedIsIgnored(t *testing.T) {
 	span := findRootSpan(t, sink)
 	_, has := span.Attributes().Get("bazel.workspace.late_key")
 	assert.False(t, has, "workspace events after BuildFinished must not mutate the emitted root span")
+}
+
+// --- Target lifecycle tests (issue #19) ---
+
+// findTargetSpan returns the sole bazel.target span with the given label,
+// failing the test if zero or more than one match.
+func findTargetSpan(t *testing.T, sink *consumertest.TracesSink, label string) ptrace.Span {
+	t.Helper()
+	var match ptrace.Span
+	var found int
+	for _, tr := range sink.AllTraces() {
+		for i := range tr.ResourceSpans().Len() {
+			rs := tr.ResourceSpans().At(i)
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					s := ss.Spans().At(k)
+					if s.Name() != "bazel.target" {
+						continue
+					}
+					got, ok := s.Attributes().Get("bazel.target.label")
+					if ok && got.Str() == label {
+						match = s
+						found++
+					}
+				}
+			}
+		}
+	}
+	require.Equal(t, 1, found, "expected exactly one bazel.target span for %q", label)
+	return match
+}
+
+func TestTraceBuilder_TargetComplete_Success(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-tc-1", "uuid-tc-1", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-tc-1", "//pkg:lib", 2),
+		makeTargetCompleteOBE(t, "inv-tc-1", "//pkg:lib", 3, true, 0, "", 2),
+		makeBuildFinishedOBE(t, "inv-tc-1", 4, 0, "SUCCESS"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:lib")
+	success, ok := span.Attributes().Get("bazel.target.success")
+	require.True(t, ok)
+	assert.True(t, success.Bool())
+
+	ogCount, ok := span.Attributes().Get("bazel.target.output_group_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(2), ogCount.Int())
+
+	assert.Equal(t, ptrace.StatusCodeUnset, span.Status().Code())
+}
+
+func TestTraceBuilder_TargetComplete_Failure(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-tc-2", "uuid-tc-2", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-tc-2", "//pkg:lib", 2),
+		makeTargetCompleteOBE(t, "inv-tc-2", "//pkg:lib", 3, false, 0, "compilation failed", 0),
+		makeBuildFinishedOBE(t, "inv-tc-2", 4, 1, "FAILURE"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:lib")
+	success, _ := span.Attributes().Get("bazel.target.success")
+	assert.False(t, success.Bool())
+
+	detail, ok := span.Attributes().Get("bazel.target.failure_detail")
+	require.True(t, ok)
+	assert.Equal(t, "compilation failed", detail.Str())
+
+	assert.Equal(t, ptrace.StatusCodeError, span.Status().Code())
+	assert.Equal(t, "compilation failed", span.Status().Message())
+}
+
+func TestTraceBuilder_TargetComplete_TestTimeout(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-tc-3", "uuid-tc-3", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-tc-3", "//pkg:test", 2),
+		makeTargetCompleteOBE(t, "inv-tc-3", "//pkg:test", 3, true, 60*time.Second, "", 0),
+		makeBuildFinishedOBE(t, "inv-tc-3", 4, 0, "SUCCESS"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:test")
+	timeout, ok := span.Attributes().Get("bazel.target.test_timeout_s")
+	require.True(t, ok)
+	assert.Equal(t, 60.0, timeout.Double())
+}
+
+func TestTraceBuilder_TestSummary(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-ts-1", "uuid-ts-1", "test", 1),
+		makeTargetConfiguredOBE(t, "inv-ts-1", "//pkg:test", 2),
+		makeTestSummaryOBE(t, "inv-ts-1", "//pkg:test", 3, bep.TestStatus_FAILED, 6, 3, 2, 1500*time.Millisecond),
+		makeBuildFinishedOBE(t, "inv-ts-1", 4, 1, "FAILURE"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:test")
+
+	status, ok := span.Attributes().Get("bazel.target.test.overall_status")
+	require.True(t, ok)
+	assert.Equal(t, "FAILED", status.Str())
+
+	runCount, ok := span.Attributes().Get("bazel.target.test.total_run_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(6), runCount.Int())
+
+	shards, _ := span.Attributes().Get("bazel.target.test.shard_count")
+	assert.Equal(t, int64(3), shards.Int())
+
+	cached, _ := span.Attributes().Get("bazel.target.test.total_num_cached")
+	assert.Equal(t, int64(2), cached.Int())
+
+	dur, ok := span.Attributes().Get("bazel.target.test.total_run_duration_ms")
+	require.True(t, ok)
+	assert.Equal(t, int64(1500), dur.Int())
+}
+
+func TestTraceBuilder_TargetComplete_WithoutConfigured(t *testing.T) {
+	// TargetComplete arriving without a prior TargetConfigured is a no-op.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-tc-nc", "uuid-tc-nc", "build", 1),
+		makeTargetCompleteOBE(t, "inv-tc-nc", "//pkg:ghost", 2, false, 0, "boom", 0),
+		makeBuildFinishedOBE(t, "inv-tc-nc", 3, 1, "FAILURE"),
+	)
+
+	// No bazel.target span should exist (no TargetConfigured emitted it).
+	for _, tr := range sink.AllTraces() {
+		for i := range tr.ResourceSpans().Len() {
+			rs := tr.ResourceSpans().At(i)
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					assert.NotEqual(t, "bazel.target", ss.Spans().At(k).Name(),
+						"no target span should exist without TargetConfigured")
+				}
+			}
+		}
+	}
+}
+
+func TestTraceBuilder_TestSummary_WithoutConfigured(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-ts-nc", "uuid-ts-nc", "test", 1),
+		makeTestSummaryOBE(t, "inv-ts-nc", "//pkg:ghost", 2, bep.TestStatus_PASSED, 1, 1, 0, 0),
+		makeBuildFinishedOBE(t, "inv-ts-nc", 3, 0, "SUCCESS"),
+	)
+
+	// No target span, no panic, trace still emits the root span.
+	span := findRootSpan(t, sink)
+	assert.NotNil(t, span)
+}
+
+func TestTraceBuilder_NoTargetComplete_LeavesTargetAttrsMinimal(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// TargetConfigured without matching TargetComplete (e.g. aborted build).
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-no-tc", "uuid-no-tc", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-no-tc", "//pkg:abort", 2),
+		makeBuildFinishedOBE(t, "inv-no-tc", 3, 1, "FAILURE"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:abort")
+	_, hasSuccess := span.Attributes().Get("bazel.target.success")
+	assert.False(t, hasSuccess, "target without TargetComplete should not have success attr")
+	assert.Equal(t, ptrace.StatusCodeUnset, span.Status().Code())
+}
+
+func TestTraceBuilder_NoTestSummary_LeavesTestAttrsAbsent(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Non-test target path: TargetConfigured + TargetComplete, no TestSummary.
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-no-ts", "uuid-no-ts", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-no-ts", "//pkg:lib", 2),
+		makeTargetCompleteOBE(t, "inv-no-ts", "//pkg:lib", 3, true, 0, "", 1),
+		makeBuildFinishedOBE(t, "inv-no-ts", 4, 0, "SUCCESS"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:lib")
+	span.Attributes().Range(func(k string, _ pcommon.Value) bool {
+		assert.False(t, strings.HasPrefix(k, "bazel.target.test."),
+			"non-test target should not have bazel.target.test.* attrs; got %s", k)
+		return true
+	})
 }


### PR DESCRIPTION
Closes #19.

Target spans now carry outcome in addition to configuration. bazel.target.success, bazel.target.test_timeout_s, bazel.target.failure_detail, and bazel.target.output_group_count come from TargetComplete; bazel.target.test.overall_status, total_run_count, shard_count, total_num_cached, and total_run_duration_ms come from TestSummary. The span status flips to ERROR (with the failure_detail message when present) on target failure.

Both events arrive after TargetConfigured and mutate the existing target span by label, so no new spans are introduced. Non-test targets receive no bazel.target.test.* attributes; missing TargetComplete (aborted build) leaves the span at the pre-completion state with no new attributes — the same silent-degradation pattern we use elsewhere when events arrive out-of-order.

Extends docs/attributes.md with the new target-lifecycle attributes.

Stacked on #42.