### PR TITLE
feat(besreceiver): add build configuration and command-line context

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -31,16 +31,20 @@ without `BuildFinished`, from the reaper path.
 
 | Attribute                  | Type   | Source                                                         |
 |----------------------------|--------|----------------------------------------------------------------|
-| `bazel.command`            | string | `BuildStarted.command`                                         |
-| `bazel.uuid`               | string | `BuildStarted.uuid`                                            |
-| `bazel.build_tool_version` | string | `BuildStarted.build_tool_version`                              |
-| `bazel.workspace_directory`| string | `BuildStarted.workspace_directory`                             |
-| `bazel.exit_code.name`     | string | `BuildFinished.exit_code.name` (absent on abort-only finalize) |
-| `bazel.exit_code.code`     | int    | `BuildFinished.exit_code.code`                                 |
-| `bazel.abort.reason`       | string | `Aborted.reason` — lowercased enum; first abort wins           |
-| `bazel.abort.description`  | string | `Aborted.description`                                          |
-| `bazel.workspace.<key>`    | string | `WorkspaceStatus.item[*]` — keys sanitized, capped at 30       |
-| `bazel.metadata.<key>`     | string | `BuildMetadata.metadata` — keys sanitized, capped at 20        |
+| `bazel.command`              | string | `BuildStarted.command`                                           |
+| `bazel.uuid`                 | string | `BuildStarted.uuid`                                              |
+| `bazel.build_tool_version`   | string | `BuildStarted.build_tool_version`                                |
+| `bazel.workspace_directory`  | string | `BuildStarted.workspace_directory`                               |
+| `bazel.exit_code.name`       | string | `BuildFinished.exit_code.name` (absent on abort-only finalize)   |
+| `bazel.exit_code.code`       | int    | `BuildFinished.exit_code.code`                                   |
+| `bazel.abort.reason`         | string | `Aborted.reason` — lowercased enum; first abort wins             |
+| `bazel.abort.description`    | string | `Aborted.description`                                            |
+| `bazel.workspace.<key>`      | string | `WorkspaceStatus.item[*]` — keys sanitized, capped at 30         |
+| `bazel.metadata.<key>`       | string | `BuildMetadata.metadata` — keys sanitized, capped at 20          |
+| `bazel.tool_tag`             | string | `OptionsParsed.tool_tag` (e.g. CI system identifier)             |
+| `bazel.options.startup_count`| int    | `len(OptionsParsed.explicit_startup_options)`                    |
+| `bazel.options.command_count`| int    | `len(OptionsParsed.explicit_cmd_line)`                           |
+| `bazel.command_line`         | string | Reconstructed `StructuredCommandLine` ("original" label, 1024 B) |
 
 Key sanitization for `bazel.workspace.*` and `bazel.metadata.*`: lowercase,
 collapse whitespace to `_`, strip characters outside `[a-z0-9_.]`, trim
@@ -62,17 +66,27 @@ enrich the existing span with outcome and aggregate-test attributes.
 
 | Attribute                              | Type    | Source                                             |
 |----------------------------------------|---------|----------------------------------------------------|
-| `bazel.target.label`                   | string  | Target label from `TargetConfiguredId`             |
-| `bazel.target.rule_kind`               | string  | `TargetConfigured.target_kind`                     |
-| `bazel.target.success`                 | bool    | `TargetComplete.success`                           |
-| `bazel.target.test_timeout_s`          | float64 | `TargetComplete.test_timeout` (seconds)            |
-| `bazel.target.failure_detail`          | string  | `TargetComplete.failure_detail.message`            |
-| `bazel.target.output_group_count`      | int     | `len(TargetComplete.output_group)`                 |
-| `bazel.target.test.overall_status`     | string  | `TestSummary.overall_status` (enum)                |
-| `bazel.target.test.total_run_count`    | int     | `TestSummary.total_run_count`                      |
-| `bazel.target.test.shard_count`        | int     | `TestSummary.shard_count`                          |
-| `bazel.target.test.total_num_cached`   | int     | `TestSummary.total_num_cached`                     |
-| `bazel.target.test.total_run_duration_ms` | int  | `TestSummary.total_run_duration` (ms)              |
+| `bazel.target.label`                      | string  | Target label from `TargetConfiguredId`             |
+| `bazel.target.rule_kind`                  | string  | `TargetConfigured.target_kind`                     |
+| `bazel.target.config.mnemonic`            | string  | `Configuration.mnemonic` (e.g. `k8-opt`)           |
+| `bazel.target.config.platform`            | string  | `Configuration.platform_name`                      |
+| `bazel.target.config.cpu`                 | string  | `Configuration.cpu`                                |
+| `bazel.target.config.is_tool`             | bool    | `Configuration.is_tool` (host/exec vs target)      |
+| `bazel.target.success`                    | bool    | `TargetComplete.success`                           |
+| `bazel.target.test_timeout_s`             | float64 | `TargetComplete.test_timeout` (seconds)            |
+| `bazel.target.failure_detail`             | string  | `TargetComplete.failure_detail.message`            |
+| `bazel.target.output_group_count`         | int     | `len(TargetComplete.output_group)`                 |
+| `bazel.target.test.overall_status`        | string  | `TestSummary.overall_status` (enum)                |
+| `bazel.target.test.total_run_count`       | int     | `TestSummary.total_run_count`                      |
+| `bazel.target.test.shard_count`           | int     | `TestSummary.shard_count`                          |
+| `bazel.target.test.total_num_cached`      | int     | `TestSummary.total_num_cached`                     |
+| `bazel.target.test.total_run_duration_ms` | int     | `TestSummary.total_run_duration` (ms)              |
+
+`bazel.target.config.*` attributes require the `Configuration` event for
+this target's config id to have arrived before `TargetConfigured`. Bazel
+emits it in that order in practice; when the Configuration is missing or
+has the sentinel id `"none"`, config attributes are skipped. The receiver
+does not back-patch attributes retroactively.
 
 Status is set to `ERROR` when `TargetComplete.success` is false — message
 is the `failure_detail.message` when present, otherwise `"target failed"`.
@@ -160,6 +174,16 @@ aggregate `bazel.metrics.wall_time_ms` with a p50.
 `bazel.uuid` on the root span matches the `--invocation_id` shown in
 Bazel's terminal output, making it easy to pivot from a CI log line
 ("Invocation ID: abc-123") to the full trace.
+
+**Compare build times across configurations.**
+Group target spans by `bazel.target.config.mnemonic` (e.g. `k8-opt` vs
+`k8-fastbuild`) and aggregate their duration. Separate host-tool builds
+from user-target builds using `bazel.target.config.is_tool = false`.
+
+**Identify builds launched by a specific tool.**
+Filter root spans where `bazel.tool_tag = "gazelle-ci"` (or whatever
+value CI passes via `--tool_tag=...`) to see every invocation from that
+tool without pulling metadata from external systems.
 
 ## Logs
 

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -61,6 +61,20 @@ type invocationState struct {
 	// buildMetadata buffers sanitized --build_metadata entries until the root
 	// span is emitted. Keys are pre-sanitized; values are pre-truncated.
 	buildMetadata map[string]string
+
+	// configurations maps config id → Configuration payload. Populated by
+	// handleConfiguration so handleTargetConfigured can stamp config attrs
+	// on the target span at creation time. No back-patching: if a
+	// Configuration arrives after its TargetConfigured, the attrs are
+	// skipped (documented ordering assumption).
+	configurations map[string]*bep.Configuration
+
+	// Root-span attrs buffered from OptionsParsed + StructuredCommandLine,
+	// applied in writeRootSpan.
+	toolTag      string
+	startupCount int64
+	commandCount int64
+	commandLine  string
 }
 
 func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time) *invocationState {
@@ -88,7 +102,7 @@ func newTracesPayload() (ptrace.Traces, ptrace.ScopeSpans) {
 	return traces, ss
 }
 
-func (s *invocationState) addTarget(label, ruleKind string) {
+func (s *invocationState) addTarget(label, ruleKind, configID string) {
 	if s.flushed {
 		return
 	}
@@ -104,6 +118,11 @@ func (s *invocationState) addTarget(label, ruleKind string) {
 	if ruleKind != "" {
 		span.Attributes().PutStr("bazel.target.rule_kind", ruleKind)
 	}
+
+	// Stamp configuration attributes if we already have the Configuration
+	// payload for this target's config id. No back-patching if it arrives
+	// later — Bazel emits Configuration before TargetConfigured in practice.
+	s.stampTargetConfig(span, configID)
 
 	// Store the span handle so later TargetComplete / TestSummary events can
 	// mutate attributes on the existing target span.
@@ -254,6 +273,19 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 		span.Attributes().PutStr("bazel.workspace_directory", s.started.GetWorkspaceDirectory())
 	}
 
+	if s.toolTag != "" {
+		span.Attributes().PutStr("bazel.tool_tag", s.toolTag)
+	}
+	if s.startupCount > 0 {
+		span.Attributes().PutInt("bazel.options.startup_count", s.startupCount)
+	}
+	if s.commandCount > 0 {
+		span.Attributes().PutInt("bazel.options.command_count", s.commandCount)
+	}
+	if s.commandLine != "" {
+		span.Attributes().PutStr("bazel.command_line", s.commandLine)
+	}
+
 	s.applyContextAttributes(span)
 
 	if finished != nil {
@@ -402,6 +434,29 @@ func (s *invocationState) summarizeTarget(label string, ts *bep.TestSummary) {
 	}
 }
 
+// storeConfiguration buffers a Configuration payload keyed by its config id.
+// Later invocations of addTarget look the payload up to stamp config attrs.
+func (s *invocationState) storeConfiguration(configID string, cfg *bep.Configuration) {
+	if s.flushed || configID == "" || configID == nullConfigID {
+		return
+	}
+	if s.configurations == nil {
+		s.configurations = make(map[string]*bep.Configuration)
+	}
+	s.configurations[configID] = cfg
+}
+
+// setOptionsParsed captures tool_tag plus startup / command option counts for
+// emission on the root span during finalize.
+func (s *invocationState) setOptionsParsed(op *bep.OptionsParsed) {
+	if s.flushed {
+		return
+	}
+	s.toolTag = op.GetToolTag()
+	s.startupCount = int64(len(op.GetExplicitStartupOptions()))
+	s.commandCount = int64(len(op.GetExplicitCmdLine()))
+}
+
 // applyContextAttributes writes buffered WorkspaceStatus + BuildMetadata
 // entries onto the root span. Keys are emitted in sorted order for
 // deterministic attribute listings across backends.
@@ -426,6 +481,32 @@ func (s *invocationState) applyContextAttributes(span ptrace.Span) {
 			span.Attributes().PutStr("bazel.metadata."+k, s.buildMetadata[k])
 		}
 	}
+}
+
+// nullConfigID is Bazel's sentinel for the null configuration — a TargetCompletedId
+// carrying this id has no associated Configuration payload.
+const nullConfigID = "none"
+
+// stampTargetConfig writes bazel.target.config.* attrs from the buffered
+// Configuration (if any) for the given config id.
+func (s *invocationState) stampTargetConfig(span ptrace.Span, configID string) {
+	if configID == "" || configID == nullConfigID {
+		return
+	}
+	cfg, ok := s.configurations[configID]
+	if !ok {
+		return
+	}
+	if m := cfg.GetMnemonic(); m != "" {
+		span.Attributes().PutStr("bazel.target.config.mnemonic", m)
+	}
+	if p := cfg.GetPlatformName(); p != "" {
+		span.Attributes().PutStr("bazel.target.config.platform", p)
+	}
+	if c := cfg.GetCpu(); c != "" {
+		span.Attributes().PutStr("bazel.target.config.cpu", c)
+	}
+	span.Attributes().PutBool("bazel.target.config.is_tool", cfg.GetIsTool())
 }
 
 // buildMetricsSpan creates a standalone Traces payload for BuildMetrics.

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+	"github.com/chagui/besreceiver/internal/bep/commandline"
 	"github.com/chagui/besreceiver/internal/bep/failuredetails"
 )
 
@@ -260,6 +261,110 @@ func makeTargetCompleteOBE(t testing.TB, invID, label string, seqNum int64, succ
 		},
 		Payload: &bep.BuildEvent_Completed{Completed: tc},
 	})
+}
+
+// makeTargetConfiguredWithConfigOBE is like makeTargetConfiguredOBE but
+// attaches a TargetCompleted child event id carrying a configuration id so
+// handleTargetConfigured can resolve the matching Configuration.
+func makeTargetConfiguredWithConfigOBE(t testing.TB, invID, label, configID string, seqNum int64) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_TargetConfigured{
+				TargetConfigured: &bep.BuildEventId_TargetConfiguredId{Label: label},
+			},
+		},
+		Children: []*bep.BuildEventId{{
+			Id: &bep.BuildEventId_TargetCompleted{
+				TargetCompleted: &bep.BuildEventId_TargetCompletedId{
+					Label:         label,
+					Configuration: &bep.BuildEventId_ConfigurationId{Id: configID},
+				},
+			},
+		}},
+		Payload: &bep.BuildEvent_Configured{
+			Configured: &bep.TargetConfigured{TargetKind: "java_library rule"},
+		},
+	})
+}
+
+func makeConfigurationOBE(t testing.TB, invID, configID, mnemonic, platform, cpu string, isTool bool, seqNum int64) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_Configuration{
+				Configuration: &bep.BuildEventId_ConfigurationId{Id: configID},
+			},
+		},
+		Payload: &bep.BuildEvent_Configuration{
+			Configuration: &bep.Configuration{
+				Mnemonic:     mnemonic,
+				PlatformName: platform,
+				Cpu:          cpu,
+				IsTool:       isTool,
+			},
+		},
+	})
+}
+
+func makeOptionsParsedOBE(t testing.TB, invID, toolTag string, startup, cmd []string, seqNum int64) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_OptionsParsed{
+				OptionsParsed: &bep.BuildEventId_OptionsParsedId{},
+			},
+		},
+		Payload: &bep.BuildEvent_OptionsParsed{
+			OptionsParsed: &bep.OptionsParsed{
+				ToolTag:                toolTag,
+				ExplicitStartupOptions: startup,
+				ExplicitCmdLine:        cmd,
+			},
+		},
+	})
+}
+
+func makeStructuredCommandLineOBE(t testing.TB, invID, label string, sections []*commandline.CommandLineSection, seqNum int64) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_StructuredCommandLine{
+				StructuredCommandLine: &bep.BuildEventId_StructuredCommandLineId{
+					CommandLineLabel: label,
+				},
+			},
+		},
+		Payload: &bep.BuildEvent_StructuredCommandLine{
+			StructuredCommandLine: &commandline.CommandLine{
+				CommandLineLabel: label,
+				Sections:         sections,
+			},
+		},
+	})
+}
+
+// chunkSection wraps a ChunkList section factory for tests.
+func chunkSection(chunks ...string) *commandline.CommandLineSection {
+	return &commandline.CommandLineSection{
+		SectionType: &commandline.CommandLineSection_ChunkList{
+			ChunkList: &commandline.ChunkList{Chunk: chunks},
+		},
+	}
+}
+
+// optionSection wraps an OptionList section factory for tests. Each option
+// is represented by its combined_form.
+func optionSection(options ...string) *commandline.CommandLineSection {
+	opts := make([]*commandline.Option, 0, len(options))
+	for _, o := range options {
+		opts = append(opts, &commandline.Option{CombinedForm: o})
+	}
+	return &commandline.CommandLineSection{
+		SectionType: &commandline.CommandLineSection_OptionList{
+			OptionList: &commandline.OptionList{Option: opts},
+		},
+	}
 }
 
 func makeTestSummaryOBE(t testing.TB, invID, label string, seqNum int64, status bep.TestStatus, totalRun, shards, cached int32, dur time.Duration) *pb.OrderedBuildEvent {

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -24,6 +25,7 @@ import (
 	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
 
 	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+	"github.com/chagui/besreceiver/internal/bep/commandline"
 )
 
 const (
@@ -185,7 +187,7 @@ func (tb *TraceBuilder) ProcessOrderedBuildEvent(ctx context.Context, obe *pb.Or
 	}
 }
 
-//nolint:gocyclo,gocognit,cyclop // Flat payload dispatch: grows as the receiver handles more BEP event types. Splitting by payload family would hurt discoverability.
+//nolint:gocyclo,gocognit,cyclop,funlen // Flat payload dispatch: grows as the receiver handles more BEP event types. Splitting by payload family would hurt discoverability.
 func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string]*invocationState, invocationID string, event *bep.BuildEvent) error {
 	tb.eventsProcessed.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("event_type", eventTypeName(event)),
@@ -204,7 +206,22 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 		if p.Configured == nil {
 			return nil
 		}
-		return tb.handleTargetConfigured(ctx, invocations, invocationID, event.GetId(), p.Configured)
+		return tb.handleTargetConfigured(ctx, invocations, invocationID, event, p.Configured)
+	case *bep.BuildEvent_Configuration:
+		if p.Configuration == nil {
+			return nil
+		}
+		return tb.handleConfiguration(ctx, invocations, invocationID, event.GetId(), p.Configuration)
+	case *bep.BuildEvent_OptionsParsed:
+		if p.OptionsParsed == nil {
+			return nil
+		}
+		return tb.handleOptionsParsed(ctx, invocations, invocationID, p.OptionsParsed)
+	case *bep.BuildEvent_StructuredCommandLine:
+		if p.StructuredCommandLine == nil {
+			return nil
+		}
+		return tb.handleStructuredCommandLine(ctx, invocations, invocationID, p.StructuredCommandLine)
 	case *bep.BuildEvent_Action:
 		if p.Action == nil {
 			return nil
@@ -279,6 +296,12 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "target_complete"
 	case *bep.BuildEvent_TestSummary:
 		return "test_summary"
+	case *bep.BuildEvent_Configuration:
+		return "configuration"
+	case *bep.BuildEvent_OptionsParsed:
+		return "options_parsed"
+	case *bep.BuildEvent_StructuredCommandLine:
+		return "structured_command_line"
 	default:
 		return "other"
 	}
@@ -314,18 +337,30 @@ func (tb *TraceBuilder) handleBuildStarted(ctx context.Context, invocations map[
 	return nil
 }
 
-func (tb *TraceBuilder) handleTargetConfigured(ctx context.Context, invocations map[string]*invocationState, invocationID string, eventID *bep.BuildEventId, configured *bep.TargetConfigured) error {
+func (tb *TraceBuilder) handleTargetConfigured(ctx context.Context, invocations map[string]*invocationState, invocationID string, event *bep.BuildEvent, configured *bep.TargetConfigured) error {
 	state := invocations[invocationID]
 	if state == nil {
 		return nil
 	}
 
-	tc := eventID.GetTargetConfigured()
+	tc := event.GetId().GetTargetConfigured()
 	if tc == nil {
 		return nil
 	}
 
-	state.addTarget(tc.GetLabel(), configured.GetTargetKind())
+	// Config id for this target lives on the TargetCompleted child event id,
+	// not on the TargetConfigured payload itself. Pick the first non-empty
+	// id that isn't "none" (the null config per BEP spec).
+	configID := ""
+	for _, child := range event.GetChildren() {
+		id := child.GetTargetCompleted().GetConfiguration().GetId()
+		if id != "" && id != nullConfigID {
+			configID = id
+			break
+		}
+	}
+
+	state.addTarget(tc.GetLabel(), configured.GetTargetKind(), configID)
 
 	tb.logger.Debug("Target configured",
 		zap.String("invocation_id", invocationID),
@@ -529,6 +564,84 @@ func (tb *TraceBuilder) handleBuildMetadata(_ context.Context, invocations map[s
 		zap.Int("entries", len(bm.GetMetadata())),
 	)
 	return nil
+}
+
+// handleConfiguration buffers a Configuration payload keyed by its id for
+// later lookup when the owning TargetConfigured event arrives.
+func (tb *TraceBuilder) handleConfiguration(_ context.Context, invocations map[string]*invocationState, invocationID string, eventID *bep.BuildEventId, cfg *bep.Configuration) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	configID := eventID.GetConfiguration().GetId()
+	state.storeConfiguration(configID, cfg)
+	tb.logger.Debug("Configuration received",
+		zap.String("invocation_id", invocationID),
+		zap.String("config_id", configID),
+		zap.String("mnemonic", cfg.GetMnemonic()),
+	)
+	return nil
+}
+
+// handleOptionsParsed buffers --tool_tag and explicit option counts onto the
+// invocation state for emission on the root span at finalize.
+func (tb *TraceBuilder) handleOptionsParsed(_ context.Context, invocations map[string]*invocationState, invocationID string, op *bep.OptionsParsed) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	state.setOptionsParsed(op)
+	return nil
+}
+
+// handleStructuredCommandLine reconstructs a human-readable command-line
+// string from the "original" StructuredCommandLine payload and buffers it
+// on the invocation state. Canonical and tool variants are ignored.
+func (tb *TraceBuilder) handleStructuredCommandLine(_ context.Context, invocations map[string]*invocationState, invocationID string, cl *commandline.CommandLine) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	if cl.GetCommandLineLabel() != "original" {
+		return nil
+	}
+	if state.flushed {
+		return nil
+	}
+	state.commandLine = reconstructCommandLine(cl)
+	return nil
+}
+
+const commandLineMaxBytes = 1024
+
+// reconstructCommandLine joins a CommandLine's sections into a single string
+// (ChunkList chunks verbatim, Option lists via combined_form), truncating to
+// commandLineMaxBytes and appending an ellipsis when truncated.
+func reconstructCommandLine(cl *commandline.CommandLine) string {
+	var parts []string
+	for _, section := range cl.GetSections() {
+		if cl := section.GetChunkList(); cl != nil {
+			parts = append(parts, cl.GetChunk()...)
+			continue
+		}
+		if ol := section.GetOptionList(); ol != nil {
+			for _, opt := range ol.GetOption() {
+				if cf := opt.GetCombinedForm(); cf != "" {
+					parts = append(parts, cf)
+				}
+			}
+		}
+	}
+	joined := strings.Join(parts, " ")
+	if len(joined) <= commandLineMaxBytes {
+		return joined
+	}
+	// Back off to rune boundary so we never emit invalid UTF-8.
+	end := commandLineMaxBytes
+	for end > 0 && !utf8.RuneStart(joined[end]) {
+		end--
+	}
+	return joined[:end] + "…"
 }
 
 // handleTargetComplete enriches an existing bazel.target span with outcome

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -23,6 +23,7 @@ import (
 	buildpb "google.golang.org/genproto/googleapis/devtools/build/v1"
 
 	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+	"github.com/chagui/besreceiver/internal/bep/commandline"
 )
 
 func TestTraceBuilder_BuildStarted(t *testing.T) {
@@ -1849,4 +1850,193 @@ func TestTraceBuilder_NoTestSummary_LeavesTestAttrsAbsent(t *testing.T) {
 			"non-test target should not have bazel.target.test.* attrs; got %s", k)
 		return true
 	})
+}
+
+// --- Build configuration / command line context tests (issue #21) ---
+
+func TestTraceBuilder_Configuration_StampsTargetConfigAttrs(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-cfg-1", "uuid-cfg-1", "build", 1),
+		makeConfigurationOBE(t, "inv-cfg-1", "k8-opt", "k8-opt", "linux-x86_64", "k8", false, 2),
+		makeTargetConfiguredWithConfigOBE(t, "inv-cfg-1", "//pkg:lib", "k8-opt", 3),
+		makeBuildFinishedOBE(t, "inv-cfg-1", 4, 0, "SUCCESS"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:lib")
+
+	mnemonic, ok := span.Attributes().Get("bazel.target.config.mnemonic")
+	require.True(t, ok)
+	assert.Equal(t, "k8-opt", mnemonic.Str())
+
+	platform, ok := span.Attributes().Get("bazel.target.config.platform")
+	require.True(t, ok)
+	assert.Equal(t, "linux-x86_64", platform.Str())
+
+	cpu, ok := span.Attributes().Get("bazel.target.config.cpu")
+	require.True(t, ok)
+	assert.Equal(t, "k8", cpu.Str())
+
+	isTool, ok := span.Attributes().Get("bazel.target.config.is_tool")
+	require.True(t, ok)
+	assert.False(t, isTool.Bool())
+}
+
+func TestTraceBuilder_Configuration_ArrivesAfterTarget(t *testing.T) {
+	// Documents the no-back-patching contract: if Configuration arrives after
+	// the TargetConfigured it serves, the target span will lack config attrs.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-cfg-late", "uuid-cfg-late", "build", 1),
+		makeTargetConfiguredWithConfigOBE(t, "inv-cfg-late", "//pkg:lib", "k8-opt", 2),
+		makeConfigurationOBE(t, "inv-cfg-late", "k8-opt", "k8-opt", "linux-x86_64", "k8", false, 3),
+		makeBuildFinishedOBE(t, "inv-cfg-late", 4, 0, "SUCCESS"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:lib")
+	_, hasMnemonic := span.Attributes().Get("bazel.target.config.mnemonic")
+	assert.False(t, hasMnemonic, "late-arriving Configuration is not back-patched")
+}
+
+func TestTraceBuilder_Configuration_MissingConfigDoesNotBreak(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-cfg-miss", "uuid-cfg-miss", "build", 1),
+		makeTargetConfiguredWithConfigOBE(t, "inv-cfg-miss", "//pkg:lib", "never-sent", 2),
+		makeBuildFinishedOBE(t, "inv-cfg-miss", 3, 0, "SUCCESS"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:lib")
+	_, hasMnemonic := span.Attributes().Get("bazel.target.config.mnemonic")
+	assert.False(t, hasMnemonic)
+}
+
+func TestTraceBuilder_Configuration_NoneConfigIgnored(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-cfg-none", "uuid-cfg-none", "build", 1),
+		// A "none" child config id should be treated as no config.
+		makeConfigurationOBE(t, "inv-cfg-none", "none", "phantom", "phantom-platform", "phantom", false, 2),
+		makeTargetConfiguredWithConfigOBE(t, "inv-cfg-none", "//pkg:lib", "none", 3),
+		makeBuildFinishedOBE(t, "inv-cfg-none", 4, 0, "SUCCESS"),
+	)
+
+	span := findTargetSpan(t, sink, "//pkg:lib")
+	_, hasMnemonic := span.Attributes().Get("bazel.target.config.mnemonic")
+	assert.False(t, hasMnemonic, "'none' config id should never stamp attrs")
+}
+
+func TestTraceBuilder_OptionsParsed_RootAttrs(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-op", "uuid-op", "build", 1),
+		makeOptionsParsedOBE(t, "inv-op",
+			"gazelle-ci",
+			[]string{"--output_base=/tmp/x"},
+			[]string{"--config=ci", "//..."},
+			2,
+		),
+		makeBuildFinishedOBE(t, "inv-op", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+
+	tag, ok := span.Attributes().Get("bazel.tool_tag")
+	require.True(t, ok)
+	assert.Equal(t, "gazelle-ci", tag.Str())
+
+	startup, ok := span.Attributes().Get("bazel.options.startup_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(1), startup.Int())
+
+	cmd, ok := span.Attributes().Get("bazel.options.command_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(2), cmd.Int())
+}
+
+func TestTraceBuilder_StructuredCommandLine_OriginalOnly(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	originalSections := []*commandline.CommandLineSection{
+		chunkSection("bazel"),
+		optionSection("--foo=bar"),
+		chunkSection("build"),
+		chunkSection("//..."),
+	}
+	canonicalSections := []*commandline.CommandLineSection{
+		chunkSection("bazel"),
+		optionSection("--foo=canonical"),
+		chunkSection("build"),
+		chunkSection("//..."),
+	}
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-cmd", "uuid-cmd", "build", 1),
+		makeStructuredCommandLineOBE(t, "inv-cmd", "original", originalSections, 2),
+		makeStructuredCommandLineOBE(t, "inv-cmd", "canonical", canonicalSections, 3),
+		makeBuildFinishedOBE(t, "inv-cmd", 4, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	cmd, ok := span.Attributes().Get("bazel.command_line")
+	require.True(t, ok)
+	assert.Equal(t, "bazel --foo=bar build //...", cmd.Str())
+	assert.NotContains(t, cmd.Str(), "canonical", "canonical variant must not leak into output")
+}
+
+func TestTraceBuilder_StructuredCommandLine_Truncated(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// 200 chunks of 10 chars each = 2000 bytes plus spaces, well over 1024.
+	longChunks := make([]string, 200)
+	for i := range longChunks {
+		longChunks[i] = strings.Repeat("x", 10)
+	}
+	sections := []*commandline.CommandLineSection{chunkSection(longChunks...)}
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-long", "uuid-long", "build", 1),
+		makeStructuredCommandLineOBE(t, "inv-long", "original", sections, 2),
+		makeBuildFinishedOBE(t, "inv-long", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	cmd, ok := span.Attributes().Get("bazel.command_line")
+	require.True(t, ok)
+	// <= commandLineMaxBytes + ellipsis rune (3 bytes).
+	assert.LessOrEqual(t, len(cmd.Str()), commandLineMaxBytes+3)
+	assert.True(t, strings.HasSuffix(cmd.Str(), "…"), "expected truncation marker")
 }


### PR DESCRIPTION
Closes #21.

Enriches traces with build-level signal from three new BEP events: Configuration, OptionsParsed, and StructuredCommandLine. Target spans gain bazel.target.config.mnemonic / platform / cpu / is_tool so trace queries can separate k8-opt from k8-fastbuild, or host-tool builds from user-target builds. The root span gains bazel.tool_tag (so CI systems identify themselves), bazel.options.startup_count / command_count (a summary of how the build was invoked), and bazel.command_line (a reconstructed and truncated version of the original command, from the "original" StructuredCommandLine only — canonical and tool variants are dropped).

Configuration is buffered on the invocation state by id; target spans look up their config via the id carried on the TargetCompletedId child event of TargetConfigured. No back-patching: if Configuration arrives after TargetConfigured (not observed in practice), config attrs are skipped silently.

Extends docs/attributes.md with the new attributes and two additional use-case queries.

Stacked on #43.