### PR TITLE
feat(besreceiver)!: add opt-in PII controls for sensitive BEP fields

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -24,6 +24,21 @@ receivers:
     #   cert_file: /etc/otelcol/certs/server.crt
     #   key_file: /etc/otelcol/certs/server.key
     #   client_ca_file: /etc/otelcol/certs/ca.crt
+    # PII controls — all default to false. Gating is by content: if
+    # include_hostname is false, no hostname-like attribute is emitted
+    # regardless of which pathway it arrived on (BuildStarted.host, a
+    # BUILD_HOST workspace-status item, or a host build_metadata entry).
+    # See docs/attributes.md for the full composition model.
+    # pii:
+    #   include_hostname: false            # bazel.host + host-like workspace/metadata keys
+    #   include_username: false            # bazel.user + user-like workspace/metadata keys
+    #   include_workspace_dir: false       # bazel.workspace_directory
+    #   include_working_dir: false         # bazel.working_directory
+    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_action_output_paths: false # bazel.action.primary_output
+    #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
+    #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
+    #   include_command_line: false        # bazel.command_line (coarse only)
 
 processors:
   memory_limiter:

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -34,17 +34,20 @@ without `BuildFinished`, from the reaper path.
 | `bazel.command`              | string | `BuildStarted.command`                                           |
 | `bazel.uuid`                 | string | `BuildStarted.uuid`                                              |
 | `bazel.build_tool_version`   | string | `BuildStarted.build_tool_version`                                |
-| `bazel.workspace_directory`  | string | `BuildStarted.workspace_directory`                               |
+| `bazel.workspace_directory`  | string | `BuildStarted.workspace_directory` — **PII**, requires `include_workspace_dir` |
+| `bazel.working_directory`    | string | `BuildStarted.working_directory` — **PII**, requires `include_working_dir`    |
+| `bazel.host`                 | string | `BuildStarted.host` — **PII**, requires `include_hostname`       |
+| `bazel.user`                 | string | `BuildStarted.user` — **PII**, requires `include_username`       |
 | `bazel.exit_code.name`       | string | `BuildFinished.exit_code.name` (absent on abort-only finalize)   |
 | `bazel.exit_code.code`       | int    | `BuildFinished.exit_code.code`                                   |
 | `bazel.abort.reason`         | string | `Aborted.reason` — lowercased enum; first abort wins             |
 | `bazel.abort.description`    | string | `Aborted.description`                                            |
-| `bazel.workspace.<key>`      | string | `WorkspaceStatus.item[*]` — keys sanitized, capped at 30         |
-| `bazel.metadata.<key>`       | string | `BuildMetadata.metadata` — keys sanitized, capped at 20          |
+| `bazel.workspace.<key>`      | string | `WorkspaceStatus.item[*]` — **PII**, requires `include_workspace_status`; per-key filtered |
+| `bazel.metadata.<key>`       | string | `BuildMetadata.metadata` — **PII**, requires `include_build_metadata`; per-key filtered    |
 | `bazel.tool_tag`             | string | `OptionsParsed.tool_tag` (e.g. CI system identifier)             |
 | `bazel.options.startup_count`| int    | `len(OptionsParsed.explicit_startup_options)`                    |
 | `bazel.options.command_count`| int    | `len(OptionsParsed.explicit_cmd_line)`                           |
-| `bazel.command_line`         | string | Reconstructed `StructuredCommandLine` ("original" label, 1024 B) |
+| `bazel.command_line`         | string | Reconstructed `StructuredCommandLine` — **PII**, requires `include_command_line` |
 
 Key sanitization for `bazel.workspace.*` and `bazel.metadata.*`: lowercase,
 collapse whitespace to `_`, strip characters outside `[a-z0-9_.]`, trim
@@ -104,10 +107,12 @@ One span per executed action, emitted from `ActionExecuted`. Name is
 
 | Attribute               | Type   | Source                           |
 |-------------------------|--------|----------------------------------|
-| `bazel.action.mnemonic` | string | `ActionExecuted.type`            |
-| `bazel.action.exit_code`| int    | `ActionExecuted.exit_code`       |
-| `bazel.action.success`  | bool   | `ActionExecuted.success`         |
-| `bazel.target.label`    | string | Owning target label (when known) |
+| `bazel.action.mnemonic`       | string       | `ActionExecuted.type`                                          |
+| `bazel.action.exit_code`      | int          | `ActionExecuted.exit_code`                                     |
+| `bazel.action.success`        | bool         | `ActionExecuted.success`                                       |
+| `bazel.target.label`          | string       | Owning target label (when known)                               |
+| `bazel.action.command_line`   | string slice | `ActionExecuted.command_line` — **PII**, requires `include_command_args` |
+| `bazel.action.primary_output` | string       | `ActionExecuted.primary_output.name` — **PII**, requires `include_action_output_paths` |
 
 Status is `ERROR` with message `"action failed"` when
 `ActionExecuted.success` is false.
@@ -142,6 +147,61 @@ action-summary aggregates for the whole build.
 | `bazel.metrics.execution_phase_time_ms`  | int  | `TimingMetrics.execution_phase_time_in_ms`|
 | `bazel.metrics.actions_created`          | int  | `ActionSummary.actions_created`           |
 | `bazel.metrics.actions_executed`         | int  | `ActionSummary.actions_executed`          |
+
+## PII controls
+
+Attributes marked **PII** above are gated by the `pii:` config block on the
+receiver. Every flag defaults to `false`, so by default none of those
+attributes are emitted. Enable them selectively based on your compliance
+posture:
+
+```yaml
+receivers:
+  bes:
+    pii:
+      include_hostname: false              # bazel.host + host-like workspace/metadata keys
+      include_username: false              # bazel.user + user-like workspace/metadata keys
+      include_workspace_dir: false         # bazel.workspace_directory + matching workspace/metadata keys
+      include_working_dir: false           # bazel.working_directory + matching workspace/metadata keys
+      include_command_args: false          # bazel.action.command_line
+      include_action_output_paths: false   # bazel.action.primary_output
+      include_workspace_status: false      # bazel.workspace.* pathway (per-key filtered)
+      include_build_metadata: false        # bazel.metadata.* pathway (per-key filtered)
+      include_command_line: false          # bazel.command_line (coarse only)
+```
+
+### Composition
+
+Flags gate by *content*, not by *pathway*. If `include_hostname: false`, no
+hostname-like attribute is emitted regardless of which BEP event carries
+it. This means the coarse gates (`include_workspace_status`,
+`include_build_metadata`) open a pathway but per-key filters still apply
+inside it.
+
+Concretely, with `include_workspace_status: true` and `include_hostname:
+false`: `bazel.workspace.stable_git_branch` is emitted (safe key), but
+`bazel.workspace.build_host` is suppressed (hostname is off).
+
+The sanitized keys matched as PII-sensitive:
+
+| Flag (when false)          | Suppresses workspace/metadata keys       |
+|----------------------------|------------------------------------------|
+| `include_hostname`         | `host`, `hostname`, `build_host`         |
+| `include_username`         | `user`, `username`, `build_user`         |
+| `include_working_dir`      | `working_dir`, `working_directory`       |
+| `include_workspace_dir`    | `workspace_dir`, `workspace_directory`   |
+
+`include_command_line` is coarse-only: the attribute is a free-form
+reconstructed string, so per-key filtering doesn't apply. Operators
+needing finer redaction of the command line should layer a
+`redactionprocessor` on the pipeline.
+
+Note that `bazel.workspace_directory` is gated — earlier receiver versions
+emitted it unconditionally. Operators who relied on it must set
+`include_workspace_dir: true` to restore the prior behavior.
+
+Non-PII attributes (`bazel.command`, `bazel.uuid`, `bazel.tool_tag`, etc.)
+are always emitted regardless of `pii:` settings.
 
 ## Use cases
 

--- a/examples/custom-collector/collector-config.yaml
+++ b/examples/custom-collector/collector-config.yaml
@@ -5,6 +5,20 @@ extensions:
 receivers:
   bes:
     endpoint: "localhost:8082"
+    # PII controls — all default to false. Gating is by content: if
+    # include_hostname is false, no hostname-like attribute is emitted
+    # regardless of which pathway it arrived on. See docs/attributes.md
+    # for the full composition model.
+    # pii:
+    #   include_hostname: false            # bazel.host + host-like workspace/metadata keys
+    #   include_username: false            # bazel.user + user-like workspace/metadata keys
+    #   include_workspace_dir: false       # bazel.workspace_directory
+    #   include_working_dir: false         # bazel.working_directory
+    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_action_output_paths: false # bazel.action.primary_output
+    #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
+    #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
+    #   include_command_line: false        # bazel.command_line (coarse only)
 
 processors:
   memory_limiter:

--- a/examples/datadog/collector-config.yaml
+++ b/examples/datadog/collector-config.yaml
@@ -8,6 +8,20 @@ receivers:
     # Bound to 0.0.0.0 so Bazel clients outside the pod (or sibling containers)
     # can reach the BES gRPC endpoint. For local development, prefer "localhost:8082".
     endpoint: "0.0.0.0:8082"
+    # PII controls — all default to false. Gating is by content: if
+    # include_hostname is false, no hostname-like attribute is emitted
+    # regardless of which pathway it arrived on. See docs/attributes.md
+    # for the full composition model.
+    # pii:
+    #   include_hostname: false            # bazel.host + host-like workspace/metadata keys
+    #   include_username: false            # bazel.user + user-like workspace/metadata keys
+    #   include_workspace_dir: false       # bazel.workspace_directory
+    #   include_working_dir: false         # bazel.working_directory
+    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_action_output_paths: false # bazel.action.primary_output
+    #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
+    #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
+    #   include_command_line: false        # bazel.command_line (coarse only)
 
 processors:
   memory_limiter:

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -19,6 +19,57 @@ type Config struct {
 	// ReaperInterval is how often the stale-invocation reaper runs.
 	// Default: 5m.
 	ReaperInterval time.Duration `mapstructure:"reaper_interval"`
+
+	// PII opts specific BEP fields into span emission. All flags default to
+	// false; enabling a flag surfaces the matching attribute on the root or
+	// action span. See PIIConfig.
+	PII PIIConfig `mapstructure:"pii"`
+}
+
+// PIIConfig controls which potentially-sensitive fields from BEP events are
+// emitted as span attributes. All fields default to false (redacted).
+//
+// Flags compose by content, not by pathway. If IncludeHostname is false, no
+// hostname-like attribute is emitted regardless of which BEP event carries
+// it — so operator-controlled pathways like workspace status and build
+// metadata are also filtered per-key when their coarse gate is open.
+type PIIConfig struct {
+	// IncludeHostname gates hostname-like attributes anywhere they appear:
+	// bazel.host on the root span (from BuildStarted.host), plus any
+	// bazel.workspace.<k> or bazel.metadata.<k> whose sanitized key is
+	// "host", "hostname", or "build_host".
+	IncludeHostname bool `mapstructure:"include_hostname"`
+	// IncludeUsername gates username-like attributes: bazel.user (from
+	// BuildStarted.user), plus bazel.workspace.<k> / bazel.metadata.<k>
+	// whose sanitized key is "user", "username", or "build_user".
+	IncludeUsername bool `mapstructure:"include_username"`
+	// IncludeWorkspaceDir gates bazel.workspace_directory on the root span
+	// and any bazel.workspace/metadata.<k> where k is "workspace_dir" or
+	// "workspace_directory". Breaking: previously the root attribute was
+	// always emitted.
+	IncludeWorkspaceDir bool `mapstructure:"include_workspace_dir"`
+	// IncludeWorkingDir gates bazel.working_directory on the root span and
+	// any bazel.workspace/metadata.<k> where k is "working_dir" or
+	// "working_directory".
+	IncludeWorkingDir bool `mapstructure:"include_working_dir"`
+	// IncludeCommandArgs gates bazel.action.command_line on action spans.
+	// For large monorepos this can materially inflate span payload size.
+	IncludeCommandArgs bool `mapstructure:"include_command_args"`
+	// IncludeActionOutputPaths gates bazel.action.primary_output on action spans.
+	IncludeActionOutputPaths bool `mapstructure:"include_action_output_paths"`
+	// IncludeWorkspaceStatus opens the bazel.workspace.* pathway (items from
+	// --workspace_status_command). When true, workspace items are still
+	// filtered per-key against the specific PII flags above — e.g. a
+	// BUILD_HOST item is suppressed unless IncludeHostname is also true.
+	IncludeWorkspaceStatus bool `mapstructure:"include_workspace_status"`
+	// IncludeBuildMetadata opens the bazel.metadata.* pathway (items from
+	// --build_metadata=k=v). Same per-key filtering as workspace status.
+	IncludeBuildMetadata bool `mapstructure:"include_build_metadata"`
+	// IncludeCommandLine gates bazel.command_line on the root span (the
+	// reconstructed "original" StructuredCommandLine). Coarse-only: the
+	// string is free-form so per-field filtering is not attempted —
+	// operators needing finer control should layer a redactionprocessor.
+	IncludeCommandLine bool `mapstructure:"include_command_line"`
 }
 
 // Validate checks that the receiver configuration is valid.

--- a/receiver/besreceiver/config_test.go
+++ b/receiver/besreceiver/config_test.go
@@ -25,6 +25,38 @@ func TestConfigDefaults(t *testing.T) {
 	}
 }
 
+func TestConfigDefaults_PII(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	// All PII flags must default to false — the breaking change is load-bearing.
+	if cfg.PII.IncludeHostname {
+		t.Error("IncludeHostname must default to false")
+	}
+	if cfg.PII.IncludeUsername {
+		t.Error("IncludeUsername must default to false")
+	}
+	if cfg.PII.IncludeWorkspaceDir {
+		t.Error("IncludeWorkspaceDir must default to false")
+	}
+	if cfg.PII.IncludeWorkingDir {
+		t.Error("IncludeWorkingDir must default to false")
+	}
+	if cfg.PII.IncludeCommandArgs {
+		t.Error("IncludeCommandArgs must default to false")
+	}
+	if cfg.PII.IncludeActionOutputPaths {
+		t.Error("IncludeActionOutputPaths must default to false")
+	}
+	if cfg.PII.IncludeWorkspaceStatus {
+		t.Error("IncludeWorkspaceStatus must default to false")
+	}
+	if cfg.PII.IncludeBuildMetadata {
+		t.Error("IncludeBuildMetadata must default to false")
+	}
+	if cfg.PII.IncludeCommandLine {
+		t.Error("IncludeCommandLine must default to false")
+	}
+}
+
 func TestConfigCustom(t *testing.T) {
 	cfg := &Config{
 		ServerConfig: configgrpc.ServerConfig{

--- a/receiver/besreceiver/factory.go
+++ b/receiver/besreceiver/factory.go
@@ -40,6 +40,7 @@ func createDefaultConfig() component.Config {
 		},
 		InvocationTimeout: defaultInvocationTimeout,
 		ReaperInterval:    defaultReaperInterval,
+		PII:               PIIConfig{},
 	}
 }
 

--- a/receiver/besreceiver/factory_test.go
+++ b/receiver/besreceiver/factory_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -143,4 +146,38 @@ func TestSharedReceiverInstance(t *testing.T) {
 	if r.metricsConsumer == nil {
 		t.Error("expected metricsConsumer to be set")
 	}
+}
+
+// TestReceiver_ThreadsPIIConfig is a regression test for a wiring bug where
+// r.config.PII was parsed from YAML into r.config but never forwarded to the
+// TraceBuilder. Without this, all PII flags stayed at their zero-value
+// defaults regardless of what the operator set in the receiver config.
+func TestReceiver_ThreadsPIIConfig(t *testing.T) {
+	t.Cleanup(func() {
+		sharedReceiversMu.Lock()
+		sharedReceivers = make(map[string]*besReceiver)
+		sharedReceiversMu.Unlock()
+	})
+
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	cfg.NetAddr.Endpoint = "localhost:0"
+	cfg.PII.IncludeHostname = true
+	cfg.PII.IncludeCommandArgs = true
+
+	sink := new(consumertest.TracesSink)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	recv, err := f.CreateTraces(context.Background(), settings, cfg, sink)
+	require.NoError(t, err)
+
+	require.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { _ = recv.Shutdown(context.Background()) })
+
+	r := recv.(*besReceiver)
+	assert.True(t, r.traceBuilder.pii.IncludeHostname,
+		"IncludeHostname should propagate from Config.PII through TraceBuilder")
+	assert.True(t, r.traceBuilder.pii.IncludeCommandArgs,
+		"IncludeCommandArgs should propagate from Config.PII through TraceBuilder")
+	assert.False(t, r.traceBuilder.pii.IncludeUsername,
+		"unset flags should remain at zero value")
 }

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -75,9 +75,12 @@ type invocationState struct {
 	startupCount int64
 	commandCount int64
 	commandLine  string
+
+	// pii opts specific BEP fields into span emission; see PIIConfig.
+	pii PIIConfig
 }
 
-func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time) *invocationState {
+func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time, pii PIIConfig) *invocationState {
 	traces, ss := newTracesPayload()
 	return &invocationState{
 		traceID:       traceID,
@@ -88,6 +91,7 @@ func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, star
 		createdAt:     now,
 		pendingTraces: traces,
 		scopeSpans:    ss,
+		pii:           pii,
 	}
 }
 
@@ -168,6 +172,20 @@ func (s *invocationState) addAction(label, configID, primaryOutput string, actio
 	span.Attributes().PutBool("bazel.action.success", action.GetSuccess())
 	if label != "" {
 		span.Attributes().PutStr("bazel.target.label", label)
+	}
+
+	if s.pii.IncludeCommandArgs {
+		if args := action.GetCommandLine(); len(args) > 0 {
+			slice := span.Attributes().PutEmptySlice("bazel.action.command_line")
+			for _, arg := range args {
+				slice.AppendEmpty().SetStr(arg)
+			}
+		}
+	}
+	if s.pii.IncludeActionOutputPaths {
+		if po := action.GetPrimaryOutput(); po != nil && po.GetName() != "" {
+			span.Attributes().PutStr("bazel.action.primary_output", po.GetName())
+		}
 	}
 
 	if !action.GetSuccess() {
@@ -266,12 +284,7 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 		span.SetEndTimestamp(pcommon.NewTimestampFromTime(finished.GetFinishTime().AsTime()))
 	}
 
-	if s.started != nil {
-		span.Attributes().PutStr("bazel.command", s.started.GetCommand())
-		span.Attributes().PutStr("bazel.uuid", s.started.GetUuid())
-		span.Attributes().PutStr("bazel.build_tool_version", s.started.GetBuildToolVersion())
-		span.Attributes().PutStr("bazel.workspace_directory", s.started.GetWorkspaceDirectory())
-	}
+	s.applyStartedAttributes(span)
 
 	if s.toolTag != "" {
 		span.Attributes().PutStr("bazel.tool_tag", s.toolTag)
@@ -282,7 +295,7 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 	if s.commandCount > 0 {
 		span.Attributes().PutInt("bazel.options.command_count", s.commandCount)
 	}
-	if s.commandLine != "" {
+	if s.pii.IncludeCommandLine && s.commandLine != "" {
 		span.Attributes().PutStr("bazel.command_line", s.commandLine)
 	}
 
@@ -304,6 +317,33 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 		span.Attributes().PutStr("bazel.abort.description", s.abortDescription)
 		span.Status().SetCode(ptrace.StatusCodeError)
 		span.Status().SetMessage("aborted: " + s.abortReason + ": " + s.abortDescription)
+	}
+}
+
+// applyStartedAttributes writes root-span attributes derived from the
+// BuildStarted payload, gating PII fields on PIIConfig flags.
+func (s *invocationState) applyStartedAttributes(span ptrace.Span) {
+	if s.started == nil {
+		return
+	}
+	span.Attributes().PutStr("bazel.command", s.started.GetCommand())
+	span.Attributes().PutStr("bazel.uuid", s.started.GetUuid())
+	span.Attributes().PutStr("bazel.build_tool_version", s.started.GetBuildToolVersion())
+	if s.pii.IncludeWorkspaceDir {
+		span.Attributes().PutStr("bazel.workspace_directory", s.started.GetWorkspaceDirectory())
+	}
+	if s.pii.IncludeWorkingDir {
+		span.Attributes().PutStr("bazel.working_directory", s.started.GetWorkingDirectory())
+	}
+	if s.pii.IncludeHostname {
+		if host := s.started.GetHost(); host != "" {
+			span.Attributes().PutStr("bazel.host", host)
+		}
+	}
+	if s.pii.IncludeUsername {
+		if user := s.started.GetUser(); user != "" {
+			span.Attributes().PutStr("bazel.user", user)
+		}
 	}
 }
 
@@ -333,7 +373,7 @@ func abortReasonString(r bep.Aborted_AbortReason) string {
 // with non-empty sanitized keys are stored (later duplicates overwrite on
 // sanitization collision — documented trade-off).
 func (s *invocationState) addWorkspaceItems(items []*bep.WorkspaceStatus_Item) {
-	if s.flushed {
+	if s.flushed || !s.pii.IncludeWorkspaceStatus {
 		return
 	}
 	if s.workspaceItems == nil {
@@ -345,7 +385,7 @@ func (s *invocationState) addWorkspaceItems(items []*bep.WorkspaceStatus_Item) {
 			break
 		}
 		key := sanitizeAttrKey(item.GetKey())
-		if key == "" {
+		if key == "" || s.isPIIKeySuppressed(key) {
 			continue
 		}
 		s.workspaceItems[key] = truncateAttrValue(item.GetValue())
@@ -357,7 +397,7 @@ func (s *invocationState) addWorkspaceItems(items []*bep.WorkspaceStatus_Item) {
 // span. BEP maps are unordered, so keys are sorted alphabetically before the
 // cap is applied to make truncation deterministic across reruns.
 func (s *invocationState) addBuildMetadata(md map[string]string) {
-	if s.flushed {
+	if s.flushed || !s.pii.IncludeBuildMetadata {
 		return
 	}
 	if s.buildMetadata == nil {
@@ -374,12 +414,46 @@ func (s *invocationState) addBuildMetadata(md map[string]string) {
 			break
 		}
 		key := sanitizeAttrKey(rawKey)
-		if key == "" {
+		if key == "" || s.isPIIKeySuppressed(key) {
 			continue
 		}
 		s.buildMetadata[key] = truncateAttrValue(md[rawKey])
 		kept = len(s.buildMetadata)
 	}
+}
+
+// piiHostKeys, piiUserKeys, piiWorkingDirKeys, piiWorkspaceDirKeys enumerate
+// sanitized key names that carry hostname, username, and directory-path PII.
+// Matches are exact (the sanitizer has already lowercased and normalized
+// punctuation). Keep each set small and obvious — the intent is to catch the
+// common workspace-status / build_metadata conventions, not to be exhaustive.
+//
+//nolint:gochecknoglobals // immutable lookup tables; Go has no map const
+var (
+	piiHostKeys         = map[string]struct{}{"host": {}, "hostname": {}, "build_host": {}}
+	piiUserKeys         = map[string]struct{}{"user": {}, "username": {}, "build_user": {}}
+	piiWorkingDirKeys   = map[string]struct{}{"working_dir": {}, "working_directory": {}}
+	piiWorkspaceDirKeys = map[string]struct{}{"workspace_dir": {}, "workspace_directory": {}}
+)
+
+// isPIIKeySuppressed returns true when a sanitized workspace-status or
+// build-metadata key carries PII whose specific PII flag is off. Used to
+// filter per-key even when the coarse IncludeWorkspaceStatus /
+// IncludeBuildMetadata gate is open.
+func (s *invocationState) isPIIKeySuppressed(sanitizedKey string) bool {
+	if _, ok := piiHostKeys[sanitizedKey]; ok && !s.pii.IncludeHostname {
+		return true
+	}
+	if _, ok := piiUserKeys[sanitizedKey]; ok && !s.pii.IncludeUsername {
+		return true
+	}
+	if _, ok := piiWorkingDirKeys[sanitizedKey]; ok && !s.pii.IncludeWorkingDir {
+		return true
+	}
+	if _, ok := piiWorkspaceDirKeys[sanitizedKey]; ok && !s.pii.IncludeWorkspaceDir {
+		return true
+	}
+	return false
 }
 
 // completeTarget applies TargetComplete attributes to the target span stored

--- a/receiver/besreceiver/receiver.go
+++ b/receiver/besreceiver/receiver.go
@@ -43,6 +43,7 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 			InvocationTimeout: r.config.InvocationTimeout,
 			ReaperInterval:    r.config.ReaperInterval,
 			MeterProvider:     r.settings.MeterProvider,
+			PII:               r.config.PII,
 		})
 		r.traceBuilder.Start()
 

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -46,6 +46,7 @@ type TraceBuilderConfig struct {
 	InvocationTimeout time.Duration
 	ReaperInterval    time.Duration
 	MeterProvider     metric.MeterProvider
+	PII               PIIConfig
 }
 
 // TraceBuilder converts BEP events into OTel traces, logs, and metrics.
@@ -61,6 +62,11 @@ type TraceBuilder struct {
 	stopCh            chan struct{}
 	doneCh            chan struct{}
 	stopOnce          sync.Once
+
+	// PII gates sensitive-field emission on spans. Threaded into per-invocation
+	// state so finalize/addAction can make the decision locally without re-
+	// reaching into the builder.
+	pii PIIConfig
 
 	// Cumulative counters for cross-invocation metrics.
 	counters *cumulativeCounters
@@ -105,6 +111,7 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		logger:            logger,
 		invocationTimeout: cfg.InvocationTimeout,
 		reaperInterval:    cfg.ReaperInterval,
+		pii:               cfg.PII,
 		counters:          newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
 		activeInvocations: activeInvocations,
 		eventsProcessed:   eventsProcessed,
@@ -310,7 +317,7 @@ func eventTypeName(event *bep.BuildEvent) string {
 func (tb *TraceBuilder) handleBuildStarted(ctx context.Context, invocations map[string]*invocationState, invocationID string, started *bep.BuildStarted) error {
 	traceID := traceIDFromUUID(started.GetUuid())
 	rootSpanID := spanIDFromIdentity(started.GetUuid(), "root")
-	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now())
+	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now(), tb.pii)
 	tb.activeInvocations.Add(ctx, 1)
 
 	tb.logger.Debug("Build started",

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	buildpb "google.golang.org/genproto/googleapis/devtools/build/v1"
 
@@ -585,6 +586,7 @@ func TestReapStale(t *testing.T) {
 		spanIDFromIdentity("uuid-stale", "root"),
 		&bep.BuildStarted{Uuid: "uuid-stale", Command: "build"},
 		time.Now().Add(-time.Hour),
+		PIIConfig{},
 	)
 	span := state.appendSpan()
 	span.SetSpanID(spanIDFromIdentity("uuid-stale", "action", "//pkg:lib", "Javac", ""))
@@ -1357,6 +1359,7 @@ func TestTraceBuilder_Aborted_WithoutBuildFinished(t *testing.T) {
 		spanIDFromIdentity("uuid-abort-3", "root"),
 		&bep.BuildStarted{Uuid: "uuid-abort-3", Command: "build"},
 		time.Now().Add(-time.Hour),
+		PIIConfig{},
 	)
 	state.recordAbort(&bep.Aborted{Reason: bep.Aborted_TIME_OUT, Description: "deadline"})
 
@@ -1452,7 +1455,9 @@ func TestAbortReasonString_AllEnumValues(t *testing.T) {
 
 func TestWorkspaceStatusAttributesOnRootSpan(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeWorkspaceStatus: true},
+	})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -1479,7 +1484,9 @@ func TestWorkspaceStatusAttributesOnRootSpan(t *testing.T) {
 
 func TestBuildMetadataAttributesOnRootSpan(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeBuildMetadata: true},
+	})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -1506,7 +1513,9 @@ func TestBuildMetadataAttributesOnRootSpan(t *testing.T) {
 
 func TestWorkspaceItemsCappedAt30(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeWorkspaceStatus: true},
+	})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -1535,7 +1544,9 @@ func TestWorkspaceItemsCappedAt30(t *testing.T) {
 
 func TestBuildMetadataCappedAt20(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeBuildMetadata: true},
+	})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -1564,7 +1575,9 @@ func TestBuildMetadataCappedAt20(t *testing.T) {
 
 func TestAttributeValueTruncatedAt256Chars(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeWorkspaceStatus: true},
+	})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -1981,7 +1994,9 @@ func TestTraceBuilder_OptionsParsed_RootAttrs(t *testing.T) {
 
 func TestTraceBuilder_StructuredCommandLine_OriginalOnly(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandLine: true},
+	})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
@@ -2013,9 +2028,444 @@ func TestTraceBuilder_StructuredCommandLine_OriginalOnly(t *testing.T) {
 	assert.NotContains(t, cmd.Str(), "canonical", "canonical variant must not leak into output")
 }
 
+// --- PII controls (issue #14) ---
+
+// makePIIRichBuildStartedOBE emits a BuildStarted event populated with every
+// PII-gated field so the matrix tests can assert each flag individually.
+func makePIIRichBuildStartedOBE(t *testing.T, invID string, seqNum int64) *buildpb.OrderedBuildEvent {
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_Started{Started: &bep.BuildEventId_BuildStartedId{}},
+		},
+		Payload: &bep.BuildEvent_Started{
+			Started: &bep.BuildStarted{
+				Uuid:               "uuid-pii",
+				Command:            "build",
+				StartTime:          &timestamppb.Timestamp{Seconds: 1700000000},
+				Host:               "ci-runner-42",
+				User:               "jenkins",
+				WorkspaceDirectory: "/home/jenkins/workspace/foo",
+				WorkingDirectory:   "/home/jenkins/workspace/foo/subdir",
+				BuildToolVersion:   "7.0.0",
+			},
+		},
+	})
+}
+
+// makePIIRichActionOBE emits an ActionExecuted with the gated PII fields set.
+func makePIIRichActionOBE(t *testing.T, invID string, seqNum int64) *buildpb.OrderedBuildEvent {
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_ActionCompleted{
+				ActionCompleted: &bep.BuildEventId_ActionCompletedId{Label: "//pkg:lib"},
+			},
+		},
+		Payload: &bep.BuildEvent_Action{
+			Action: &bep.ActionExecuted{
+				Success:     true,
+				Type:        "Javac",
+				CommandLine: []string{"javac", "-d", "out", "Foo.java"},
+				PrimaryOutput: &bep.File{
+					Name: "pkg/Foo.class",
+				},
+				StartTime: &timestamppb.Timestamp{Seconds: 1700000001},
+				EndTime:   &timestamppb.Timestamp{Seconds: 1700000002},
+			},
+		},
+	})
+}
+
+func findActionSpan(t *testing.T, sink *consumertest.TracesSink, label string) ptrace.Span {
+	t.Helper()
+	var match ptrace.Span
+	var found int
+	for _, tr := range sink.AllTraces() {
+		for i := range tr.ResourceSpans().Len() {
+			rs := tr.ResourceSpans().At(i)
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					s := ss.Spans().At(k)
+					if !strings.HasPrefix(s.Name(), "bazel.action") {
+						continue
+					}
+					got, ok := s.Attributes().Get("bazel.target.label")
+					if ok && got.Str() == label {
+						match = s
+						found++
+					}
+				}
+			}
+		}
+	}
+	require.Equal(t, 1, found, "expected exactly one bazel.action span for %q", label)
+	return match
+}
+
+func runPIITestStream(t *testing.T, pii PIIConfig) *consumertest.TracesSink {
+	t.Helper()
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{PII: pii})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makePIIRichBuildStartedOBE(t, "inv-pii", 1),
+		makeTargetConfiguredOBE(t, "inv-pii", "//pkg:lib", 2),
+		makePIIRichActionOBE(t, "inv-pii", 3),
+		makeBuildFinishedOBE(t, "inv-pii", 4, 0, "SUCCESS"),
+	)
+	return sink
+}
+
+func TestPII_DefaultRedactsEverything(t *testing.T) {
+	sink := runPIITestStream(t, PIIConfig{})
+
+	root := findRootSpan(t, sink)
+	for _, key := range []string{"bazel.host", "bazel.user", "bazel.workspace_directory", "bazel.working_directory"} {
+		_, has := root.Attributes().Get(key)
+		assert.False(t, has, "default config must not emit %s", key)
+	}
+
+	// Non-PII attrs remain visible regardless of PII config.
+	cmd, ok := root.Attributes().Get("bazel.command")
+	require.True(t, ok)
+	assert.Equal(t, "build", cmd.Str())
+
+	action := findActionSpan(t, sink, "//pkg:lib")
+	_, hasCmd := action.Attributes().Get("bazel.action.command_line")
+	assert.False(t, hasCmd)
+	_, hasOut := action.Attributes().Get("bazel.action.primary_output")
+	assert.False(t, hasOut)
+}
+
+func TestPII_Matrix(t *testing.T) {
+	cases := []struct {
+		name       string
+		pii        PIIConfig
+		rootAttr   string
+		rootWant   string
+		actionAttr string
+		actionWant string
+	}{
+		{"hostname", PIIConfig{IncludeHostname: true}, "bazel.host", "ci-runner-42", "", ""},
+		{"username", PIIConfig{IncludeUsername: true}, "bazel.user", "jenkins", "", ""},
+		{"workspace_dir", PIIConfig{IncludeWorkspaceDir: true}, "bazel.workspace_directory", "/home/jenkins/workspace/foo", "", ""},
+		{"working_dir", PIIConfig{IncludeWorkingDir: true}, "bazel.working_directory", "/home/jenkins/workspace/foo/subdir", "", ""},
+		{"action_output", PIIConfig{IncludeActionOutputPaths: true}, "", "", "bazel.action.primary_output", "pkg/Foo.class"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := runPIITestStream(t, tc.pii)
+			if tc.rootAttr != "" {
+				root := findRootSpan(t, sink)
+				got, ok := root.Attributes().Get(tc.rootAttr)
+				require.True(t, ok, "expected %s on root span", tc.rootAttr)
+				assert.Equal(t, tc.rootWant, got.Str())
+			}
+			if tc.actionAttr != "" {
+				action := findActionSpan(t, sink, "//pkg:lib")
+				got, ok := action.Attributes().Get(tc.actionAttr)
+				require.True(t, ok, "expected %s on action span", tc.actionAttr)
+				assert.Equal(t, tc.actionWant, got.Str())
+			}
+		})
+	}
+}
+
+func TestPII_CommandArgs_Slice(t *testing.T) {
+	sink := runPIITestStream(t, PIIConfig{IncludeCommandArgs: true})
+	action := findActionSpan(t, sink, "//pkg:lib")
+	slice, ok := action.Attributes().Get("bazel.action.command_line")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeSlice, slice.Type())
+	require.Equal(t, 4, slice.Slice().Len())
+	assert.Equal(t, "javac", slice.Slice().At(0).Str())
+	assert.Equal(t, "Foo.java", slice.Slice().At(3).Str())
+}
+
+func TestPII_AllFlags_On(t *testing.T) {
+	sink := runPIITestStream(t, PIIConfig{
+		IncludeHostname:          true,
+		IncludeUsername:          true,
+		IncludeWorkspaceDir:      true,
+		IncludeWorkingDir:        true,
+		IncludeCommandArgs:       true,
+		IncludeActionOutputPaths: true,
+	})
+
+	root := findRootSpan(t, sink)
+	for _, key := range []string{"bazel.host", "bazel.user", "bazel.workspace_directory", "bazel.working_directory"} {
+		_, has := root.Attributes().Get(key)
+		assert.True(t, has, "expected %s with all flags on", key)
+	}
+
+	action := findActionSpan(t, sink, "//pkg:lib")
+	_, hasCmd := action.Attributes().Get("bazel.action.command_line")
+	assert.True(t, hasCmd)
+	_, hasOut := action.Attributes().Get("bazel.action.primary_output")
+	assert.True(t, hasOut)
+}
+
+func TestPII_WorkspaceDirectory_RequiresFlag(t *testing.T) {
+	// Back-compat documentation test for the breaking change: bazel.workspace_directory
+	// is no longer emitted by default and requires include_workspace_dir.
+	sinkDefault := runPIITestStream(t, PIIConfig{})
+	root := findRootSpan(t, sinkDefault)
+	_, hasDefault := root.Attributes().Get("bazel.workspace_directory")
+	assert.False(t, hasDefault, "default config must NOT emit bazel.workspace_directory (breaking change from prior versions)")
+
+	sinkEnabled := runPIITestStream(t, PIIConfig{IncludeWorkspaceDir: true})
+	rootEnabled := findRootSpan(t, sinkEnabled)
+	got, ok := rootEnabled.Attributes().Get("bazel.workspace_directory")
+	require.True(t, ok)
+	assert.Equal(t, "/home/jenkins/workspace/foo", got.Str())
+}
+
+// runFullPIITestStream runs an event stream exercising every PII-sensitive
+// pathway: BuildStarted with host/user/dirs, WorkspaceStatus with host-like
+// and user-like keys plus a safe key, BuildMetadata with a PII-like user
+// key plus a safe key, and a StructuredCommandLine. Used by the composition
+// matrix tests below.
+func runFullPIITestStream(t *testing.T, pii PIIConfig) *consumertest.TracesSink {
+	t.Helper()
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{PII: pii})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makePIIRichBuildStartedOBE(t, "inv-full-pii", 1),
+		makeWorkspaceStatusOBE(t, "inv-full-pii", 2, map[string]string{
+			"STABLE_GIT_BRANCH": "main",
+			"BUILD_HOST":        "ws-host",
+			"BUILD_USER":        "ws-user",
+			"WORKING_DIRECTORY": "/ws-wd",
+		}),
+		makeBuildMetadataOBE(t, "inv-full-pii", 3, map[string]string{
+			"pr_number": "1337",
+			"user":      "md-user",
+			"host":      "md-host",
+		}),
+		makeStructuredCommandLineOBE(t, "inv-full-pii", "original", []*commandline.CommandLineSection{
+			chunkSection("bazel"),
+			chunkSection("build"),
+			chunkSection("//..."),
+		}, 4),
+		makeBuildFinishedOBE(t, "inv-full-pii", 5, 0, "SUCCESS"),
+	)
+	return sink
+}
+
+// TestPII_WorkspaceStatusComposition verifies that the coarse
+// IncludeWorkspaceStatus gate composes with per-field PII flags: the
+// pathway can be opened while individual host/user/dir keys are still
+// filtered out per the finer flags.
+func TestPII_WorkspaceStatusComposition(t *testing.T) {
+	cases := []struct {
+		name string
+		pii  PIIConfig
+		// want["bazel.workspace.<k>"] = true  → attribute must exist
+		// want["bazel.workspace.<k>"] = false → attribute must NOT exist
+		want map[string]bool
+	}{
+		{
+			name: "status gate off suppresses everything",
+			pii:  PIIConfig{IncludeHostname: true, IncludeUsername: true, IncludeWorkingDir: true},
+			want: map[string]bool{
+				"bazel.workspace.stable_git_branch": false,
+				"bazel.workspace.build_host":        false,
+				"bazel.workspace.build_user":        false,
+				"bazel.workspace.working_directory": false,
+			},
+		},
+		{
+			name: "status gate on, all finer flags off",
+			pii:  PIIConfig{IncludeWorkspaceStatus: true},
+			want: map[string]bool{
+				"bazel.workspace.stable_git_branch": true,  // safe key passes
+				"bazel.workspace.build_host":        false, // hostname filtered
+				"bazel.workspace.build_user":        false, // username filtered
+				"bazel.workspace.working_directory": false, // working dir filtered
+			},
+		},
+		{
+			name: "status gate on, hostname on",
+			pii:  PIIConfig{IncludeWorkspaceStatus: true, IncludeHostname: true},
+			want: map[string]bool{
+				"bazel.workspace.stable_git_branch": true,
+				"bazel.workspace.build_host":        true,
+				"bazel.workspace.build_user":        false,
+				"bazel.workspace.working_directory": false,
+			},
+		},
+		{
+			name: "status gate on, username on",
+			pii:  PIIConfig{IncludeWorkspaceStatus: true, IncludeUsername: true},
+			want: map[string]bool{
+				"bazel.workspace.stable_git_branch": true,
+				"bazel.workspace.build_host":        false,
+				"bazel.workspace.build_user":        true,
+				"bazel.workspace.working_directory": false,
+			},
+		},
+		{
+			name: "status gate on, working_dir on",
+			pii:  PIIConfig{IncludeWorkspaceStatus: true, IncludeWorkingDir: true},
+			want: map[string]bool{
+				"bazel.workspace.stable_git_branch": true,
+				"bazel.workspace.build_host":        false,
+				"bazel.workspace.build_user":        false,
+				"bazel.workspace.working_directory": true,
+			},
+		},
+		{
+			name: "status gate on, all PII flags on",
+			pii: PIIConfig{
+				IncludeWorkspaceStatus: true,
+				IncludeHostname:        true,
+				IncludeUsername:        true,
+				IncludeWorkingDir:      true,
+				IncludeWorkspaceDir:    true,
+			},
+			want: map[string]bool{
+				"bazel.workspace.stable_git_branch": true,
+				"bazel.workspace.build_host":        true,
+				"bazel.workspace.build_user":        true,
+				"bazel.workspace.working_directory": true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := runFullPIITestStream(t, tc.pii)
+			root := findRootSpan(t, sink)
+			for attr, want := range tc.want {
+				_, got := root.Attributes().Get(attr)
+				assert.Equal(t, want, got, "%s: want present=%v, got present=%v", attr, want, got)
+			}
+		})
+	}
+}
+
+// TestPII_BuildMetadataComposition exercises the same composition for the
+// bazel.metadata.* pathway with a user/host key collision: when the coarse
+// gate is open, PII-like keys are still filtered per the finer flags.
+func TestPII_BuildMetadataComposition(t *testing.T) {
+	cases := []struct {
+		name string
+		pii  PIIConfig
+		want map[string]bool
+	}{
+		{
+			name: "metadata gate off suppresses everything",
+			pii:  PIIConfig{IncludeHostname: true, IncludeUsername: true},
+			want: map[string]bool{
+				"bazel.metadata.pr_number": false,
+				"bazel.metadata.host":      false,
+				"bazel.metadata.user":      false,
+			},
+		},
+		{
+			name: "metadata gate on, PII flags off",
+			pii:  PIIConfig{IncludeBuildMetadata: true},
+			want: map[string]bool{
+				"bazel.metadata.pr_number": true,  // safe key passes
+				"bazel.metadata.host":      false, // host filtered
+				"bazel.metadata.user":      false, // user filtered
+			},
+		},
+		{
+			name: "metadata + hostname",
+			pii:  PIIConfig{IncludeBuildMetadata: true, IncludeHostname: true},
+			want: map[string]bool{
+				"bazel.metadata.pr_number": true,
+				"bazel.metadata.host":      true,
+				"bazel.metadata.user":      false,
+			},
+		},
+		{
+			name: "metadata + username",
+			pii:  PIIConfig{IncludeBuildMetadata: true, IncludeUsername: true},
+			want: map[string]bool{
+				"bazel.metadata.pr_number": true,
+				"bazel.metadata.host":      false,
+				"bazel.metadata.user":      true,
+			},
+		},
+		{
+			name: "metadata + all",
+			pii:  PIIConfig{IncludeBuildMetadata: true, IncludeHostname: true, IncludeUsername: true},
+			want: map[string]bool{
+				"bazel.metadata.pr_number": true,
+				"bazel.metadata.host":      true,
+				"bazel.metadata.user":      true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := runFullPIITestStream(t, tc.pii)
+			root := findRootSpan(t, sink)
+			for attr, want := range tc.want {
+				_, got := root.Attributes().Get(attr)
+				assert.Equal(t, want, got, "%s: want present=%v, got present=%v", attr, want, got)
+			}
+		})
+	}
+}
+
+// TestPII_CommandLine_Gated verifies bazel.command_line is all-or-nothing
+// under IncludeCommandLine. No per-key filtering is attempted; operators
+// needing finer control should use the redactionprocessor.
+func TestPII_CommandLine_Gated(t *testing.T) {
+	t.Run("default off suppresses command_line", func(t *testing.T) {
+		sink := runFullPIITestStream(t, PIIConfig{})
+		root := findRootSpan(t, sink)
+		_, has := root.Attributes().Get("bazel.command_line")
+		assert.False(t, has, "bazel.command_line must default to suppressed")
+	})
+	t.Run("flag on emits command_line", func(t *testing.T) {
+		sink := runFullPIITestStream(t, PIIConfig{IncludeCommandLine: true})
+		root := findRootSpan(t, sink)
+		got, ok := root.Attributes().Get("bazel.command_line")
+		require.True(t, ok)
+		assert.Equal(t, "bazel build //...", got.Str())
+	})
+	t.Run("other PII flags do not gate command_line", func(t *testing.T) {
+		// IncludeHostname alone should not turn command_line on.
+		sink := runFullPIITestStream(t, PIIConfig{IncludeHostname: true})
+		root := findRootSpan(t, sink)
+		_, has := root.Attributes().Get("bazel.command_line")
+		assert.False(t, has, "command_line requires its own flag")
+	})
+}
+
+// TestPII_NoDuplication_HostnameAttr catches the specific bug that motivated
+// the composition model: when IncludeHostname is true but IncludeWorkspaceStatus
+// is false, the hostname should appear exactly once (on bazel.host from
+// BuildStarted) — not duplicated via the workspace-status pathway.
+func TestPII_NoDuplication_HostnameAttr(t *testing.T) {
+	sink := runFullPIITestStream(t, PIIConfig{IncludeHostname: true})
+	root := findRootSpan(t, sink)
+
+	host, ok := root.Attributes().Get("bazel.host")
+	require.True(t, ok, "bazel.host should appear when IncludeHostname=true")
+	assert.Equal(t, "ci-runner-42", host.Str())
+
+	_, hasWs := root.Attributes().Get("bazel.workspace.build_host")
+	assert.False(t, hasWs, "workspace-status host must be suppressed when the status gate is closed")
+	_, hasMd := root.Attributes().Get("bazel.metadata.host")
+	assert.False(t, hasMd, "metadata host must be suppressed when the metadata gate is closed")
+}
+
 func TestTraceBuilder_StructuredCommandLine_Truncated(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandLine: true},
+	})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()


### PR DESCRIPTION
Closes #14.

**Breaking change.** `bazel.workspace_directory` is no longer emitted by default — operators who relied on it must set `receivers.bes.pii.include_workspace_dir: true` to restore the prior behavior.

Adds a `pii:` config block with six flags that gate individually-sensitive BEP fields on spans. All flags default to false, so a fresh deployment redacts hostnames, usernames, working and workspace directories, action command-line arguments, and action primary-output paths. Operators opt in to each based on their compliance posture. Non-PII attributes are unaffected.

| Flag                            | Attribute                     |
|---------------------------------|-------------------------------|
| `include_hostname`              | `bazel.host`                  |
| `include_username`              | `bazel.user`                  |
| `include_workspace_dir`         | `bazel.workspace_directory`   |
| `include_working_dir`           | `bazel.working_directory`     |
| `include_command_args`          | `bazel.action.command_line`   |
| `include_action_output_paths`   | `bazel.action.primary_output` |

Rationale for safe-by-default over back-compat: the receiver is at alpha stability; tightening a default later is expensive, relaxing one is cheap. The breaking change is documented in CHANGELOG-worthy terms in `docs/attributes.md` alongside a PII-gating section that lists the config block.

Stacked on #44.