### PR TITLE
docs: replace Mermaid diagrams with SVG architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 An OpenTelemetry Collector custom receiver designed to receive [Bazel Build Event Protocol (BEP)](https://bazel.build/remote/bep) streams via the BES gRPC API and converts them into the OpenTelemetry trace model. Bazel builds become trace flamegraphs in Datadog, Tempo, Jaeger, or any OTLP backend.
 
+![End-to-end pipeline: Bazel CLI → besreceiver (inside OTel Collector) → batch processor + OTLP exporter → Datadog / Tempo / Jaeger](docs/architecture-pipeline.svg)
+
 ## Quick start
 
 ### Build the custom collector
@@ -68,7 +70,7 @@ make fuzz       # Run fuzz tests
 
 ## Documentation
 
-- [Architecture](docs/architecture.md) -- system overview and Mermaid diagrams
+- [Architecture](docs/architecture.md) -- system overview, internal components, and span hierarchy
 - [Sequence diagrams](docs/sequence.md) -- BEP stream processing flow
 
 ## License

--- a/docs/architecture-components.svg
+++ b/docs/architecture-components.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1300" height="430" viewBox="0 0 1300 430">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .fill-grpc     { fill: #ede9fe; stroke: #7c3aed; }
+    .fill-recv     { fill: #d1fae5; stroke: #059669; }
+    .fill-owner    { fill: #fef9c3; stroke: #ca8a04; }
+    .fill-invoc    { fill: #fff7ed; stroke: #ea580c; }
+    .fill-metrics  { fill: #fce7f3; stroke: #db2777; }
+    .fill-consumer { fill: #e0f2fe; stroke: #0284c7; }
+    .label-main  { font-size: 13px; font-weight: 600; fill: #1a1a2e; }
+    .label-sub   { font-size: 11px; fill: #475569; }
+    .label-mono  { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-dim   { font-size: 10px; fill: #94a3b8; }
+  </style>
+  <defs>
+    <marker id="ah2" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <polygon points="0 0, 7 2.5, 0 5" fill="#94a3b8"/>
+    </marker>
+    <marker id="ah2-teal" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <polygon points="0 0, 7 2.5, 0 5" fill="#059669"/>
+    </marker>
+    <marker id="ah2-yellow" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <polygon points="0 0, 7 2.5, 0 5" fill="#ca8a04"/>
+    </marker>
+    <marker id="ah2-blue" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <polygon points="0 0, 7 2.5, 0 5" fill="#0284c7"/>
+    </marker>
+    <marker id="ah2-pink" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <polygon points="0 0, 7 2.5, 0 5" fill="#db2777"/>
+    </marker>
+  </defs>
+
+  <rect width="100%" height="100%" fill="#ffffff"/>
+
+  <text x="125" y="18" text-anchor="middle" class="label-dim" font-weight="700">CONCURRENT gRPC GOROUTINES</text>
+  <text x="574" y="18" text-anchor="middle" class="label-dim" font-weight="700">OWNER GOROUTINE (single-threaded)</text>
+  <text x="1162" y="18" text-anchor="middle" class="label-dim" font-weight="700">SIGNAL CONSUMERS</text>
+
+  <line x1="325" y1="25" x2="325" y2="420" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="4 3"/>
+  <line x1="942" y1="25" x2="942" y2="420" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="4 3"/>
+
+  <rect x="20" y="32" width="210" height="60" rx="8" class="fill-recv"/>
+  <text x="125" y="54" text-anchor="middle" class="label-main">receiver.go</text>
+  <text x="125" y="71" text-anchor="middle" class="label-mono">PublishBuildToolEventStream()</text>
+  <text x="125" y="84" text-anchor="middle" class="label-sub">Start · Shutdown · refCount</text>
+
+  <rect x="30" y="115" width="190" height="78" rx="8" fill="#f0fdf4" stroke="#86efac" stroke-width="1.5"/>
+  <text x="125" y="137" text-anchor="middle" class="label-sub" font-weight="600">goroutine A  (stream)</text>
+  <text x="125" y="153" text-anchor="middle" class="label-mono">recv OrderedBuildEvent</text>
+  <text x="125" y="169" text-anchor="middle" class="label-mono">→ ParseBazelEvent()</text>
+  <text x="125" y="183" text-anchor="middle" class="label-mono">→ send to eventCh</text>
+
+  <rect x="30" y="200" width="190" height="78" rx="8" fill="#f0fdf4" stroke="#86efac" stroke-width="1.5"/>
+  <text x="125" y="222" text-anchor="middle" class="label-sub" font-weight="600">goroutine B  (stream)</text>
+  <text x="125" y="238" text-anchor="middle" class="label-mono">recv OrderedBuildEvent</text>
+  <text x="125" y="254" text-anchor="middle" class="label-mono">→ ParseBazelEvent()</text>
+  <text x="125" y="268" text-anchor="middle" class="label-mono">→ send to eventCh</text>
+
+  <rect x="30" y="285" width="190" height="45" rx="8" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="125" y="311" text-anchor="middle" class="label-dim">goroutine N  · · ·</text>
+
+  <rect x="30" y="350" width="190" height="70" rx="8" class="fill-grpc"/>
+  <text x="125" y="378" text-anchor="middle" class="label-main">bepparser.go</text>
+  <text x="125" y="395" text-anchor="middle" class="label-mono">anypb.Any → bep.BuildEvent</text>
+  <text x="125" y="410" text-anchor="middle" class="label-sub">called per gRPC goroutine</text>
+
+  <rect x="340" y="32" width="468" height="380" rx="10" fill="#fefce8" stroke="#fbbf24" stroke-width="2"/>
+  <text x="574" y="52" text-anchor="middle" class="label-main" font-size="14">tracebuilder.go  —  owner goroutine</text>
+
+  <rect x="352" y="65" width="444" height="40" rx="6" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="574" y="82" text-anchor="middle" class="label-mono">eventCh  chan eventMsg  (buffered 64)</text>
+  <text x="574" y="94" text-anchor="middle" class="label-dim">one writer per gRPC goroutine · one reader: owner</text>
+
+  <rect x="352" y="112" width="200" height="72" rx="8" class="fill-owner"/>
+  <text x="452" y="134" text-anchor="middle" class="label-main">processEvent()</text>
+  <text x="452" y="151" text-anchor="middle" class="label-mono">switch event type {</text>
+  <text x="452" y="165" text-anchor="middle" class="label-mono">BuildStarted | Action |</text>
+  <text x="452" y="177" text-anchor="middle" class="label-mono">TestResult | Finished …</text>
+
+  <rect x="352" y="202" width="200" height="60" rx="8" class="fill-invoc"/>
+  <text x="452" y="224" text-anchor="middle" class="label-main">invocations map</text>
+  <text x="452" y="241" text-anchor="middle" class="label-mono">invocationID → *state</text>
+  <text x="452" y="256" text-anchor="middle" class="label-sub">keyed by Bazel UUID</text>
+
+  <rect x="352" y="278" width="200" height="120" rx="8" fill="#fff7ed" stroke="#fb923c" stroke-width="1.5"/>
+  <text x="452" y="298" text-anchor="middle" class="label-main">invocationState</text>
+  <text x="452" y="315" text-anchor="middle" class="label-mono">traceID  rootSpanID</text>
+  <text x="452" y="330" text-anchor="middle" class="label-mono">targets map[label]Span</text>
+  <text x="452" y="345" text-anchor="middle" class="label-mono">pendingTraces ptrace.Traces</text>
+  <text x="452" y="360" text-anchor="middle" class="label-mono">orphanedSpans map</text>
+  <text x="452" y="375" text-anchor="middle" class="label-mono">pii PIIConfig</text>
+  <text x="452" y="390" text-anchor="middle" class="label-dim">finalize() → ptrace.Traces</text>
+
+  <rect x="570" y="112" width="220" height="56" rx="8" class="fill-metrics"/>
+  <text x="680" y="132" text-anchor="middle" class="label-main">reaper ticker</text>
+  <text x="680" y="149" text-anchor="middle" class="label-mono">every reaper_interval (5m)</text>
+  <text x="680" y="162" text-anchor="middle" class="label-mono">flush stale &gt; invocation_timeout</text>
+
+  <rect x="570" y="185" width="220" height="72" rx="8" class="fill-metrics"/>
+  <text x="680" y="206" text-anchor="middle" class="label-main">metricsbuilder.go</text>
+  <text x="680" y="223" text-anchor="middle" class="label-mono">buildInvocationGauges()</text>
+  <text x="680" y="239" text-anchor="middle" class="label-sub">wall_time · cpu_time · actions</text>
+  <text x="680" y="252" text-anchor="middle" class="label-sub">heap · cumulative counters</text>
+
+  <rect x="570" y="275" width="220" height="56" rx="8" fill="#fdf2f8" stroke="#f0abfc" stroke-width="1.5"/>
+  <text x="680" y="295" text-anchor="middle" class="label-main">cumulativeCounters</text>
+  <text x="680" y="312" text-anchor="middle" class="label-mono">totalWallTimeMs</text>
+  <text x="680" y="325" text-anchor="middle" class="label-mono">totalActionsExecuted …</text>
+
+  <rect x="570" y="348" width="220" height="58" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="680" y="368" text-anchor="middle" class="label-main">config.go  /  PIIConfig</text>
+  <text x="680" y="383" text-anchor="middle" class="label-mono">hostname · username · cmd_line</text>
+  <text x="680" y="396" text-anchor="middle" class="label-sub">all opt-in (default: off)</text>
+
+  <line x1="452" y1="184" x2="452" y2="202" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#ah2-yellow)"/>
+  <line x1="452" y1="262" x2="452" y2="278" stroke="#ea580c" stroke-width="1.5" marker-end="url(#ah2)"/>
+  <line x1="680" y1="257" x2="680" y2="275" stroke="#db2777" stroke-width="1.5" marker-end="url(#ah2-pink)"/>
+
+  <rect x="962" y="70" width="200" height="56" rx="8" class="fill-consumer"/>
+  <text x="1062" y="93" text-anchor="middle" class="label-main">tracesConsumer</text>
+  <text x="1062" y="110" text-anchor="middle" class="label-mono">consumer.Traces</text>
+  <text x="1062" y="120" text-anchor="middle" class="label-dim">(required)</text>
+
+  <rect x="962" y="145" width="200" height="56" rx="8" class="fill-consumer"/>
+  <text x="1062" y="168" text-anchor="middle" class="label-main">logsConsumer</text>
+  <text x="1062" y="185" text-anchor="middle" class="label-mono">consumer.Logs</text>
+  <text x="1062" y="195" text-anchor="middle" class="label-dim">(optional)</text>
+
+  <rect x="962" y="220" width="200" height="56" rx="8" class="fill-consumer"/>
+  <text x="1062" y="243" text-anchor="middle" class="label-main">metricsConsumer</text>
+  <text x="1062" y="260" text-anchor="middle" class="label-mono">consumer.Metrics</text>
+  <text x="1062" y="270" text-anchor="middle" class="label-dim">(optional)</text>
+
+  <rect x="962" y="305" width="200" height="76" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="1062" y="325" text-anchor="middle" class="label-sub" font-weight="700">Shared receiver</text>
+  <text x="1062" y="342" text-anchor="middle" class="label-mono">one gRPC server</text>
+  <text x="1062" y="357" text-anchor="middle" class="label-mono">per endpoint</text>
+  <text x="1062" y="371" text-anchor="middle" class="label-dim">factory.go sharedReceivers</text>
+
+  <path d="M220,154 H280 V81 H352" stroke="#059669" stroke-width="1.5" fill="none" marker-end="url(#ah2-teal)"/>
+  <path d="M220,239 H280 V81 H352" stroke="#059669" stroke-width="1.5" fill="none" marker-end="url(#ah2-teal)"/>
+
+  <path d="M352,100 H302 V262 H220" stroke="#94a3b8" stroke-width="1.2" stroke-dasharray="4 2" fill="none" marker-end="url(#ah2)"/>
+  <text x="261" y="276" text-anchor="middle" class="label-dim" font-size="10" fill="#94a3b8">error channel</text>
+
+  <path d="M808,128 H885 V98 H962" stroke="#0284c7" stroke-width="1.5" fill="none" marker-end="url(#ah2-blue)"/>
+  <text x="885" y="87" text-anchor="middle" class="label-dim" font-size="10" fill="#0284c7">ConsumeTraces()</text>
+
+  <path d="M808,173 H962" stroke="#0284c7" stroke-width="1.5" fill="none" marker-end="url(#ah2-blue)"/>
+  <text x="885" y="162" text-anchor="middle" class="label-dim" font-size="10" fill="#0284c7">ConsumeLogs()</text>
+
+  <path d="M808,221 H885 V248 H962" stroke="#db2777" stroke-width="1.5" fill="none" marker-end="url(#ah2-pink)"/>
+  <text x="885" y="210" text-anchor="middle" class="label-dim" font-size="10" fill="#db2777">ConsumeMetrics()</text>
+</svg>

--- a/docs/architecture-pipeline.svg
+++ b/docs/architecture-pipeline.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="160" viewBox="0 0 1200 160">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .fill-bazel    { fill: #dbeafe; stroke: #3b82f6; }
+    .fill-recv     { fill: #d1fae5; stroke: #059669; }
+    .fill-consumer { fill: #e0f2fe; stroke: #0284c7; }
+    .fill-backend  { fill: #f1f5f9; stroke: #64748b; }
+    .label-main  { font-size: 13px; font-weight: 600; fill: #1a1a2e; }
+    .label-sub   { font-size: 11px; fill: #475569; }
+    .label-mono  { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-arrow { font-size: 11px; fill: #64748b; }
+    .label-dim   { font-size: 10px; fill: #94a3b8; }
+    .arrow { stroke: #94a3b8; stroke-width: 1.5; fill: none; }
+    .arrow-blue   { stroke: #3b82f6; }
+    .arrow-green  { stroke: #059669; }
+    .arrow-orange { stroke: #ea580c; }
+    .arrow-dashed { stroke-dasharray: 5 3; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#3b82f6"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#059669"/>
+    </marker>
+    <marker id="arrowhead-orange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#ea580c"/>
+    </marker>
+  </defs>
+
+  <rect width="100%" height="100%" fill="#ffffff"/>
+
+  <rect x="10" y="40" width="160" height="80" rx="10" class="fill-bazel"/>
+  <text x="90" y="72" text-anchor="middle" class="label-main">Bazel CLI</text>
+  <text x="90" y="90" text-anchor="middle" class="label-mono">--bes_backend=</text>
+  <text x="90" y="104" text-anchor="middle" class="label-mono">grpc://host:8082</text>
+
+  <line x1="170" y1="80" x2="375" y2="80" class="arrow arrow-blue" marker-end="url(#arrowhead-blue)"/>
+  <text x="272" y="68" text-anchor="middle" class="label-arrow">BES gRPC</text>
+  <text x="272" y="96" text-anchor="middle" class="label-dim">bidirectional stream</text>
+
+  <rect x="358" y="10" width="450" height="140" rx="12" fill="none" stroke="#c7d2fe" stroke-width="2" stroke-dasharray="6 3"/>
+  <text x="372" y="28" class="label-dim" font-weight="700" fill="#818cf8">OTel Collector</text>
+
+  <rect x="378" y="36" width="200" height="88" rx="8" class="fill-recv"/>
+  <text x="478" y="62" text-anchor="middle" class="label-main">besreceiver</text>
+  <text x="478" y="80" text-anchor="middle" class="label-sub">gRPC server · BEP parser</text>
+  <text x="478" y="96" text-anchor="middle" class="label-sub">trace builder · metrics builder</text>
+  <text x="478" y="113" text-anchor="middle" class="label-mono">:8082</text>
+
+  <line x1="578" y1="80" x2="648" y2="80" class="arrow arrow-green" marker-end="url(#arrowhead-green)"/>
+
+  <rect x="648" y="52" width="140" height="56" rx="8" class="fill-consumer"/>
+  <text x="718" y="77" text-anchor="middle" class="label-main">batch processor</text>
+  <text x="718" y="95" text-anchor="middle" class="label-sub">+ OTLP exporter</text>
+
+  <line x1="788" y1="80" x2="968" y2="80" class="arrow arrow-orange" marker-end="url(#arrowhead-orange)"/>
+  <text x="878" y="68" text-anchor="middle" class="label-arrow">OTLP/gRPC</text>
+
+  <rect x="970" y="30" width="130" height="42" rx="8" class="fill-backend"/>
+  <text x="1035" y="49" text-anchor="middle" class="label-main" font-size="12">Datadog</text>
+  <text x="1035" y="64" text-anchor="middle" class="label-sub">APM Traces</text>
+
+  <rect x="970" y="82" width="130" height="42" rx="8" class="fill-backend"/>
+  <text x="1035" y="101" text-anchor="middle" class="label-main" font-size="12">Tempo / Jaeger</text>
+  <text x="1035" y="116" text-anchor="middle" class="label-sub">any OTLP backend</text>
+
+  <path d="M378,96 Q272,124 170,96" class="arrow arrow-dashed" stroke="#3b82f6" stroke-width="1.5" fill="none" marker-end="url(#arrowhead-blue)"/>
+  <text x="272" y="138" text-anchor="middle" class="label-dim">ACK</text>
+</svg>

--- a/docs/architecture-spans.svg
+++ b/docs/architecture-spans.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="430" viewBox="0 0 1100 430">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .fill-bazel    { fill: #dbeafe; stroke: #3b82f6; }
+    .fill-grpc     { fill: #ede9fe; stroke: #7c3aed; }
+    .fill-recv     { fill: #d1fae5; stroke: #059669; }
+    .fill-owner    { fill: #fef9c3; stroke: #ca8a04; }
+    .fill-metrics  { fill: #fce7f3; stroke: #db2777; }
+    .label-main  { font-size: 13px; font-weight: 600; fill: #1a1a2e; }
+    .label-sub   { font-size: 11px; fill: #475569; }
+    .label-mono  { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-dim   { font-size: 10px; fill: #94a3b8; }
+    .tree-line { stroke: #cbd5e1; stroke-width: 1.5; fill: none; }
+  </style>
+
+  <rect width="100%" height="100%" fill="#ffffff"/>
+
+  <rect x="20" y="20" width="220" height="62" rx="8" class="fill-recv"/>
+  <text x="130" y="42" text-anchor="middle" class="label-main">bazel.build  (root span)</text>
+  <text x="130" y="58" text-anchor="middle" class="label-mono">traceID = SHA256(invocation_uuid)</text>
+  <text x="130" y="70" text-anchor="middle" class="label-sub">command · exit_code · uuid</text>
+
+  <line x1="130" y1="82"  x2="130" y2="375" class="tree-line"/>
+  <line x1="130" y1="133" x2="290" y2="133" class="tree-line"/>
+  <line x1="130" y1="267" x2="290" y2="267" class="tree-line"/>
+  <line x1="130" y1="375" x2="290" y2="375" class="tree-line"/>
+
+  <rect x="290" y="106" width="200" height="54" rx="8" class="fill-bazel"/>
+  <text x="390" y="127" text-anchor="middle" class="label-main">bazel.target</text>
+  <text x="390" y="143" text-anchor="middle" class="label-mono">//pkg:lib</text>
+  <text x="390" y="156" text-anchor="middle" class="label-sub">rule_kind · status · output_groups</text>
+
+  <line x1="490" y1="133" x2="510" y2="133" class="tree-line"/>
+  <line x1="510" y1="113" x2="510" y2="175" class="tree-line"/>
+  <line x1="510" y1="113" x2="530" y2="113" class="tree-line"/>
+  <line x1="510" y1="175" x2="530" y2="175" class="tree-line"/>
+
+  <rect x="530" y="86"  width="200" height="54" rx="8" class="fill-owner"/>
+  <text x="630" y="111" text-anchor="middle" class="label-main">bazel.action  Javac</text>
+  <text x="630" y="125" text-anchor="middle" class="label-mono">mnemonic · exit_code · timing</text>
+
+  <rect x="530" y="148" width="200" height="54" rx="8" class="fill-owner"/>
+  <text x="630" y="173" text-anchor="middle" class="label-main">bazel.action  Turbine</text>
+  <text x="630" y="187" text-anchor="middle" class="label-mono">command_line [PII-gated]</text>
+
+  <rect x="290" y="240" width="200" height="54" rx="8" class="fill-bazel"/>
+  <text x="390" y="261" text-anchor="middle" class="label-main">bazel.target</text>
+  <text x="390" y="277" text-anchor="middle" class="label-mono">//pkg:test</text>
+  <text x="390" y="290" text-anchor="middle" class="label-sub">test_summary: pass/fail counts</text>
+
+  <line x1="490" y1="267" x2="510" y2="267" class="tree-line"/>
+  <line x1="510" y1="247" x2="510" y2="309" class="tree-line"/>
+  <line x1="510" y1="247" x2="530" y2="247" class="tree-line"/>
+  <line x1="510" y1="309" x2="530" y2="309" class="tree-line"/>
+
+  <rect x="530" y="220" width="200" height="54" rx="8" class="fill-grpc"/>
+  <text x="630" y="245" text-anchor="middle" class="label-main">bazel.test  shard=0 run=1</text>
+  <text x="630" y="259" text-anchor="middle" class="label-mono">status · duration_ms · attempt</text>
+
+  <rect x="530" y="282" width="200" height="54" rx="8" class="fill-grpc"/>
+  <text x="630" y="307" text-anchor="middle" class="label-main">bazel.test  shard=1 run=1</text>
+  <text x="630" y="321" text-anchor="middle" class="label-mono">status · duration_ms · attempt</text>
+
+  <rect x="290" y="344" width="200" height="62" rx="8" class="fill-metrics"/>
+  <text x="390" y="369" text-anchor="middle" class="label-main">bazel.metrics</text>
+  <text x="390" y="385" text-anchor="middle" class="label-mono">wall_time · cpu_time</text>
+  <text x="390" y="398" text-anchor="middle" class="label-sub">actions_executed · heap</text>
+
+  <rect x="790" y="20" width="290" height="200" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="935" y="42" text-anchor="middle" class="label-sub" font-weight="700">PII-gated attributes</text>
+  <text x="935" y="58" text-anchor="middle" class="label-dim">(all opt-in via config, default: omitted)</text>
+
+  <rect x="810" y="68" width="10" height="10" rx="2" fill="#7c3aed"/>
+  <text x="828" y="78" class="label-mono">bazel.host</text>
+  <text x="828" y="91" class="label-dim">include_hostname: true</text>
+
+  <rect x="810" y="104" width="10" height="10" rx="2" fill="#7c3aed"/>
+  <text x="828" y="114" class="label-mono">bazel.user</text>
+  <text x="828" y="127" class="label-dim">include_username: true</text>
+
+  <rect x="810" y="140" width="10" height="10" rx="2" fill="#7c3aed"/>
+  <text x="828" y="150" class="label-mono">bazel.workspace_directory</text>
+  <text x="828" y="163" class="label-dim">include_workspace_dir: true</text>
+
+  <rect x="810" y="176" width="10" height="10" rx="2" fill="#7c3aed"/>
+  <text x="828" y="186" class="label-mono">bazel.action.command_line</text>
+  <text x="828" y="199" class="label-dim">include_command_args: true</text>
+
+  <rect x="790" y="235" width="290" height="90" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="935" y="257" text-anchor="middle" class="label-sub" font-weight="700">Deterministic IDs</text>
+  <text x="810" y="278" class="label-mono">traceID  = SHA256(uuid)[0:16]</text>
+  <text x="810" y="295" class="label-mono">spanID   = SHA256(uuid+type+…)[0:8]</text>
+  <text x="810" y="312" class="label-dim">same build → same trace ID always</text>
+</svg>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,87 +1,13 @@
 # Architecture
 
-## System Overview
+## End-to-end data flow
 
-```mermaid
-graph TD
-    subgraph "Build Machines"
-        B1[Bazel Build 1<br/>--bes_backend=grpc://collector:8082]
-        B2[Bazel Build 2]
-        B3[Bazel Build N]
-    end
+![End-to-end pipeline: Bazel CLI → besreceiver (inside OTel Collector) → batch processor + OTLP exporter → Datadog / Tempo / Jaeger](architecture-pipeline.svg)
 
-    subgraph "OTel Collector (otelcol-bazel)"
-        subgraph "besreceiver"
-            GRPC[gRPC BES Server<br/>:8082]
-            PARSER[BEP Parser<br/>anypb.Any → BuildEvent]
-            TB[Trace Builder<br/>BEP events → ptrace.Traces]
-        end
-        BATCH[Batch Processor]
-        subgraph "Exporters"
-            EXP_DD[OTLP Exporter<br/>→ Datadog Agent]
-            EXP_TEMPO[OTLP Exporter<br/>→ Grafana Tempo]
-            EXP_DEBUG[Debug Exporter<br/>→ stdout]
-        end
-    end
+## Internal components
 
-    subgraph "Observability Backends"
-        DD[Datadog]
-        TEMPO[Grafana Tempo]
-    end
+![Internal components: concurrent gRPC goroutines feed a buffered eventCh, a single owner goroutine in tracebuilder.go processes events against the invocations map and invocationState, the reaper flushes stale invocations, and metricsbuilder emits gauges and cumulative counters to the traces/logs/metrics consumers](architecture-components.svg)
 
-    B1 -- "gRPC stream<br/>PublishBuildToolEventStream" --> GRPC
-    B2 -- "gRPC stream" --> GRPC
-    B3 -- "gRPC stream" --> GRPC
-    GRPC --> PARSER
-    PARSER --> TB
-    TB -- "consumer.ConsumeTraces()" --> BATCH
-    BATCH --> EXP_DD
-    BATCH --> EXP_TEMPO
-    BATCH --> EXP_DEBUG
-    EXP_DD -- "OTLP gRPC :4317" --> DD
-    EXP_TEMPO -- "OTLP gRPC :4317" --> TEMPO
-```
+## Span hierarchy per Bazel invocation
 
-## Internal Component Architecture
-
-```mermaid
-graph LR
-    subgraph "receiver/besreceiver"
-        direction TB
-        CFG[config.go<br/>configgrpc.ServerConfig]
-        FAC[factory.go<br/>NewFactory]
-        RCV[receiver.go<br/>Start / Shutdown<br/>PublishBuildToolEventStream]
-        BPP[bepparser.go<br/>ParseBazelEvent]
-        TRB[tracebuilder.go<br/>invocationState<br/>BEP → ptrace.Traces]
-    end
-
-    FAC --> RCV
-    CFG --> FAC
-    RCV --> BPP
-    BPP --> TRB
-    TRB --> CON[consumer.Traces]
-```
-
-## Trace Span Hierarchy
-
-A single Bazel invocation produces one trace with this span tree:
-
-```mermaid
-graph TD
-    ROOT["bazel.build<br/>traceID: from invocation UUID<br/>command: build | test<br/>start_time → finish_time"]
-    T1["bazel.target<br/>//pkg:library<br/>rule_kind: java_library"]
-    T2["bazel.target<br/>//pkg:test<br/>rule_kind: java_test"]
-    A1["bazel.action<br/>mnemonic: Javac<br/>start_time → end_time<br/>exit_code: 0"]
-    A2["bazel.action<br/>mnemonic: Turbine<br/>start_time → end_time"]
-    A3["bazel.action<br/>mnemonic: JavacTurbine<br/>start_time → end_time"]
-    TR1["bazel.test<br/>shard: 0, run: 1, attempt: 1<br/>status: PASSED<br/>duration: 3.2s"]
-    TR2["bazel.test<br/>shard: 1, run: 1, attempt: 1<br/>status: PASSED<br/>duration: 2.8s"]
-
-    ROOT --> T1
-    ROOT --> T2
-    T1 --> A1
-    T1 --> A2
-    T2 --> A3
-    T2 --> TR1
-    T2 --> TR2
-```
+![Span hierarchy: bazel.build root span fans out to bazel.target spans (each with child bazel.action spans and bazel.test shard spans) and one bazel.metrics span; PII-gated attributes and deterministic trace/span IDs called out in side legends](architecture-spans.svg)


### PR DESCRIPTION
## Summary

Extract the three architecture panels from `docs/architecture.html` into standalone SVGs (`docs/architecture-{pipeline,components,spans}.svg`) with inline styles and a baked-in white background rect, so they render consistently across GitHub light/dark mode, pkg.go.dev, and other markdown renderers. Replace the Mermaid sources in `docs/architecture.md` with image references to those SVGs, and embed the pipeline diagram in the top-level `README.md` so the end-to-end data flow is visible without clicking through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)