### PR TITLE
docs: replace Mermaid sequence diagrams with SVGs

### DIFF
--- a/docs/sequence-bep-stream.svg
+++ b/docs/sequence-bep-stream.svg
@@ -1,0 +1,176 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="990" viewBox="0 0 1200 990">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .fill-bazel    { fill: #dbeafe; stroke: #3b82f6; }
+    .fill-grpc     { fill: #ede9fe; stroke: #7c3aed; }
+    .fill-recv     { fill: #d1fae5; stroke: #059669; }
+    .fill-owner    { fill: #fef9c3; stroke: #ca8a04; }
+    .fill-consumer { fill: #e0f2fe; stroke: #0284c7; }
+    .fill-backend  { fill: #f1f5f9; stroke: #64748b; }
+    .label-main  { font-size: 13px; font-weight: 600; fill: #1a1a2e; }
+    .label-sub   { font-size: 11px; fill: #475569; }
+    .label-mono  { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-arrow { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-dim   { font-size: 10px; fill: #94a3b8; }
+    .lifeline { stroke: #cbd5e1; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; }
+    .arrow { stroke-width: 1.5; fill: none; }
+    .arrow-solid-blue   { stroke: #3b82f6; }
+    .arrow-solid-purple { stroke: #7c3aed; }
+    .arrow-solid-green  { stroke: #059669; }
+    .arrow-solid-yellow { stroke: #ca8a04; }
+    .arrow-solid-sky    { stroke: #0284c7; }
+    .arrow-solid-slate  { stroke: #64748b; }
+    .arrow-dashed { stroke-dasharray: 5 3; }
+    .stage-label { font-size: 10px; font-weight: 700; fill: #94a3b8; letter-spacing: 0.5px; }
+    .note-rect { fill: #fef9c3; stroke: #ca8a04; stroke-width: 1.2; }
+    .phase-rect { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; stroke-dasharray: 4 3; }
+  </style>
+  <defs>
+    <marker id="mh-blue"   markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3b82f6"/></marker>
+    <marker id="mh-purple" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#7c3aed"/></marker>
+    <marker id="mh-green"  markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#059669"/></marker>
+    <marker id="mh-yellow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#ca8a04"/></marker>
+    <marker id="mh-sky"    markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#0284c7"/></marker>
+    <marker id="mh-slate"  markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#64748b"/></marker>
+  </defs>
+
+  <rect width="100%" height="100%" fill="#ffffff"/>
+
+  <!-- Actor headers -->
+  <rect x="30"   y="20" width="150" height="48" rx="8" class="fill-bazel"/>
+  <text x="105"  y="42" text-anchor="middle" class="label-main">Bazel</text>
+  <text x="105"  y="58" text-anchor="middle" class="label-mono">--bes_backend</text>
+
+  <rect x="220"  y="20" width="160" height="48" rx="8" class="fill-grpc"/>
+  <text x="300"  y="42" text-anchor="middle" class="label-main">besreceiver</text>
+  <text x="300"  y="58" text-anchor="middle" class="label-sub">gRPC server</text>
+
+  <rect x="420"  y="20" width="150" height="48" rx="8" class="fill-recv"/>
+  <text x="495"  y="42" text-anchor="middle" class="label-main">BEP Parser</text>
+  <text x="495"  y="58" text-anchor="middle" class="label-mono">bepparser.go</text>
+
+  <rect x="610"  y="20" width="170" height="48" rx="8" class="fill-owner"/>
+  <text x="695"  y="42" text-anchor="middle" class="label-main">Trace Builder</text>
+  <text x="695"  y="58" text-anchor="middle" class="label-mono">tracebuilder.go</text>
+
+  <rect x="820"  y="20" width="150" height="48" rx="8" class="fill-consumer"/>
+  <text x="895"  y="42" text-anchor="middle" class="label-main">consumer.Traces</text>
+  <text x="895"  y="58" text-anchor="middle" class="label-sub">Collector API</text>
+
+  <rect x="1010" y="20" width="160" height="48" rx="8" class="fill-backend"/>
+  <text x="1090" y="42" text-anchor="middle" class="label-main">Pipeline</text>
+  <text x="1090" y="58" text-anchor="middle" class="label-sub">batch → export</text>
+
+  <!-- Lifelines -->
+  <line x1="105"  y1="68" x2="105"  y2="975" class="lifeline"/>
+  <line x1="300"  y1="68" x2="300"  y2="975" class="lifeline"/>
+  <line x1="495"  y1="68" x2="495"  y2="975" class="lifeline"/>
+  <line x1="695"  y1="68" x2="695"  y2="975" class="lifeline"/>
+  <line x1="895"  y1="68" x2="895"  y2="975" class="lifeline"/>
+  <line x1="1090" y1="68" x2="1090" y2="975" class="lifeline"/>
+
+  <!-- Stream open -->
+  <line x1="105" y1="100" x2="300" y2="100" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
+  <text x="202" y="92" text-anchor="middle" class="label-arrow">PublishBuildToolEventStream  (open bidirectional stream)</text>
+
+  <!-- Phase 1: BuildStarted -->
+  <rect x="18" y="120" width="1170" height="130" rx="8" class="phase-rect"/>
+  <text x="30" y="138" class="stage-label">EVENT 1  ·  BuildStarted</text>
+
+  <line x1="105" y1="158" x2="300" y2="158" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
+  <text x="202" y="152" text-anchor="middle" class="label-arrow">OrderedBuildEvent  seq=1  bazel_event=Any</text>
+
+  <line x1="300" y1="182" x2="495" y2="182" class="arrow arrow-solid-purple" marker-end="url(#mh-purple)"/>
+  <text x="397" y="176" text-anchor="middle" class="label-arrow">ParseBazelEvent(Any)</text>
+
+  <line x1="495" y1="204" x2="300" y2="204" class="arrow arrow-solid-purple arrow-dashed" marker-end="url(#mh-purple)"/>
+  <text x="397" y="198" text-anchor="middle" class="label-arrow">BuildEvent{BuildStarted}</text>
+
+  <line x1="300" y1="226" x2="695" y2="226" class="arrow arrow-solid-yellow" marker-end="url(#mh-yellow)"/>
+  <text x="497" y="220" text-anchor="middle" class="label-arrow">ProcessEvent(BuildStarted)</text>
+
+  <!-- Note over Builder: create invocation state -->
+  <rect x="612" y="240" width="300" height="58" rx="4" class="note-rect"/>
+  <text x="762" y="257" text-anchor="middle" class="label-sub" font-weight="700">Create invocationState</text>
+  <text x="762" y="272" text-anchor="middle" class="label-mono">traceID = SHA256(uuid)</text>
+  <text x="762" y="286" text-anchor="middle" class="label-mono">new root span  "bazel.build"  + start_time</text>
+
+  <!-- ACK seq=1 -->
+  <line x1="300" y1="330" x2="105" y2="330" class="arrow arrow-solid-blue arrow-dashed" marker-end="url(#mh-blue)"/>
+  <text x="202" y="324" text-anchor="middle" class="label-arrow">ACK  seq=1</text>
+
+  <!-- Phase 2: TargetConfigured -->
+  <rect x="18" y="350" width="1170" height="118" rx="8" class="phase-rect"/>
+  <text x="30" y="368" class="stage-label">EVENT 2  ·  TargetConfigured</text>
+
+  <line x1="105" y1="388" x2="300" y2="388" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
+  <text x="202" y="382" text-anchor="middle" class="label-arrow">OrderedBuildEvent  seq=2</text>
+
+  <line x1="300" y1="410" x2="695" y2="410" class="arrow arrow-solid-yellow" marker-end="url(#mh-yellow)"/>
+  <text x="497" y="404" text-anchor="middle" class="label-arrow">ParseBazelEvent  →  ProcessEvent(TargetConfigured)</text>
+
+  <rect x="612" y="420" width="280" height="42" rx="4" class="note-rect"/>
+  <text x="752" y="437" text-anchor="middle" class="label-sub" font-weight="700">Create "bazel.target" span</text>
+  <text x="752" y="451" text-anchor="middle" class="label-mono">targets[(label, config)] = spanID</text>
+
+  <line x1="300" y1="458" x2="105" y2="458" class="arrow arrow-solid-blue arrow-dashed" marker-end="url(#mh-blue)"/>
+  <text x="202" y="452" text-anchor="middle" class="label-arrow">ACK  seq=2</text>
+
+  <!-- Phase 3: ActionExecuted -->
+  <rect x="18" y="486" width="1170" height="210" rx="8" class="phase-rect"/>
+  <text x="30" y="504" class="stage-label">EVENT 3  ·  ActionExecuted</text>
+
+  <line x1="105" y1="524" x2="300" y2="524" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
+  <text x="202" y="518" text-anchor="middle" class="label-arrow">OrderedBuildEvent  seq=3</text>
+
+  <line x1="300" y1="548" x2="695" y2="548" class="arrow arrow-solid-yellow" marker-end="url(#mh-yellow)"/>
+  <text x="497" y="542" text-anchor="middle" class="label-arrow">ParseBazelEvent  →  ProcessEvent(ActionExecuted)</text>
+
+  <rect x="612" y="558" width="300" height="68" rx="4" class="note-rect"/>
+  <text x="762" y="575" text-anchor="middle" class="label-sub" font-weight="700">Create "bazel.action" span</text>
+  <text x="762" y="590" text-anchor="middle" class="label-mono">parent = targets[(label, config)]</text>
+  <text x="762" y="604" text-anchor="middle" class="label-mono">start_time · end_time · mnemonic · exit_code</text>
+
+  <line x1="695" y1="646" x2="895" y2="646" class="arrow arrow-solid-sky" marker-end="url(#mh-sky)"/>
+  <text x="795" y="640" text-anchor="middle" class="label-arrow">ConsumeTraces(ptrace.Traces)</text>
+
+  <line x1="895" y1="668" x2="1090" y2="668" class="arrow arrow-solid-slate" marker-end="url(#mh-slate)"/>
+  <text x="992" y="662" text-anchor="middle" class="label-arrow">batch → export</text>
+
+  <line x1="300" y1="690" x2="105" y2="690" class="arrow arrow-solid-blue arrow-dashed" marker-end="url(#mh-blue)"/>
+  <text x="202" y="684" text-anchor="middle" class="label-arrow">ACK  seq=3</text>
+
+  <!-- Ellipsis separator -->
+  <line x1="60" y1="718" x2="1160" y2="718" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="2 4"/>
+  <text x="600" y="734" text-anchor="middle" class="label-dim" font-style="italic">... further ActionExecuted / TestResult events stream and get processed the same way ...</text>
+
+  <!-- Phase N: BuildFinished -->
+  <rect x="18" y="752" width="1170" height="164" rx="8" class="phase-rect"/>
+  <text x="30" y="770" class="stage-label">EVENT N  ·  BuildFinished</text>
+
+  <line x1="105" y1="790" x2="300" y2="790" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
+  <text x="202" y="784" text-anchor="middle" class="label-arrow">OrderedBuildEvent  seq=N</text>
+
+  <line x1="300" y1="812" x2="695" y2="812" class="arrow arrow-solid-yellow" marker-end="url(#mh-yellow)"/>
+  <text x="497" y="806" text-anchor="middle" class="label-arrow">ParseBazelEvent  →  ProcessEvent(BuildFinished)</text>
+
+  <rect x="612" y="822" width="280" height="42" rx="4" class="note-rect"/>
+  <text x="752" y="839" text-anchor="middle" class="label-sub" font-weight="700">Close root span</text>
+  <text x="752" y="853" text-anchor="middle" class="label-mono">finish_time · exit_code</text>
+
+  <line x1="695" y1="880" x2="895" y2="880" class="arrow arrow-solid-sky" marker-end="url(#mh-sky)"/>
+  <text x="795" y="874" text-anchor="middle" class="label-arrow">ConsumeTraces(remaining spans)</text>
+
+  <line x1="895" y1="900" x2="1090" y2="900" class="arrow arrow-solid-slate" marker-end="url(#mh-slate)"/>
+  <text x="992" y="894" text-anchor="middle" class="label-arrow">batch → export</text>
+
+  <line x1="300" y1="912" x2="105" y2="912" class="arrow arrow-solid-blue arrow-dashed" marker-end="url(#mh-blue)"/>
+  <text x="202" y="906" text-anchor="middle" class="label-arrow">ACK  seq=N</text>
+
+  <!-- Stream close -->
+  <line x1="105" y1="940" x2="300" y2="940" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
+  <text x="202" y="934" text-anchor="middle" class="label-arrow">stream EOF</text>
+
+  <rect x="242" y="951" width="280" height="20" rx="4" class="note-rect"/>
+  <text x="382" y="965" text-anchor="middle" class="label-mono">Clean up invocationState</text>
+</svg>

--- a/docs/sequence-bep-stream.svg
+++ b/docs/sequence-bep-stream.svg
@@ -61,6 +61,12 @@
   <text x="1090" y="42" text-anchor="middle" class="label-main">Pipeline</text>
   <text x="1090" y="58" text-anchor="middle" class="label-sub">batch → export</text>
 
+  <!-- Phase bands (rendered before lifelines so the dashed lifelines read across them) -->
+  <rect x="18" y="120" width="1170" height="130" rx="8" class="phase-rect"/>
+  <rect x="18" y="350" width="1170" height="118" rx="8" class="phase-rect"/>
+  <rect x="18" y="486" width="1170" height="210" rx="8" class="phase-rect"/>
+  <rect x="18" y="752" width="1170" height="164" rx="8" class="phase-rect"/>
+
   <!-- Lifelines -->
   <line x1="105"  y1="68" x2="105"  y2="975" class="lifeline"/>
   <line x1="300"  y1="68" x2="300"  y2="975" class="lifeline"/>
@@ -74,7 +80,6 @@
   <text x="202" y="92" text-anchor="middle" class="label-arrow">PublishBuildToolEventStream  (open bidirectional stream)</text>
 
   <!-- Phase 1: BuildStarted -->
-  <rect x="18" y="120" width="1170" height="130" rx="8" class="phase-rect"/>
   <text x="30" y="138" class="stage-label">EVENT 1  ·  BuildStarted</text>
 
   <line x1="105" y1="158" x2="300" y2="158" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
@@ -100,7 +105,6 @@
   <text x="202" y="324" text-anchor="middle" class="label-arrow">ACK  seq=1</text>
 
   <!-- Phase 2: TargetConfigured -->
-  <rect x="18" y="350" width="1170" height="118" rx="8" class="phase-rect"/>
   <text x="30" y="368" class="stage-label">EVENT 2  ·  TargetConfigured</text>
 
   <line x1="105" y1="388" x2="300" y2="388" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
@@ -117,7 +121,6 @@
   <text x="202" y="452" text-anchor="middle" class="label-arrow">ACK  seq=2</text>
 
   <!-- Phase 3: ActionExecuted -->
-  <rect x="18" y="486" width="1170" height="210" rx="8" class="phase-rect"/>
   <text x="30" y="504" class="stage-label">EVENT 3  ·  ActionExecuted</text>
 
   <line x1="105" y1="524" x2="300" y2="524" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>
@@ -145,7 +148,6 @@
   <text x="600" y="734" text-anchor="middle" class="label-dim" font-style="italic">... further ActionExecuted / TestResult events stream and get processed the same way ...</text>
 
   <!-- Phase N: BuildFinished -->
-  <rect x="18" y="752" width="1170" height="164" rx="8" class="phase-rect"/>
   <text x="30" y="770" class="stage-label">EVENT N  ·  BuildFinished</text>
 
   <line x1="105" y1="790" x2="300" y2="790" class="arrow arrow-solid-blue" marker-end="url(#mh-blue)"/>

--- a/docs/sequence-concurrent.svg
+++ b/docs/sequence-concurrent.svg
@@ -1,0 +1,144 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="720" viewBox="0 0 1100 720">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .fill-bazel    { fill: #dbeafe; stroke: #3b82f6; }
+    .fill-bazel2   { fill: #fce7f3; stroke: #db2777; }
+    .fill-recv     { fill: #d1fae5; stroke: #059669; }
+    .fill-invoc    { fill: #fff7ed; stroke: #ea580c; }
+    .fill-consumer { fill: #e0f2fe; stroke: #0284c7; }
+    .label-main  { font-size: 13px; font-weight: 600; fill: #1a1a2e; }
+    .label-sub   { font-size: 11px; fill: #475569; }
+    .label-mono  { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-arrow { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-dim   { font-size: 10px; fill: #94a3b8; }
+    .lifeline { stroke: #cbd5e1; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; }
+    .arrow { stroke-width: 1.5; fill: none; }
+    .arrow-blue   { stroke: #3b82f6; }
+    .arrow-pink   { stroke: #db2777; }
+    .arrow-green  { stroke: #059669; }
+    .arrow-orange { stroke: #ea580c; }
+    .arrow-sky    { stroke: #0284c7; }
+    .arrow-dashed { stroke-dasharray: 5 3; }
+    .stage-label { font-size: 10px; font-weight: 700; fill: #94a3b8; letter-spacing: 0.5px; }
+    .note-rect { fill: #fef9c3; stroke: #ca8a04; stroke-width: 1.2; }
+  </style>
+  <defs>
+    <marker id="mh-blue"   markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#3b82f6"/></marker>
+    <marker id="mh-pink"   markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#db2777"/></marker>
+    <marker id="mh-green"  markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#059669"/></marker>
+    <marker id="mh-orange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#ea580c"/></marker>
+    <marker id="mh-sky"    markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#0284c7"/></marker>
+  </defs>
+
+  <rect width="100%" height="100%" fill="#ffffff"/>
+
+  <!-- Actor headers -->
+  <rect x="30"  y="20" width="160" height="48" rx="8" class="fill-bazel"/>
+  <text x="110" y="42" text-anchor="middle" class="label-main">Bazel Build 1</text>
+  <text x="110" y="58" text-anchor="middle" class="label-mono">uuid=aaa</text>
+
+  <rect x="240" y="20" width="160" height="48" rx="8" class="fill-bazel2"/>
+  <text x="320" y="42" text-anchor="middle" class="label-main">Bazel Build 2</text>
+  <text x="320" y="58" text-anchor="middle" class="label-mono">uuid=bbb</text>
+
+  <rect x="470" y="20" width="170" height="48" rx="8" class="fill-recv"/>
+  <text x="555" y="42" text-anchor="middle" class="label-main">besreceiver</text>
+  <text x="555" y="58" text-anchor="middle" class="label-sub">gRPC server</text>
+
+  <rect x="700" y="20" width="170" height="48" rx="8" class="fill-invoc"/>
+  <text x="785" y="42" text-anchor="middle" class="label-main">invocations</text>
+  <text x="785" y="58" text-anchor="middle" class="label-mono">sync.Map</text>
+
+  <rect x="920" y="20" width="160" height="48" rx="8" class="fill-consumer"/>
+  <text x="1000" y="42" text-anchor="middle" class="label-main">consumer.Traces</text>
+  <text x="1000" y="58" text-anchor="middle" class="label-sub">Collector API</text>
+
+  <!-- Lifelines -->
+  <line x1="110"  y1="68" x2="110"  y2="700" class="lifeline"/>
+  <line x1="320"  y1="68" x2="320"  y2="700" class="lifeline"/>
+  <line x1="555"  y1="68" x2="555"  y2="700" class="lifeline"/>
+  <line x1="785"  y1="68" x2="785"  y2="700" class="lifeline"/>
+  <line x1="1000" y1="68" x2="1000" y2="700" class="lifeline"/>
+
+  <!-- Phase 1: B1 starts -->
+  <text x="30" y="96" class="stage-label">STREAM 1  ·  BuildStarted</text>
+  <line x1="110" y1="110" x2="555" y2="110" class="arrow arrow-blue" marker-end="url(#mh-blue)"/>
+  <text x="333" y="104" text-anchor="middle" class="label-arrow">BuildStarted  uuid=aaa</text>
+
+  <line x1="555" y1="134" x2="785" y2="134" class="arrow arrow-orange" marker-end="url(#mh-orange)"/>
+  <text x="670" y="128" text-anchor="middle" class="label-arrow">Store("aaa", invocationState{traceID=...})</text>
+
+  <line x1="555" y1="158" x2="110" y2="158" class="arrow arrow-blue arrow-dashed" marker-end="url(#mh-blue)"/>
+  <text x="333" y="152" text-anchor="middle" class="label-arrow">ACK</text>
+
+  <!-- Phase 2: B2 starts -->
+  <text x="30" y="188" class="stage-label">STREAM 2  ·  BuildStarted</text>
+  <line x1="320" y1="202" x2="555" y2="202" class="arrow arrow-pink" marker-end="url(#mh-pink)"/>
+  <text x="438" y="196" text-anchor="middle" class="label-arrow">BuildStarted  uuid=bbb</text>
+
+  <line x1="555" y1="226" x2="785" y2="226" class="arrow arrow-orange" marker-end="url(#mh-orange)"/>
+  <text x="670" y="220" text-anchor="middle" class="label-arrow">Store("bbb", invocationState{traceID=...})</text>
+
+  <line x1="555" y1="250" x2="320" y2="250" class="arrow arrow-pink arrow-dashed" marker-end="url(#mh-pink)"/>
+  <text x="438" y="244" text-anchor="middle" class="label-arrow">ACK</text>
+
+  <!-- par block -->
+  <rect x="20" y="280" width="1070" height="260" rx="8" fill="none" stroke="#ca8a04" stroke-width="1.5" stroke-dasharray="6 3"/>
+  <rect x="20" y="280" width="130" height="22" rx="0" fill="#fef9c3" stroke="#ca8a04" stroke-width="1.5"/>
+  <text x="30" y="296" class="stage-label" fill="#854d0e">par  CONCURRENT</text>
+
+  <!-- Divider inside par -->
+  <line x1="20" y1="410" x2="1090" y2="410" stroke="#ca8a04" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="30" y="424" class="stage-label" fill="#854d0e">and</text>
+
+  <!-- Top half: B1 action -->
+  <line x1="110" y1="320" x2="555" y2="320" class="arrow arrow-blue" marker-end="url(#mh-blue)"/>
+  <text x="333" y="314" text-anchor="middle" class="label-arrow">Stream 1: ActionExecuted</text>
+
+  <line x1="555" y1="344" x2="785" y2="344" class="arrow arrow-orange" marker-end="url(#mh-orange)"/>
+  <text x="670" y="338" text-anchor="middle" class="label-arrow">Load("aaa")</text>
+
+  <rect x="450" y="352" width="230" height="20" rx="4" class="note-rect"/>
+  <text x="565" y="366" text-anchor="middle" class="label-mono">Build span with traceID from aaa</text>
+
+  <line x1="555" y1="384" x2="1000" y2="384" class="arrow arrow-sky" marker-end="url(#mh-sky)"/>
+  <text x="778" y="378" text-anchor="middle" class="label-arrow">ConsumeTraces()</text>
+
+  <line x1="555" y1="402" x2="110" y2="402" class="arrow arrow-blue arrow-dashed" marker-end="url(#mh-blue)"/>
+  <text x="333" y="396" text-anchor="middle" class="label-arrow">ACK</text>
+
+  <!-- Bottom half: B2 action -->
+  <line x1="320" y1="446" x2="555" y2="446" class="arrow arrow-pink" marker-end="url(#mh-pink)"/>
+  <text x="438" y="440" text-anchor="middle" class="label-arrow">Stream 2: ActionExecuted</text>
+
+  <line x1="555" y1="470" x2="785" y2="470" class="arrow arrow-orange" marker-end="url(#mh-orange)"/>
+  <text x="670" y="464" text-anchor="middle" class="label-arrow">Load("bbb")</text>
+
+  <rect x="450" y="478" width="230" height="20" rx="4" class="note-rect"/>
+  <text x="565" y="492" text-anchor="middle" class="label-mono">Build span with traceID from bbb</text>
+
+  <line x1="555" y1="510" x2="1000" y2="510" class="arrow arrow-sky" marker-end="url(#mh-sky)"/>
+  <text x="778" y="504" text-anchor="middle" class="label-arrow">ConsumeTraces()</text>
+
+  <line x1="555" y1="528" x2="320" y2="528" class="arrow arrow-pink arrow-dashed" marker-end="url(#mh-pink)"/>
+  <text x="438" y="522" text-anchor="middle" class="label-arrow">ACK</text>
+
+  <!-- Phase: B1 finish -->
+  <text x="30" y="568" class="stage-label">STREAM 1  ·  BuildFinished</text>
+  <line x1="110" y1="582" x2="555" y2="582" class="arrow arrow-blue" marker-end="url(#mh-blue)"/>
+  <text x="333" y="576" text-anchor="middle" class="label-arrow">BuildFinished</text>
+
+  <line x1="555" y1="606" x2="785" y2="606" class="arrow arrow-orange" marker-end="url(#mh-orange)"/>
+  <text x="670" y="600" text-anchor="middle" class="label-arrow">Delete("aaa")</text>
+
+  <line x1="555" y1="630" x2="110" y2="630" class="arrow arrow-blue arrow-dashed" marker-end="url(#mh-blue)"/>
+  <text x="333" y="624" text-anchor="middle" class="label-arrow">ACK</text>
+
+  <!-- Phase: B2 finish -->
+  <text x="30" y="658" class="stage-label">STREAM 2  ·  BuildFinished</text>
+  <line x1="320" y1="672" x2="555" y2="672" class="arrow arrow-pink" marker-end="url(#mh-pink)"/>
+  <text x="438" y="666" text-anchor="middle" class="label-arrow">BuildFinished</text>
+
+  <line x1="555" y1="692" x2="320" y2="692" class="arrow arrow-pink arrow-dashed" marker-end="url(#mh-pink)"/>
+  <text x="438" y="686" text-anchor="middle" class="label-arrow">ACK  (Delete "bbb")</text>
+</svg>

--- a/docs/sequence-startup.svg
+++ b/docs/sequence-startup.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="620" viewBox="0 0 1160 620">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .fill-main     { fill: #f1f5f9; stroke: #64748b; }
+    .fill-svc      { fill: #e0f2fe; stroke: #0284c7; }
+    .fill-factory  { fill: #ede9fe; stroke: #7c3aed; }
+    .fill-recv     { fill: #d1fae5; stroke: #059669; }
+    .fill-grpc     { fill: #fef9c3; stroke: #ca8a04; }
+    .label-main  { font-size: 13px; font-weight: 600; fill: #1a1a2e; }
+    .label-sub   { font-size: 11px; fill: #475569; }
+    .label-mono  { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-arrow { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #374151; }
+    .label-dim   { font-size: 10px; fill: #94a3b8; }
+    .lifeline { stroke: #cbd5e1; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; }
+    .arrow { stroke-width: 1.5; fill: none; }
+    .arrow-slate  { stroke: #64748b; }
+    .arrow-sky    { stroke: #0284c7; }
+    .arrow-purple { stroke: #7c3aed; }
+    .arrow-green  { stroke: #059669; }
+    .arrow-yellow { stroke: #ca8a04; }
+    .arrow-dashed { stroke-dasharray: 5 3; }
+    .stage-label { font-size: 10px; font-weight: 700; fill: #94a3b8; letter-spacing: 0.5px; }
+    .note-rect { fill: #fef9c3; stroke: #ca8a04; stroke-width: 1.2; }
+    .phase-rect { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; stroke-dasharray: 4 3; }
+  </style>
+  <defs>
+    <marker id="mh-slate"  markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#64748b"/></marker>
+    <marker id="mh-sky"    markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#0284c7"/></marker>
+    <marker id="mh-purple" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#7c3aed"/></marker>
+    <marker id="mh-green"  markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#059669"/></marker>
+    <marker id="mh-yellow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#ca8a04"/></marker>
+  </defs>
+
+  <rect width="100%" height="100%" fill="#ffffff"/>
+
+  <!-- Actor headers -->
+  <rect x="30"   y="20" width="170" height="48" rx="8" class="fill-main"/>
+  <text x="115"  y="42" text-anchor="middle" class="label-main">otelcol-bazel</text>
+  <text x="115"  y="58" text-anchor="middle" class="label-mono">main()</text>
+
+  <rect x="250"  y="20" width="180" height="48" rx="8" class="fill-svc"/>
+  <text x="340"  y="42" text-anchor="middle" class="label-main">Collector Service</text>
+  <text x="340"  y="58" text-anchor="middle" class="label-sub">component lifecycle</text>
+
+  <rect x="480"  y="20" width="200" height="48" rx="8" class="fill-factory"/>
+  <text x="580"  y="42" text-anchor="middle" class="label-main">besreceiver Factory</text>
+  <text x="580"  y="58" text-anchor="middle" class="label-mono">factory.go</text>
+
+  <rect x="730"  y="20" width="190" height="48" rx="8" class="fill-recv"/>
+  <text x="825"  y="42" text-anchor="middle" class="label-main">besreceiver</text>
+  <text x="825"  y="58" text-anchor="middle" class="label-mono">receiver.go</text>
+
+  <rect x="970"  y="20" width="170" height="48" rx="8" class="fill-grpc"/>
+  <text x="1055" y="42" text-anchor="middle" class="label-main">gRPC Server</text>
+  <text x="1055" y="58" text-anchor="middle" class="label-sub">google.golang.org/grpc</text>
+
+  <!-- Lifelines -->
+  <line x1="115"  y1="68" x2="115"  y2="600" class="lifeline"/>
+  <line x1="340"  y1="68" x2="340"  y2="600" class="lifeline"/>
+  <line x1="580"  y1="68" x2="580"  y2="600" class="lifeline"/>
+  <line x1="825"  y1="68" x2="825"  y2="600" class="lifeline"/>
+  <line x1="1055" y1="68" x2="1055" y2="600" class="lifeline"/>
+
+  <!-- Phase: Startup -->
+  <rect x="18" y="86" width="1130" height="256" rx="8" class="phase-rect"/>
+  <text x="30" y="104" class="stage-label">STARTUP</text>
+
+  <!-- main → Service: Run -->
+  <line x1="115" y1="124" x2="340" y2="124" class="arrow arrow-slate" marker-end="url(#mh-slate)"/>
+  <text x="227" y="118" text-anchor="middle" class="label-arrow">Run(collector-config.yaml)</text>
+
+  <!-- Service → Factory: CreateTraces -->
+  <line x1="340" y1="150" x2="580" y2="150" class="arrow arrow-sky" marker-end="url(#mh-sky)"/>
+  <text x="460" y="144" text-anchor="middle" class="label-arrow">CreateTraces(settings, config, consumer)</text>
+
+  <!-- Factory → Service: besReceiver instance -->
+  <line x1="580" y1="174" x2="340" y2="174" class="arrow arrow-purple arrow-dashed" marker-end="url(#mh-purple)"/>
+  <text x="460" y="168" text-anchor="middle" class="label-arrow">besReceiver instance</text>
+
+  <!-- Service → Receiver: Start -->
+  <line x1="340" y1="200" x2="825" y2="200" class="arrow arrow-sky" marker-end="url(#mh-sky)"/>
+  <text x="582" y="194" text-anchor="middle" class="label-arrow">Start(ctx, host)</text>
+
+  <!-- Receiver → gRPC: ToServer -->
+  <line x1="825" y1="226" x2="1055" y2="226" class="arrow arrow-green" marker-end="url(#mh-green)"/>
+  <text x="940" y="220" text-anchor="middle" class="label-arrow">ServerConfig.ToServer()</text>
+
+  <!-- Receiver → gRPC: RegisterPublishBuildEventServer -->
+  <line x1="825" y1="250" x2="1055" y2="250" class="arrow arrow-green" marker-end="url(#mh-green)"/>
+  <text x="940" y="244" text-anchor="middle" class="label-arrow">RegisterPublishBuildEventServer()</text>
+
+  <!-- Receiver → gRPC: Listen -->
+  <line x1="825" y1="274" x2="1055" y2="274" class="arrow arrow-green" marker-end="url(#mh-green)"/>
+  <text x="940" y="268" text-anchor="middle" class="label-arrow">Listen(0.0.0.0:8082)</text>
+
+  <!-- Receiver → gRPC: go Serve() -->
+  <line x1="825" y1="298" x2="1055" y2="298" class="arrow arrow-green" marker-end="url(#mh-green)"/>
+  <text x="940" y="292" text-anchor="middle" class="label-arrow">go Serve()</text>
+
+  <!-- Receiver → Service: nil (started) -->
+  <line x1="825" y1="324" x2="340" y2="324" class="arrow arrow-green arrow-dashed" marker-end="url(#mh-green)"/>
+  <text x="582" y="318" text-anchor="middle" class="label-arrow">nil  (started)</text>
+
+  <!-- Running phase separator -->
+  <rect x="18" y="360" width="1130" height="80" rx="8" class="phase-rect"/>
+  <text x="30" y="378" class="stage-label">RUNNING</text>
+
+  <rect x="260" y="390" width="640" height="38" rx="6" class="note-rect"/>
+  <text x="580" y="408" text-anchor="middle" class="label-sub" font-weight="700">Collector running — accepting BEP streams from Bazel invocations</text>
+  <text x="580" y="422" text-anchor="middle" class="label-mono">gRPC server handles PublishBuildToolEventStream concurrently</text>
+
+  <!-- Shutdown phase -->
+  <rect x="18" y="458" width="1130" height="138" rx="8" class="phase-rect"/>
+  <text x="30" y="476" class="stage-label">SHUTDOWN</text>
+
+  <!-- Service → Receiver: Shutdown -->
+  <line x1="340" y1="498" x2="825" y2="498" class="arrow arrow-sky" marker-end="url(#mh-sky)"/>
+  <text x="582" y="492" text-anchor="middle" class="label-arrow">Shutdown(ctx)</text>
+
+  <!-- Receiver → gRPC: GracefulStop -->
+  <line x1="825" y1="524" x2="1055" y2="524" class="arrow arrow-green" marker-end="url(#mh-green)"/>
+  <text x="940" y="518" text-anchor="middle" class="label-arrow">GracefulStop()</text>
+
+  <rect x="944" y="534" width="220" height="20" rx="4" class="note-rect"/>
+  <text x="1054" y="548" text-anchor="middle" class="label-mono">Drain active streams</text>
+
+  <!-- Receiver → Service: nil (stopped) -->
+  <line x1="825" y1="578" x2="340" y2="578" class="arrow arrow-green arrow-dashed" marker-end="url(#mh-green)"/>
+  <text x="582" y="572" text-anchor="middle" class="label-arrow">nil  (stopped)</text>
+</svg>

--- a/docs/sequence-startup.svg
+++ b/docs/sequence-startup.svg
@@ -54,6 +54,11 @@
   <text x="1055" y="42" text-anchor="middle" class="label-main">gRPC Server</text>
   <text x="1055" y="58" text-anchor="middle" class="label-sub">google.golang.org/grpc</text>
 
+  <!-- Phase bands (rendered before lifelines so the dashed lifelines read across them) -->
+  <rect x="18" y="86"  width="1130" height="256" rx="8" class="phase-rect"/>
+  <rect x="18" y="360" width="1130" height="80"  rx="8" class="phase-rect"/>
+  <rect x="18" y="458" width="1130" height="138" rx="8" class="phase-rect"/>
+
   <!-- Lifelines -->
   <line x1="115"  y1="68" x2="115"  y2="600" class="lifeline"/>
   <line x1="340"  y1="68" x2="340"  y2="600" class="lifeline"/>
@@ -62,7 +67,6 @@
   <line x1="1055" y1="68" x2="1055" y2="600" class="lifeline"/>
 
   <!-- Phase: Startup -->
-  <rect x="18" y="86" width="1130" height="256" rx="8" class="phase-rect"/>
   <text x="30" y="104" class="stage-label">STARTUP</text>
 
   <!-- main → Service: Run -->
@@ -102,7 +106,6 @@
   <text x="582" y="318" text-anchor="middle" class="label-arrow">nil  (started)</text>
 
   <!-- Running phase separator -->
-  <rect x="18" y="360" width="1130" height="80" rx="8" class="phase-rect"/>
   <text x="30" y="378" class="stage-label">RUNNING</text>
 
   <rect x="260" y="390" width="640" height="38" rx="6" class="note-rect"/>
@@ -110,7 +113,6 @@
   <text x="580" y="422" text-anchor="middle" class="label-mono">gRPC server handles PublishBuildToolEventStream concurrently</text>
 
   <!-- Shutdown phase -->
-  <rect x="18" y="458" width="1130" height="138" rx="8" class="phase-rect"/>
   <text x="30" y="476" class="stage-label">SHUTDOWN</text>
 
   <!-- Service → Receiver: Shutdown -->

--- a/docs/sequence.md
+++ b/docs/sequence.md
@@ -2,125 +2,12 @@
 
 ## BEP Stream Processing (single invocation)
 
-```mermaid
-sequenceDiagram
-    participant Bazel
-    participant gRPC as besreceiver<br/>(gRPC server)
-    participant Parser as BEP Parser
-    participant Builder as Trace Builder
-    participant Consumer as consumer.Traces
-    participant Pipeline as Collector Pipeline<br/>(batch → export)
-
-    Bazel->>gRPC: PublishBuildToolEventStream (open bidirectional stream)
-
-    Note over Bazel,gRPC: Event 1: BuildStarted
-    Bazel->>gRPC: OrderedBuildEvent (seq=1, bazel_event=Any)
-    gRPC->>Parser: ParseBazelEvent(Any)
-    Parser-->>gRPC: BuildEvent{BuildStarted}
-    gRPC->>Builder: ProcessEvent(BuildStarted)
-    Note over Builder: Create invocationState<br/>Generate traceID from UUID<br/>Create root span "bazel.build"<br/>Set start_time
-    gRPC-->>Bazel: ACK (seq=1)
-
-    Note over Bazel,gRPC: Event 2: TargetConfigured
-    Bazel->>gRPC: OrderedBuildEvent (seq=2)
-    gRPC->>Parser: ParseBazelEvent(Any)
-    Parser-->>gRPC: BuildEvent{TargetConfigured}
-    gRPC->>Builder: ProcessEvent(TargetConfigured)
-    Note over Builder: Create "bazel.target" span<br/>Register (label,config) → spanID
-    gRPC-->>Bazel: ACK (seq=2)
-
-    Note over Bazel,gRPC: Event 3: ActionExecuted
-    Bazel->>gRPC: OrderedBuildEvent (seq=3)
-    gRPC->>Parser: ParseBazelEvent(Any)
-    Parser-->>gRPC: BuildEvent{ActionExecuted}
-    gRPC->>Builder: ProcessEvent(ActionExecuted)
-    Note over Builder: Create "bazel.action" span<br/>parent = targets[(label,config)]<br/>Set start_time, end_time<br/>Set mnemonic, exit_code
-    Builder->>Consumer: ConsumeTraces(ptrace.Traces)
-    Consumer->>Pipeline: batch → export
-
-    gRPC-->>Bazel: ACK (seq=3)
-
-    Note over Bazel,gRPC: ... more actions/tests ...
-
-    Note over Bazel,gRPC: Event N: BuildFinished
-    Bazel->>gRPC: OrderedBuildEvent (seq=N)
-    gRPC->>Parser: ParseBazelEvent(Any)
-    Parser-->>gRPC: BuildEvent{BuildFinished}
-    gRPC->>Builder: ProcessEvent(BuildFinished)
-    Note over Builder: End root span<br/>Set finish_time, exit_code
-    Builder->>Consumer: ConsumeTraces(remaining spans)
-    Consumer->>Pipeline: batch → export
-    gRPC-->>Bazel: ACK (seq=N)
-
-    Bazel->>gRPC: stream EOF
-    Note over gRPC: Clean up invocationState
-```
+![BEP stream processing: Bazel opens a bidirectional PublishBuildToolEventStream, each OrderedBuildEvent is parsed from anypb.Any into a bep.BuildEvent, the Trace Builder creates and mutates invocationState (root bazel.build span, bazel.target spans, bazel.action spans), traces are handed to consumer.Traces for batch+export, and the invocationState is cleaned up on stream EOF after BuildFinished](sequence-bep-stream.svg)
 
 ## Concurrent Invocations
 
-```mermaid
-sequenceDiagram
-    participant B1 as Bazel Build 1
-    participant B2 as Bazel Build 2
-    participant Recv as besreceiver
-    participant State as invocations<br/>(sync.Map)
-    participant Consumer as consumer.Traces
-
-    B1->>Recv: Stream 1: BuildStarted (uuid=aaa)
-    Recv->>State: Store("aaa", invocationState{traceID=...})
-    Recv-->>B1: ACK
-
-    B2->>Recv: Stream 2: BuildStarted (uuid=bbb)
-    Recv->>State: Store("bbb", invocationState{traceID=...})
-    Recv-->>B2: ACK
-
-    par Concurrent processing
-        B1->>Recv: Stream 1: ActionExecuted
-        Recv->>State: Load("aaa")
-        Note over Recv: Build span with traceID from aaa
-        Recv->>Consumer: ConsumeTraces()
-        Recv-->>B1: ACK
-    and
-        B2->>Recv: Stream 2: ActionExecuted
-        Recv->>State: Load("bbb")
-        Note over Recv: Build span with traceID from bbb
-        Recv->>Consumer: ConsumeTraces()
-        Recv-->>B2: ACK
-    end
-
-    B1->>Recv: Stream 1: BuildFinished
-    Recv->>State: Delete("aaa")
-    Recv-->>B1: ACK
-
-    B2->>Recv: Stream 2: BuildFinished
-    Recv->>State: Delete("bbb")
-    Recv-->>B2: ACK
-```
+![Concurrent invocations: two Bazel builds (uuid=aaa and uuid=bbb) open independent gRPC streams to the besreceiver, their BuildStarted events populate distinct entries in the invocations sync.Map, and inside a par block the receiver processes ActionExecuted events from both streams in parallel by loading each invocationState by UUID and emitting traces to consumer.Traces; BuildFinished for each stream deletes its map entry](sequence-concurrent.svg)
 
 ## Collector Startup Lifecycle
 
-```mermaid
-sequenceDiagram
-    participant Main as otelcol-bazel main()
-    participant Svc as Collector Service
-    participant Fac as besreceiver Factory
-    participant Recv as besreceiver
-    participant gRPC as gRPC Server
-
-    Main->>Svc: Run(collector-config.yaml)
-    Svc->>Fac: CreateTraces(settings, config, consumer)
-    Fac-->>Svc: besReceiver instance
-    Svc->>Recv: Start(ctx, host)
-    Recv->>gRPC: config.ServerConfig.ToServer()
-    Recv->>gRPC: RegisterPublishBuildEventServer()
-    Recv->>gRPC: Listen(0.0.0.0:8082)
-    Recv->>gRPC: go Serve()
-    Recv-->>Svc: nil (started)
-
-    Note over Svc: Collector running, accepting BEP streams...
-
-    Svc->>Recv: Shutdown(ctx)
-    Recv->>gRPC: GracefulStop()
-    Note over gRPC: Drain active streams
-    Recv-->>Svc: nil (stopped)
-```
+![Collector startup lifecycle: otelcol-bazel main() calls Run on the Collector Service, which invokes besreceiver Factory.CreateTraces to obtain a receiver instance, then calls Start; the receiver builds the gRPC server via ServerConfig.ToServer, registers the PublishBuildEvent service, listens on 0.0.0.0:8082, and spawns Serve in a goroutine; on Shutdown the receiver calls GracefulStop to drain active streams](sequence-startup.svg)


### PR DESCRIPTION
## Summary
- Converts the three Mermaid sequence diagrams in `docs/sequence.md` (BEP stream processing, concurrent invocations, collector startup lifecycle) to hand-authored SVGs under `docs/sequence-*.svg`, matching the visual language established for the architecture diagrams in #46 (same font stack, palette, actor-lane styling, arrow colors).
- Motivation: GitHub's native Mermaid renderer has poor contrast on dark theme — notes and arrow labels wash out. Hand-authored SVGs give us full control and stay consistent with `docs/architecture.md`.
- Follow-up commit reorders SVG z-order so the dashed component lifelines render across the phase bands (EVENT 1/2/3/N, STARTUP/RUNNING/SHUTDOWN) instead of being painted over by the band fill.

## Notable simplifications vs. the Mermaid originals
- BEP stream diagram: only Event 1 (BuildStarted) shows the full `ParseBazelEvent(Any) → BuildEvent → ProcessEvent` round-trip. Events 2 and N collapse that into a single `ParseBazelEvent → ProcessEvent(...)` arrow for vertical density. Semantics unchanged.
- Event 3 Builder note merges the four `mnemonic · exit_code · start_time · end_time` lines into a single three-line note.
- `... more actions/tests ...` rendered as a dashed separator band.

## Caveat
These SVGs inherit the same white-background choice as the architecture diagrams (#46) — they render well on light but appear as a bright rectangle on GitHub dark. A future pass could introduce `prefers-color-scheme` dark variants wrapped in `<picture>` tags for both docs; out of scope here.

## Test plan
- [x] Render `docs/sequence.md` on GitHub (both light and dark theme) and confirm all three diagrams display.
- [x] Verify lifelines are visible *across* each phase band, not cut off at the band boundaries.
- [x] Spot-check that the textual information in the SVGs matches the Mermaid originals in git history (pre-#47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)