### PR TITLE
docs(examples): add sample configs for Jaeger, Tempo, Grafana Cloud, OTLP

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,9 @@
 | `bazel-project/` | Minimal Bazel workspace with passing and failing tests for generating BES events. |
 | `custom-collector/` | Shows how to import `besreceiver` as a remote module and build your own collector image. |
 | `datadog/` | Development setup with live-reload (`air`) and a Datadog Agent sidecar. |
+| `jaeger/` | Self-contained stack: Jaeger all-in-one + `otelcol-bazel` for browsing spans in the Jaeger UI. |
+| `tempo/` | Self-contained stack: Tempo + Grafana (pre-provisioned Tempo datasource) + `otelcol-bazel`. |
+| `grafana-cloud/` | Sends traces/metrics/logs to Grafana Cloud over OTLP/HTTP with HTTP Basic auth. |
+| `otlp-generic/` | Forwards to any OTLP gRPC endpoint (Honeycomb, New Relic, internal gateway, ...). |
+
+All backend examples use the `otelcol-bazel:latest` image built via `make docker` from the repo root.

--- a/examples/grafana-cloud/README.md
+++ b/examples/grafana-cloud/README.md
@@ -1,0 +1,82 @@
+# Grafana Cloud
+
+Sends Bazel BEP traces, metrics, and logs to Grafana Cloud over OTLP/HTTP with
+HTTP Basic authentication. No local Tempo/Mimir/Loki needed — you use the
+hosted backends that come with your Grafana Cloud stack.
+
+## Prerequisites
+
+- A Grafana Cloud stack (the free tier is sufficient for evaluation)
+- A Cloud Access Policy token with scopes `traces:write`, `metrics:write`, and
+  `logs:write` — create one under **Administration → Access policies**
+- Docker and Docker Compose
+- `otelcol-bazel:latest` image built locally (`make docker` from the repo root)
+
+## Quick start
+
+1. Copy the env template and fill in credentials:
+
+   ```bash
+   cp .env.example .env
+   # edit .env: GRAFANA_CLOUD_OTLP_ENDPOINT, GRAFANA_CLOUD_OTLP_USERNAME,
+   # GRAFANA_CLOUD_OTLP_PASSWORD
+   ```
+
+   The three values are shown on the **OTLP Gateway** page of your stack
+   (Home → Connections → OpenTelemetry). The username is the numeric
+   "Instance ID"; the password is the access policy token.
+
+2. Start the collector:
+
+   ```bash
+   docker compose up -d
+   ```
+
+3. Point Bazel at the local collector:
+
+   ```bash
+   bazel build //... \
+     --bes_backend=grpc://localhost:8082 \
+     --build_event_publish_all_actions
+   ```
+
+4. In Grafana Cloud, open **Explore**, pick the Tempo datasource for your
+   stack, and query:
+
+   ```traceql
+   { name = "bazel.build" }
+   ```
+
+   Build metrics land in the Mimir datasource under `bazel_*` names; logs land
+   in Loki with `service_name="bes"`.
+
+## Verification
+
+```bash
+# Collector is healthy locally
+curl -fsS http://localhost:13133
+
+# Collector self-metrics show export attempts/successes
+curl -s http://localhost:8888/metrics | grep otelcol_exporter_sent_spans
+
+# Inspect collector logs for auth errors (401 / 403) or TLS issues
+docker compose logs -f otelcol-bazel
+```
+
+If you see `401 Unauthorized`, regenerate the access policy token and confirm
+it has all three `*:write` scopes. If you see DNS errors, double-check that
+`GRAFANA_CLOUD_OTLP_ENDPOINT` matches your stack's region.
+
+## Teardown
+
+```bash
+docker compose down
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `collector-config.yaml` | BES receiver → OTLP/HTTP with basic auth |
+| `.env.example` | Template for OTLP endpoint + Basic auth credentials |
+| `docker-compose.yaml` | Runs `otelcol-bazel:latest` with `.env` loaded |

--- a/examples/grafana-cloud/collector-config.yaml
+++ b/examples/grafana-cloud/collector-config.yaml
@@ -1,0 +1,103 @@
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+  # Grafana Cloud authenticates OTLP requests with HTTP Basic auth. The
+  # username is the "Instance ID" shown on the OTLP endpoint settings page and
+  # the password is a Cloud Access Policy token with scope `traces:write`
+  # (and `metrics:write` / `logs:write` for the other pipelines).
+  basicauth/grafana_cloud:
+    client_auth:
+      username: ${env:GRAFANA_CLOUD_OTLP_USERNAME}
+      password: ${env:GRAFANA_CLOUD_OTLP_PASSWORD}
+
+receivers:
+  bes:
+    endpoint: "0.0.0.0:8082"
+    # PII controls — all default to false. Gating is by content: if
+    # include_hostname is false, no hostname-like attribute is emitted
+    # regardless of which pathway it arrived on. See docs/attributes.md
+    # for the full composition model.
+    # pii:
+    #   include_hostname: false            # bazel.host + host-like workspace/metadata keys
+    #   include_username: false            # bazel.user + user-like workspace/metadata keys
+    #   include_workspace_dir: false       # bazel.workspace_directory
+    #   include_working_dir: false         # bazel.working_directory
+    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_action_output_paths: false # bazel.action.primary_output
+    #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
+    #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
+    #   include_command_line: false        # bazel.command_line (coarse only)
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+    send_batch_size: 8192
+    send_batch_max_size: 8192
+    timeout: 200ms
+  # Uncomment and add to the traces pipeline (after memory_limiter, before batch)
+  # to drop spans by attribute. See the filterprocessor docs for OTTL syntax.
+  # filter/targets:
+  #   traces:
+  #     span:
+  #       - 'attributes["bazel.target.label"] != nil and IsMatch(attributes["bazel.target.label"], "^//third_party/")'
+  # Uncomment and add to each pipeline's processors list (after memory_limiter,
+  # before batch) to scrub sensitive attributes before export.
+  # redaction:
+  #   allow_all_keys: true
+  #   blocked_key_patterns:
+  #     - ".*user.*"
+  #     - ".*email.*"
+  #     - ".*token.*"
+  #   blocked_values:
+  #     - "(?i)bearer\\s+[A-Za-z0-9._\\-]+"
+  #     - "[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}"
+  #   summary: debug
+
+exporters:
+  # Grafana Cloud OTLP endpoint is HTTP-only (gRPC is not exposed publicly).
+  # Override GRAFANA_CLOUD_OTLP_ENDPOINT in .env — e.g.
+  # https://otlp-gateway-prod-us-central-0.grafana.net/otlp
+  otlphttp/grafana_cloud:
+    endpoint: ${env:GRAFANA_CLOUD_OTLP_ENDPOINT}
+    auth:
+      authenticator: basicauth/grafana_cloud
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+  debug:
+    verbosity: basic
+
+service:
+  extensions: [health_check, basicauth/grafana_cloud]
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 8888
+  pipelines:
+    traces:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp/grafana_cloud, debug]
+    metrics:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp/grafana_cloud]
+    logs:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp/grafana_cloud]

--- a/examples/grafana-cloud/docker-compose.yaml
+++ b/examples/grafana-cloud/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  otelcol-bazel:
+    image: otelcol-bazel:latest
+    container_name: otelcol-bazel
+    command: ["--config", "/etc/otelcol-bazel/config.yaml"]
+    env_file:
+      - path: .env
+        required: true
+    volumes:
+      - ./collector-config.yaml:/etc/otelcol-bazel/config.yaml:ro
+    ports:
+      - "8082:8082"   # BES gRPC
+      - "13133:13133" # health_check
+      - "8888:8888"   # collector self-metrics (Prometheus)
+    restart: unless-stopped

--- a/examples/jaeger/README.md
+++ b/examples/jaeger/README.md
@@ -1,0 +1,57 @@
+# Jaeger
+
+Self-contained stack that sends Bazel BEP events to a local Jaeger all-in-one.
+Good for inspecting the span hierarchy produced by `besreceiver` without any
+external accounts or network dependencies.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- `otelcol-bazel:latest` image built locally (`make docker` from the repo root)
+- A Bazel workspace to point at the BES endpoint (see `examples/bazel-project/`)
+
+## Quick start
+
+```bash
+docker compose up -d
+```
+
+Point Bazel at the collector:
+
+```bash
+bazel build //... \
+  --bes_backend=grpc://localhost:8082 \
+  --build_event_publish_all_actions
+```
+
+Open the Jaeger UI at <http://localhost:16686>, pick the `bes` service, and look
+for `bazel.build` root spans.
+
+## Verification
+
+```bash
+# Collector is healthy
+curl -fsS http://localhost:13133
+
+# BES gRPC port is listening
+nc -z localhost 8082
+
+# Collector self-metrics (span counts, queue size, etc.)
+curl -s http://localhost:8888/metrics | grep otelcol_receiver_accepted_spans
+```
+
+## Teardown
+
+```bash
+docker compose down
+```
+
+## Ports
+
+| Port | Service | Purpose |
+|---|---|---|
+| `8082` | otelcol-bazel | BES gRPC (Bazel clients connect here) |
+| `13133` | otelcol-bazel | health_check extension |
+| `8888` | otelcol-bazel | Prometheus self-metrics |
+| `16686` | jaeger | Jaeger UI |
+| `4317` | jaeger | OTLP gRPC (exposed for debugging; collector uses internal DNS) |

--- a/examples/jaeger/collector-config.yaml
+++ b/examples/jaeger/collector-config.yaml
@@ -1,0 +1,97 @@
+extensions:
+  health_check:
+    # Bound to 0.0.0.0 so compose/kubelet probes can reach it across networks.
+    endpoint: "0.0.0.0:13133"
+
+receivers:
+  bes:
+    # Bound to 0.0.0.0 so Bazel clients on the host can reach the BES gRPC
+    # endpoint through the published port.
+    endpoint: "0.0.0.0:8082"
+    # Uncomment to enable mutual TLS on the BES gRPC endpoint.
+    # tls:
+    #   cert_file: /etc/otelcol/certs/server.crt
+    #   key_file: /etc/otelcol/certs/server.key
+    #   client_ca_file: /etc/otelcol/certs/ca.crt
+    # PII controls — all default to false. Gating is by content: if
+    # include_hostname is false, no hostname-like attribute is emitted
+    # regardless of which pathway it arrived on. See docs/attributes.md
+    # for the full composition model.
+    # pii:
+    #   include_hostname: false            # bazel.host + host-like workspace/metadata keys
+    #   include_username: false            # bazel.user + user-like workspace/metadata keys
+    #   include_workspace_dir: false       # bazel.workspace_directory
+    #   include_working_dir: false         # bazel.working_directory
+    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_action_output_paths: false # bazel.action.primary_output
+    #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
+    #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
+    #   include_command_line: false        # bazel.command_line (coarse only)
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+    send_batch_size: 8192
+    send_batch_max_size: 8192
+    timeout: 200ms
+  # Uncomment and add to the traces pipeline (after memory_limiter, before batch)
+  # to drop spans by attribute. Useful for filtering out noisy targets or actions
+  # before they reach the backend. See the filterprocessor docs for syntax.
+  # filter/targets:
+  #   traces:
+  #     span:
+  #       - 'attributes["bazel.target.label"] != nil and IsMatch(attributes["bazel.target.label"], "^//third_party/")'
+  # Uncomment and add to each pipeline's processors list (after memory_limiter,
+  # before batch) to scrub sensitive attributes before export. Regex-based
+  # value redaction is expensive — prefer blocked_key_patterns when possible.
+  # redaction:
+  #   allow_all_keys: true
+  #   blocked_key_patterns:
+  #     - ".*user.*"
+  #     - ".*email.*"
+  #     - ".*token.*"
+  #   blocked_values:
+  #     - "(?i)bearer\\s+[A-Za-z0-9._\\-]+"
+  #     - "[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}"
+  #   summary: debug
+
+exporters:
+  otlp/jaeger:
+    # Jaeger all-in-one exposes an OTLP gRPC receiver on 4317 since v1.35.
+    endpoint: "jaeger:4317"
+    tls:
+      insecure: true
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+  debug:
+    verbosity: basic
+
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 8888
+  pipelines:
+    traces:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/jaeger, debug]
+    # Jaeger does not ingest logs or metrics; keep those pipelines off or
+    # route them to a different exporter if you need them.

--- a/examples/jaeger/docker-compose.yaml
+++ b/examples/jaeger/docker-compose.yaml
@@ -1,0 +1,24 @@
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.62
+    container_name: jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686" # Jaeger UI
+      - "4317:4317"   # OTLP gRPC (only exposed for debugging; collector uses the internal network)
+    restart: unless-stopped
+
+  otelcol-bazel:
+    image: otelcol-bazel:latest
+    container_name: otelcol-bazel
+    command: ["--config", "/etc/otelcol-bazel/config.yaml"]
+    volumes:
+      - ./collector-config.yaml:/etc/otelcol-bazel/config.yaml:ro
+    ports:
+      - "8082:8082"   # BES gRPC
+      - "13133:13133" # health_check
+      - "8888:8888"   # collector self-metrics (Prometheus)
+    depends_on:
+      - jaeger
+    restart: unless-stopped

--- a/examples/otlp-generic/README.md
+++ b/examples/otlp-generic/README.md
@@ -1,0 +1,83 @@
+# Generic OTLP
+
+Minimal collector that forwards Bazel BEP traces, metrics, and logs to any
+OTLP-compatible gRPC endpoint. Use this as the starting point for backends
+without a dedicated example — Honeycomb, New Relic, Uptrace, Signoz, a shared
+internal gateway, etc.
+
+## Prerequisites
+
+- An OTLP gRPC endpoint reachable from the collector container
+- Docker and Docker Compose
+- `otelcol-bazel:latest` image built locally (`make docker` from the repo root)
+
+## Quick start
+
+1. Copy the env template and point at your OTLP endpoint:
+
+   ```bash
+   cp .env.example .env
+   # edit .env: OTLP_ENDPOINT=your.backend:4317, OTLP_INSECURE=false for TLS
+   ```
+
+2. Start the collector:
+
+   ```bash
+   docker compose up -d
+   ```
+
+3. Point Bazel at the local collector:
+
+   ```bash
+   bazel build //... \
+     --bes_backend=grpc://localhost:8082 \
+     --build_event_publish_all_actions
+   ```
+
+## Adding auth headers
+
+Most hosted OTLP backends expect a bearer token or per-vendor header. Uncomment
+the `headers:` block in `collector-config.yaml` and set values from environment
+variables. Example for Honeycomb:
+
+```yaml
+exporters:
+  otlp:
+    endpoint: ${env:OTLP_ENDPOINT}
+    tls:
+      insecure: false
+    headers:
+      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+      x-honeycomb-dataset: bazel-builds
+```
+
+For backends that use OAuth2 bearer tokens, uncomment the
+`bearertokenauth/otlp` extension and the matching `auth.authenticator`
+reference on the exporter.
+
+## Verification
+
+```bash
+# Collector is healthy
+curl -fsS http://localhost:13133
+
+# Export counters climb after a Bazel build
+curl -s http://localhost:8888/metrics | grep otelcol_exporter_sent
+
+# Watch for export errors (TLS / auth / endpoint unreachable)
+docker compose logs -f otelcol-bazel
+```
+
+## Teardown
+
+```bash
+docker compose down
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `collector-config.yaml` | BES receiver → generic OTLP gRPC exporter |
+| `.env.example` | `OTLP_ENDPOINT` + `OTLP_INSECURE` template |
+| `docker-compose.yaml` | Runs `otelcol-bazel:latest` with `.env` loaded |

--- a/examples/otlp-generic/collector-config.yaml
+++ b/examples/otlp-generic/collector-config.yaml
@@ -1,0 +1,122 @@
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+  # Uncomment to require a bearer token from Bazel clients (BES gRPC side).
+  # Must also be listed under service.extensions and referenced from
+  # receivers.bes.auth.authenticator.
+  # bearertokenauth/bes:
+  #   scheme: "Bearer"
+  #   tokens:
+  #     - "REPLACE_WITH_SECRET_TOKEN"
+  # Uncomment if the downstream OTLP endpoint expects a bearer token on export.
+  # bearertokenauth/otlp:
+  #   scheme: "Bearer"
+  #   token: ${env:OTLP_BEARER_TOKEN}
+
+receivers:
+  bes:
+    endpoint: "0.0.0.0:8082"
+    # Uncomment alongside bearertokenauth/bes above to enforce auth on BES.
+    # auth:
+    #   authenticator: bearertokenauth/bes
+    # Uncomment to enable mutual TLS on the BES gRPC endpoint.
+    # tls:
+    #   cert_file: /etc/otelcol/certs/server.crt
+    #   key_file: /etc/otelcol/certs/server.key
+    #   client_ca_file: /etc/otelcol/certs/ca.crt
+    # PII controls — all default to false. Gating is by content: if
+    # include_hostname is false, no hostname-like attribute is emitted
+    # regardless of which pathway it arrived on. See docs/attributes.md
+    # for the full composition model.
+    # pii:
+    #   include_hostname: false            # bazel.host + host-like workspace/metadata keys
+    #   include_username: false            # bazel.user + user-like workspace/metadata keys
+    #   include_workspace_dir: false       # bazel.workspace_directory
+    #   include_working_dir: false         # bazel.working_directory
+    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_action_output_paths: false # bazel.action.primary_output
+    #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
+    #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
+    #   include_command_line: false        # bazel.command_line (coarse only)
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+    send_batch_size: 8192
+    send_batch_max_size: 8192
+    timeout: 200ms
+  # Uncomment and add to the traces pipeline (after memory_limiter, before batch)
+  # to drop spans by attribute. See the filterprocessor docs for OTTL syntax.
+  # filter/targets:
+  #   traces:
+  #     span:
+  #       - 'attributes["bazel.target.label"] != nil and IsMatch(attributes["bazel.target.label"], "^//third_party/")'
+  # Uncomment and add to each pipeline's processors list (after memory_limiter,
+  # before batch) to scrub sensitive attributes before export.
+  # redaction:
+  #   allow_all_keys: true
+  #   blocked_key_patterns:
+  #     - ".*user.*"
+  #     - ".*email.*"
+  #     - ".*token.*"
+  #   blocked_values:
+  #     - "(?i)bearer\\s+[A-Za-z0-9._\\-]+"
+  #     - "[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}"
+  #   summary: debug
+
+exporters:
+  # Generic OTLP gRPC exporter. Override OTLP_ENDPOINT in .env (or your
+  # deployment env) to point at any OTLP-compatible backend:
+  # contrib collector, Honeycomb, New Relic, Uptrace, Signoz, etc.
+  otlp:
+    endpoint: ${env:OTLP_ENDPOINT}
+    # Flip to false + configure ca_file when targeting TLS-terminated endpoints.
+    tls:
+      insecure: ${env:OTLP_INSECURE}
+    # Uncomment if the backend expects a bearer token.
+    # auth:
+    #   authenticator: bearertokenauth/otlp
+    # Attach per-backend headers if needed (API keys, team IDs, dataset names).
+    # headers:
+    #   x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+    #   x-honeycomb-dataset: bazel-builds
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+  debug:
+    verbosity: basic
+
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 8888
+  pipelines:
+    traces:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp, debug]
+    metrics:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]
+    logs:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]

--- a/examples/otlp-generic/docker-compose.yaml
+++ b/examples/otlp-generic/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  otelcol-bazel:
+    image: otelcol-bazel:latest
+    container_name: otelcol-bazel
+    command: ["--config", "/etc/otelcol-bazel/config.yaml"]
+    env_file:
+      - path: .env
+        required: true
+    volumes:
+      - ./collector-config.yaml:/etc/otelcol-bazel/config.yaml:ro
+    ports:
+      - "8082:8082"   # BES gRPC
+      - "13133:13133" # health_check
+      - "8888:8888"   # collector self-metrics (Prometheus)
+    # The upstream OTLP endpoint is reached directly from the collector
+    # container — no extra service needed. If you run a local collector or
+    # backend on the host, point OTLP_ENDPOINT at host.docker.internal:<port>.
+    restart: unless-stopped

--- a/examples/tempo/README.md
+++ b/examples/tempo/README.md
@@ -1,0 +1,73 @@
+# Grafana Tempo
+
+Self-contained stack running Tempo (single-binary) behind Grafana with a
+pre-provisioned Tempo datasource. Good for exploring trace data with TraceQL
+and the service graph without signing up for a hosted backend.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- `otelcol-bazel:latest` image built locally (`make docker` from the repo root)
+- A Bazel workspace to point at the BES endpoint
+
+## Quick start
+
+```bash
+docker compose up -d
+```
+
+Point Bazel at the collector:
+
+```bash
+bazel build //... \
+  --bes_backend=grpc://localhost:8082 \
+  --build_event_publish_all_actions
+```
+
+Open Grafana at <http://localhost:3000> (anonymous admin is enabled), pick the
+Tempo datasource, and run a TraceQL query such as:
+
+```traceql
+{ name = "bazel.build" }
+```
+
+Individual target spans can be filtered by label, e.g.
+`{ span.bazel.target.label =~ "//pkg/.*" }`.
+
+## Verification
+
+```bash
+# Collector is healthy
+curl -fsS http://localhost:13133
+
+# Tempo ready (returns "ready")
+curl -fsS http://localhost:3200/ready
+
+# Grafana ping
+curl -fsS http://localhost:3000/api/health
+```
+
+## Teardown
+
+```bash
+docker compose down -v   # -v also removes the tempo-data volume
+```
+
+## Ports
+
+| Port | Service | Purpose |
+|---|---|---|
+| `8082` | otelcol-bazel | BES gRPC |
+| `13133` | otelcol-bazel | health_check |
+| `8888` | otelcol-bazel | Prometheus self-metrics |
+| `3200` | tempo | Tempo HTTP query API |
+| `3000` | grafana | Grafana UI |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `collector-config.yaml` | BES receiver → OTLP gRPC → Tempo |
+| `tempo.yaml` | Tempo single-binary config (local disk storage, 1h retention) |
+| `grafana/provisioning/datasources/tempo.yaml` | Pre-configured Tempo datasource |
+| `docker-compose.yaml` | Tempo + Grafana + otelcol-bazel |

--- a/examples/tempo/collector-config.yaml
+++ b/examples/tempo/collector-config.yaml
@@ -1,0 +1,84 @@
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+
+receivers:
+  bes:
+    endpoint: "0.0.0.0:8082"
+    # PII controls — all default to false. Gating is by content: if
+    # include_hostname is false, no hostname-like attribute is emitted
+    # regardless of which pathway it arrived on. See docs/attributes.md
+    # for the full composition model.
+    # pii:
+    #   include_hostname: false            # bazel.host + host-like workspace/metadata keys
+    #   include_username: false            # bazel.user + user-like workspace/metadata keys
+    #   include_workspace_dir: false       # bazel.workspace_directory
+    #   include_working_dir: false         # bazel.working_directory
+    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_action_output_paths: false # bazel.action.primary_output
+    #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
+    #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
+    #   include_command_line: false        # bazel.command_line (coarse only)
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+    send_batch_size: 8192
+    send_batch_max_size: 8192
+    timeout: 200ms
+  # Uncomment and add to the traces pipeline (after memory_limiter, before batch)
+  # to drop spans by attribute. See the filterprocessor docs for OTTL syntax.
+  # filter/targets:
+  #   traces:
+  #     span:
+  #       - 'attributes["bazel.target.label"] != nil and IsMatch(attributes["bazel.target.label"], "^//third_party/")'
+  # Uncomment and add to each pipeline's processors list (after memory_limiter,
+  # before batch) to scrub sensitive attributes before export.
+  # redaction:
+  #   allow_all_keys: true
+  #   blocked_key_patterns:
+  #     - ".*user.*"
+  #     - ".*email.*"
+  #     - ".*token.*"
+  #   blocked_values:
+  #     - "(?i)bearer\\s+[A-Za-z0-9._\\-]+"
+  #     - "[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}"
+  #   summary: debug
+
+exporters:
+  otlp/tempo:
+    endpoint: "tempo:4317"
+    tls:
+      insecure: true
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+  debug:
+    verbosity: basic
+
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 8888
+  pipelines:
+    traces:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/tempo, debug]

--- a/examples/tempo/docker-compose.yaml
+++ b/examples/tempo/docker-compose.yaml
@@ -1,0 +1,44 @@
+services:
+  tempo:
+    image: grafana/tempo:2.6.1
+    container_name: tempo
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    ports:
+      - "3200:3200" # Tempo HTTP (query API)
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - tempo
+    restart: unless-stopped
+
+  otelcol-bazel:
+    image: otelcol-bazel:latest
+    container_name: otelcol-bazel
+    command: ["--config", "/etc/otelcol-bazel/config.yaml"]
+    volumes:
+      - ./collector-config.yaml:/etc/otelcol-bazel/config.yaml:ro
+    ports:
+      - "8082:8082"   # BES gRPC
+      - "13133:13133" # health_check
+      - "8888:8888"   # collector self-metrics (Prometheus)
+    depends_on:
+      - tempo
+    restart: unless-stopped
+
+volumes:
+  tempo-data:

--- a/examples/tempo/grafana/provisioning/datasources/tempo.yaml
+++ b/examples/tempo/grafana/provisioning/datasources/tempo.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: true
+    uid: tempo
+    jsonData:
+      # Enables the "Node graph" and "Service graph" panels in the Tempo UI.
+      nodeGraph:
+        enabled: true
+      search:
+        hide: false

--- a/examples/tempo/tempo.yaml
+++ b/examples/tempo/tempo.yaml
@@ -1,0 +1,30 @@
+# Minimal Tempo single-binary config. Accepts OTLP on gRPC (4317) and HTTP
+# (4318), stores blocks on local disk. Not production-grade — single replica,
+# no retention policy, no WAL tuning. Swap the storage backend for S3/GCS in
+# production and front Tempo with an ingester/distributor split.
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks


### PR DESCRIPTION
Adds ready-to-use example collector configurations for four backends beyond the existing Datadog sample. Each directory under `examples/` is self-contained with a pinned-image `docker-compose.yaml`, a `collector-config.yaml` that includes commented `filter` and `redaction` stubs plus the `health_check` extension on `:13133`, and a README covering prerequisites, quick start, verification, and teardown. The `examples/README.md` index is updated to point at the new directories and notes that they expect a locally-built `otelcol-bazel:latest` image.

Closes #16.