### PR TITLE
feat(packaging): add systemd and launchd platform installers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all build test test-short test-cover test-bench test-e2e lint vet clean fuzz fix generate ocb ci docker \
-       compose-build compose-up compose-down compose-clean example record record-fixtures agent-status nilaway deadcode changelog
+       compose-build compose-up compose-down compose-clean example record record-fixtures agent-status nilaway deadcode changelog \
+       install uninstall
 
 # Use absolute path: GNU Make 3.81 (macOS default) doesn't propagate export PATH to recipe shells.
 GOTESTSUM := $(shell go env GOPATH)/bin/gotestsum
@@ -136,3 +137,12 @@ agent-status:
 ## changelog: Generate CHANGELOG.md from conventional commits
 changelog:
 	git-cliff -o CHANGELOG.md
+
+## install: Install besreceiver as a system service (systemd on Linux, launchd on macOS); pass BINARY=path/to/besreceiver
+install:
+	sudo BESRECEIVER_BINARY="$(BINARY)" BESRECEIVER_CONFIG="$(BESRECEIVER_CONFIG)" \
+		packaging/install.sh $(INSTALL_ARGS)
+
+## uninstall: Remove the besreceiver service, binary, and config (pass CONFIRM=1 to actually remove)
+uninstall:
+	sudo packaging/uninstall.sh $(if $(CONFIRM),--yes,) $(UNINSTALL_ARGS)

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# install.sh — install besreceiver as a managed service on Linux (systemd) or macOS (launchd).
+#
+# Idempotent: safe to re-run. Existing files are overwritten; existing users are reused;
+# an already-loaded launchd job or an enabled systemd unit is re-enabled without error.
+#
+# Does NOT build the binary. Pass --binary to point at a pre-built binary, or let the
+# script use the first of: $BESRECEIVER_BINARY, ./build/besreceiver, ./besreceiver.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+SERVICE_USER="${SERVICE_USER:-besreceiver}"
+SERVICE_GROUP="${SERVICE_GROUP:-besreceiver}"
+LAUNCHD_LABEL="com.github.chagui.besreceiver"
+
+BINARY_SRC=""
+CONFIG_SRC=""
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --binary PATH    Path to pre-built besreceiver binary (required if not discoverable)
+  --config PATH    Path to a collector config.yaml to install (optional; default sample if omitted)
+  -h, --help       Show this help
+
+Environment:
+  BESRECEIVER_BINARY  Alternative to --binary
+  BESRECEIVER_CONFIG  Installation path for the config file
+                      (default: /etc/besreceiver/config.yaml on Linux,
+                       /usr/local/etc/besreceiver/config.yaml on macOS)
+  SERVICE_USER        Service user on Linux (default: besreceiver)
+  SERVICE_GROUP       Service group on Linux (default: besreceiver)
+EOF
+}
+
+log()  { printf '[install] %s\n' "$*"; }
+warn() { printf '[install] WARN: %s\n' "$*" >&2; }
+die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_root() {
+    if [[ "${EUID}" -ne 0 ]]; then
+        die "must run as root (try: sudo $0 $*)"
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --binary) BINARY_SRC="$2"; shift 2;;
+            --config) CONFIG_SRC="$2"; shift 2;;
+            -h|--help) usage; exit 0;;
+            *) die "unknown argument: $1";;
+        esac
+    done
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux)  echo "linux";;
+        Darwin) echo "darwin";;
+        *)      die "unsupported OS: $(uname -s)";;
+    esac
+}
+
+resolve_binary() {
+    if [[ -n "${BINARY_SRC}" ]]; then
+        [[ -x "${BINARY_SRC}" ]] || die "binary not executable: ${BINARY_SRC}"
+        return
+    fi
+    if [[ -n "${BESRECEIVER_BINARY:-}" ]]; then
+        BINARY_SRC="${BESRECEIVER_BINARY}"
+    elif [[ -x "${REPO_ROOT}/build/besreceiver" ]]; then
+        BINARY_SRC="${REPO_ROOT}/build/besreceiver"
+    elif [[ -x "${REPO_ROOT}/besreceiver" ]]; then
+        BINARY_SRC="${REPO_ROOT}/besreceiver"
+    else
+        die "no binary found; pass --binary PATH or set BESRECEIVER_BINARY (installer does not build)"
+    fi
+    [[ -x "${BINARY_SRC}" ]] || die "binary not executable: ${BINARY_SRC}"
+}
+
+install_file() {
+    # install_file SRC DST MODE [OWNER:GROUP]
+    local src="$1" dst="$2" mode="$3" owner="${4:-}"
+    local dst_dir
+    dst_dir="$(dirname "${dst}")"
+    mkdir -p "${dst_dir}"
+    cp "${src}" "${dst}"
+    chmod "${mode}" "${dst}"
+    if [[ -n "${owner}" ]]; then
+        chown "${owner}" "${dst}"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Linux (systemd)
+# -----------------------------------------------------------------------------
+
+linux_paths() {
+    BIN_DIR="/usr/local/bin"
+    CONFIG_DIR="/etc/besreceiver"
+    CONFIG_PATH="${BESRECEIVER_CONFIG:-${CONFIG_DIR}/config.yaml}"
+    LOG_DIR="/var/log/besreceiver"
+    DATA_DIR="/var/lib/besreceiver"
+    UNIT_PATH="/etc/systemd/system/besreceiver.service"
+    UNIT_SRC="${SCRIPT_DIR}/systemd/besreceiver.service"
+}
+
+linux_ensure_user() {
+    if getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+        log "group ${SERVICE_GROUP} already exists"
+    else
+        log "creating group ${SERVICE_GROUP}"
+        groupadd --system "${SERVICE_GROUP}"
+    fi
+    if id "${SERVICE_USER}" >/dev/null 2>&1; then
+        log "user ${SERVICE_USER} already exists"
+    else
+        log "creating system user ${SERVICE_USER}"
+        useradd --system --no-create-home --shell /usr/sbin/nologin \
+            --gid "${SERVICE_GROUP}" "${SERVICE_USER}"
+    fi
+}
+
+linux_install() {
+    require_root "$@"
+    command -v systemctl >/dev/null 2>&1 || die "systemctl not found; this installer requires systemd"
+
+    linux_paths
+    linux_ensure_user
+
+    log "installing binary to ${BIN_DIR}/besreceiver"
+    install_file "${BINARY_SRC}" "${BIN_DIR}/besreceiver" 0755 "root:root"
+
+    log "creating directories"
+    mkdir -p "${CONFIG_DIR}" "${LOG_DIR}" "${DATA_DIR}"
+    chown "${SERVICE_USER}:${SERVICE_GROUP}" "${LOG_DIR}" "${DATA_DIR}"
+    chmod 0750 "${LOG_DIR}" "${DATA_DIR}"
+
+    if [[ -n "${CONFIG_SRC}" ]]; then
+        log "installing config from ${CONFIG_SRC} to ${CONFIG_PATH}"
+        install_file "${CONFIG_SRC}" "${CONFIG_PATH}" 0640 "root:${SERVICE_GROUP}"
+    elif [[ ! -f "${CONFIG_PATH}" ]]; then
+        if [[ -f "${REPO_ROOT}/collector-config.yaml" ]]; then
+            log "installing sample config from collector-config.yaml to ${CONFIG_PATH}"
+            install_file "${REPO_ROOT}/collector-config.yaml" "${CONFIG_PATH}" 0640 "root:${SERVICE_GROUP}"
+        else
+            warn "no config provided and ${CONFIG_PATH} does not exist; service will fail to start until one is created"
+        fi
+    else
+        log "config already present at ${CONFIG_PATH} (keeping existing)"
+    fi
+
+    log "installing systemd unit at ${UNIT_PATH}"
+    # Substitute BESRECEIVER_CONFIG default to match install location.
+    sed "s|Environment=BESRECEIVER_CONFIG=/etc/besreceiver/config.yaml|Environment=BESRECEIVER_CONFIG=${CONFIG_PATH}|" \
+        "${UNIT_SRC}" > "${UNIT_PATH}.tmp"
+    mv "${UNIT_PATH}.tmp" "${UNIT_PATH}"
+    chmod 0644 "${UNIT_PATH}"
+
+    log "reloading systemd"
+    systemctl daemon-reload
+
+    log "enabling and (re)starting besreceiver.service"
+    systemctl enable besreceiver.service
+    # restart is idempotent: starts if stopped, restarts if running.
+    systemctl restart besreceiver.service
+
+    log "done. Check status with: systemctl status besreceiver"
+}
+
+# -----------------------------------------------------------------------------
+# macOS (launchd)
+# -----------------------------------------------------------------------------
+
+darwin_paths() {
+    BIN_DIR="/usr/local/bin"
+    CONFIG_DIR="/usr/local/etc/besreceiver"
+    CONFIG_PATH="${BESRECEIVER_CONFIG:-${CONFIG_DIR}/config.yaml}"
+    LOG_DIR="/usr/local/var/log/besreceiver"
+    DATA_DIR="/usr/local/var/lib/besreceiver"
+    PLIST_PATH="/Library/LaunchDaemons/${LAUNCHD_LABEL}.plist"
+    PLIST_SRC="${SCRIPT_DIR}/launchd/${LAUNCHD_LABEL}.plist"
+}
+
+darwin_install() {
+    require_root "$@"
+    command -v launchctl >/dev/null 2>&1 || die "launchctl not found"
+
+    darwin_paths
+
+    log "installing binary to ${BIN_DIR}/besreceiver"
+    install_file "${BINARY_SRC}" "${BIN_DIR}/besreceiver" 0755
+
+    log "creating directories"
+    mkdir -p "${CONFIG_DIR}" "${LOG_DIR}" "${DATA_DIR}"
+
+    if [[ -n "${CONFIG_SRC}" ]]; then
+        log "installing config from ${CONFIG_SRC} to ${CONFIG_PATH}"
+        install_file "${CONFIG_SRC}" "${CONFIG_PATH}" 0644
+    elif [[ ! -f "${CONFIG_PATH}" ]]; then
+        if [[ -f "${REPO_ROOT}/collector-config.yaml" ]]; then
+            log "installing sample config from collector-config.yaml to ${CONFIG_PATH}"
+            install_file "${REPO_ROOT}/collector-config.yaml" "${CONFIG_PATH}" 0644
+        else
+            warn "no config provided and ${CONFIG_PATH} does not exist; service will fail to start until one is created"
+        fi
+    else
+        log "config already present at ${CONFIG_PATH} (keeping existing)"
+    fi
+
+    log "installing launchd plist at ${PLIST_PATH}"
+    # Substitute config path to match install location.
+    sed "s|/usr/local/etc/besreceiver/config.yaml|${CONFIG_PATH}|g" \
+        "${PLIST_SRC}" > "${PLIST_PATH}.tmp"
+    mv "${PLIST_PATH}.tmp" "${PLIST_PATH}"
+    chown root:wheel "${PLIST_PATH}"
+    chmod 0644 "${PLIST_PATH}"
+
+    if launchctl print "system/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+        log "unloading existing launchd job (for idempotent reload)"
+        launchctl bootout "system/${LAUNCHD_LABEL}" || true
+    fi
+
+    log "bootstrapping launchd job"
+    launchctl bootstrap system "${PLIST_PATH}"
+    launchctl enable "system/${LAUNCHD_LABEL}"
+    launchctl kickstart -k "system/${LAUNCHD_LABEL}"
+
+    log "done. Check status with: launchctl print system/${LAUNCHD_LABEL}"
+}
+
+main() {
+    parse_args "$@"
+    resolve_binary
+
+    local os
+    os="$(detect_os)"
+    log "detected OS: ${os}; binary source: ${BINARY_SRC}"
+
+    case "${os}" in
+        linux)  linux_install "$@";;
+        darwin) darwin_install "$@";;
+    esac
+}
+
+main "$@"

--- a/packaging/launchd/com.github.chagui.besreceiver.plist
+++ b/packaging/launchd/com.github.chagui.besreceiver.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.github.chagui.besreceiver</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/besreceiver</string>
+        <string>--config=/usr/local/etc/besreceiver/config.yaml</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>BESRECEIVER_CONFIG</key>
+        <string>/usr/local/etc/besreceiver/config.yaml</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/besreceiver/besreceiver.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/besreceiver/besreceiver.err.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>/usr/local/var/lib/besreceiver</string>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
+</dict>
+</plist>

--- a/packaging/systemd/besreceiver.service
+++ b/packaging/systemd/besreceiver.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=besreceiver - Bazel BES to OpenTelemetry collector
+Documentation=https://github.com/chagui/besreceiver
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=besreceiver
+Group=besreceiver
+EnvironmentFile=-/etc/besreceiver/besreceiver.env
+Environment=BESRECEIVER_CONFIG=/etc/besreceiver/config.yaml
+ExecStart=/usr/local/bin/besreceiver --config=${BESRECEIVER_CONFIG}
+Restart=on-failure
+RestartSec=5s
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=30s
+LimitNOFILE=65536
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+ProtectProc=invisible
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+CapabilityBoundingSet=
+AmbientCapabilities=
+ReadWritePaths=/var/log/besreceiver /var/lib/besreceiver
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/uninstall.sh
+++ b/packaging/uninstall.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# uninstall.sh — remove besreceiver service, binary, and configuration.
+#
+# Idempotent: safe to re-run. Missing components are skipped with an informational message.
+#
+# Requires --yes to actually perform destructive operations. Without --yes, the script
+# prints what it would do and exits.
+
+set -euo pipefail
+
+SERVICE_USER="${SERVICE_USER:-besreceiver}"
+SERVICE_GROUP="${SERVICE_GROUP:-besreceiver}"
+LAUNCHD_LABEL="com.github.chagui.besreceiver"
+
+CONFIRM="no"
+PURGE_USER="no"
+KEEP_CONFIG="no"
+
+usage() {
+    cat <<EOF
+Usage: $0 --yes [options]
+
+Without --yes the script runs in dry-run mode and prints what it would remove.
+
+Options:
+  --yes           Actually perform destructive operations
+  --keep-config   Do not remove configuration files or config directory
+  --purge-user    Also remove the dedicated service user/group on Linux
+  -h, --help      Show this help
+
+Environment:
+  SERVICE_USER    Service user on Linux (default: besreceiver)
+  SERVICE_GROUP   Service group on Linux (default: besreceiver)
+EOF
+}
+
+log()    { printf '[uninstall] %s\n' "$*"; }
+warn()   { printf '[uninstall] WARN: %s\n' "$*" >&2; }
+die()    { printf '[uninstall] ERROR: %s\n' "$*" >&2; exit 1; }
+action() { # action "description" cmd args...
+    local desc="$1"; shift
+    if [[ "${CONFIRM}" == "yes" ]]; then
+        log "${desc}"
+        "$@" || warn "command failed (continuing): $*"
+    else
+        log "DRY-RUN would: ${desc}"
+    fi
+}
+
+require_root() {
+    if [[ "${EUID}" -ne 0 ]]; then
+        die "must run as root (try: sudo $0 $*)"
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes)         CONFIRM="yes"; shift;;
+            --keep-config) KEEP_CONFIG="yes"; shift;;
+            --purge-user)  PURGE_USER="yes"; shift;;
+            -h|--help)     usage; exit 0;;
+            *) die "unknown argument: $1";;
+        esac
+    done
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux)  echo "linux";;
+        Darwin) echo "darwin";;
+        *)      die "unsupported OS: $(uname -s)";;
+    esac
+}
+
+rm_if_exists() {
+    local path="$1"
+    if [[ -e "${path}" || -L "${path}" ]]; then
+        action "remove ${path}" rm -rf "${path}"
+    else
+        log "skip (not present): ${path}"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Linux (systemd)
+# -----------------------------------------------------------------------------
+
+linux_uninstall() {
+    require_root "$@"
+    command -v systemctl >/dev/null 2>&1 || die "systemctl not found"
+
+    local unit="besreceiver.service"
+    local unit_path="/etc/systemd/system/${unit}"
+    local bin_path="/usr/local/bin/besreceiver"
+    local config_dir="/etc/besreceiver"
+    local log_dir="/var/log/besreceiver"
+    local data_dir="/var/lib/besreceiver"
+
+    if systemctl list-unit-files "${unit}" 2>/dev/null | grep -q "^${unit}"; then
+        if systemctl is-active --quiet "${unit}"; then
+            action "stop ${unit}" systemctl stop "${unit}"
+        else
+            log "service ${unit} not active"
+        fi
+        if systemctl is-enabled --quiet "${unit}" 2>/dev/null; then
+            action "disable ${unit}" systemctl disable "${unit}"
+        else
+            log "service ${unit} not enabled"
+        fi
+    else
+        log "service ${unit} not installed"
+    fi
+
+    rm_if_exists "${unit_path}"
+    action "reload systemd" systemctl daemon-reload
+    action "reset failed state" systemctl reset-failed "${unit}" 2>/dev/null || true
+
+    rm_if_exists "${bin_path}"
+    rm_if_exists "${log_dir}"
+    rm_if_exists "${data_dir}"
+
+    if [[ "${KEEP_CONFIG}" == "yes" ]]; then
+        log "keeping config directory: ${config_dir}"
+    else
+        rm_if_exists "${config_dir}"
+    fi
+
+    if [[ "${PURGE_USER}" == "yes" ]]; then
+        if id "${SERVICE_USER}" >/dev/null 2>&1; then
+            action "remove user ${SERVICE_USER}" userdel "${SERVICE_USER}"
+        else
+            log "user ${SERVICE_USER} not present"
+        fi
+        if getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+            action "remove group ${SERVICE_GROUP}" groupdel "${SERVICE_GROUP}"
+        else
+            log "group ${SERVICE_GROUP} not present"
+        fi
+    else
+        log "keeping service user/group (pass --purge-user to remove)"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# macOS (launchd)
+# -----------------------------------------------------------------------------
+
+darwin_uninstall() {
+    require_root "$@"
+    command -v launchctl >/dev/null 2>&1 || die "launchctl not found"
+
+    local plist_path="/Library/LaunchDaemons/${LAUNCHD_LABEL}.plist"
+    local bin_path="/usr/local/bin/besreceiver"
+    local config_dir="/usr/local/etc/besreceiver"
+    local log_dir="/usr/local/var/log/besreceiver"
+    local data_dir="/usr/local/var/lib/besreceiver"
+
+    if launchctl print "system/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+        action "bootout launchd job" launchctl bootout "system/${LAUNCHD_LABEL}"
+    else
+        log "launchd job ${LAUNCHD_LABEL} not loaded"
+    fi
+
+    rm_if_exists "${plist_path}"
+    rm_if_exists "${bin_path}"
+    rm_if_exists "${log_dir}"
+    rm_if_exists "${data_dir}"
+
+    if [[ "${KEEP_CONFIG}" == "yes" ]]; then
+        log "keeping config directory: ${config_dir}"
+    else
+        rm_if_exists "${config_dir}"
+    fi
+}
+
+main() {
+    parse_args "$@"
+    if [[ "${CONFIRM}" != "yes" ]]; then
+        warn "running in DRY-RUN mode; re-run with --yes to actually remove files"
+    fi
+
+    local os
+    os="$(detect_os)"
+    log "detected OS: ${os}"
+
+    case "${os}" in
+        linux)  linux_uninstall "$@";;
+        darwin) darwin_uninstall "$@";;
+    esac
+
+    log "done."
+}
+
+main "$@"


### PR DESCRIPTION
Adds platform service definitions and cross-platform install/uninstall scripts under `packaging/`. The systemd unit runs as a dedicated `besreceiver` user with standard hardening (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, `SystemCallFilter=@system-service`) and restarts on failure. The launchd plist sets `KeepAlive=true` and writes logs under `/usr/local/var/log/besreceiver/`. `install.sh` detects the OS, resolves the binary from `--binary`/`\$BESRECEIVER_BINARY`/`build/besreceiver`, creates the service user on Linux, installs the unit/plist, and activates it; `uninstall.sh` is dry-run by default and requires `--yes` to act. `make install` and `make uninstall` wrap the scripts with the usual overrides.

Closes #17.