### PR TITLE
feat(images): add otelcol-bazel Docker image scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Build output
 /build/
-otelcol-bazel
+/otelcol-bazel
 /besrecord
 
 # Generated

--- a/images/otelcol-bazel/.dockerignore
+++ b/images/otelcol-bazel/.dockerignore
@@ -1,0 +1,6 @@
+# The build context for this image only needs the builder-config.yaml and the
+# collector-config.yaml. Everything else is noise — excluding it keeps the
+# context upload small and avoids cache invalidation from unrelated changes.
+*
+!builder-config.yaml
+!collector-config.yaml

--- a/images/otelcol-bazel/Dockerfile
+++ b/images/otelcol-bazel/Dockerfile
@@ -1,0 +1,80 @@
+# syntax=docker/dockerfile:1.7
+
+# Multi-stage build for the otelcol-bazel custom OpenTelemetry Collector.
+#
+# Stage 1 (builder): run OpenTelemetry Collector Builder (OCB) to generate and
+# compile a minimal collector distribution. OCB pulls the besreceiver module at
+# the version pinned in builder-config.yaml — the Dockerfile build context does
+# NOT need the receiver source checked out.
+#
+# Stage 2 (runtime): copy only the resulting static binary and default config
+# into a distroless image. Runs as nonroot by default.
+#
+# The four versions that MUST stay in sync (see README.md):
+#   - OCB_VERSION                                       (this file)
+#   - go.opentelemetry.io/collector/*         stable    (builder-config.yaml)
+#   - go.opentelemetry.io/collector/*         beta      (builder-config.yaml)
+#   - github.com/chagui/besreceiver                     (builder-config.yaml)
+#   - open-telemetry/opentelemetry-collector-contrib/*  (builder-config.yaml)
+
+ARG GO_VERSION=1.26
+ARG OCB_VERSION=v0.146.1
+ARG DISTROLESS_TAG=nonroot
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS builder
+
+ARG OCB_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+
+# Build-time Go env overrides. Defaults are safe for public modules indexed
+# by the Go checksum database. Override `GOPRIVATE` when the pinned
+# besreceiver tag is not yet indexed by sum.golang.org (common when a tag
+# was just pushed), or when building against a private fork. Setting
+# `GOPRIVATE` implicitly disables GOSUMDB lookups for matched paths.
+# Example:
+#   docker build --build-arg GOPRIVATE=github.com/chagui/* ...
+ARG GOPROXY=https://proxy.golang.org,direct
+ARG GOPRIVATE=
+
+# OCB emits a Go module, runs `go build`, and honors GOOS/GOARCH so the
+# resulting binary matches the image target platform (enables multi-arch
+# builds via `docker buildx build --platform linux/amd64,linux/arm64`).
+ENV CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOPROXY=${GOPROXY} \
+    GOPRIVATE=${GOPRIVATE}
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go install "go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION}"
+
+WORKDIR /build
+
+COPY builder-config.yaml ./builder-config.yaml
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    builder --config builder-config.yaml
+
+FROM gcr.io/distroless/static-debian12:${DISTROLESS_TAG}
+
+LABEL org.opencontainers.image.title="otelcol-bazel" \
+      org.opencontainers.image.description="OpenTelemetry Collector with besreceiver for Bazel Build Event Protocol streams" \
+      org.opencontainers.image.source="https://github.com/chagui/besreceiver" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# distroless/static-debian12:nonroot runs as uid/gid 65532.
+COPY --from=builder /build/otelcol-bazel/otelcol-bazel /otelcol-bazel
+COPY collector-config.yaml /etc/otelcol-bazel/config.yaml
+
+# BES gRPC ingress (8082) is the only port intended to be reached from outside
+# the pod. Health check (13133) and internal prometheus (8888) bind to
+# loopback in the default config — they are documented here but not EXPOSEd.
+EXPOSE 8082
+
+ENTRYPOINT ["/otelcol-bazel"]
+# Default config can be overridden at runtime by bind-mounting a replacement
+# at /etc/otelcol-bazel/config.yaml OR by passing `--config` as a command arg.
+CMD ["--config=/etc/otelcol-bazel/config.yaml"]

--- a/images/otelcol-bazel/README.md
+++ b/images/otelcol-bazel/README.md
@@ -1,0 +1,133 @@
+# otelcol-bazel image
+
+Source-of-truth scaffolding for the `otelcol-bazel` container image. The
+artifacts in this directory are consumed by an external image monorepo that
+owns CI and publication; this directory is what changes when the receiver or
+its collector distribution is bumped.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Multi-stage build: `golang` + OCB → `distroless/static-debian12:nonroot`. |
+| `builder-config.yaml` | OCB manifest. Pins `besreceiver` and all collector modules to remote versions — no `path: "."`. |
+| `collector-config.yaml` | Default runtime config. Datadog Agent egress, loopback-only internal endpoints, operator-supplied BES bind. |
+| `.dockerignore` | Restricts the build context to only the two YAML files. |
+
+## Runtime configuration override
+
+**The default config is baked in at `/etc/otelcol-bazel/config.yaml` and can
+be overridden at runtime via `--config`.**
+
+Rationale: a baked-in default keeps the image runnable out-of-the-box (CI
+smoke tests, local `docker run`) and documents the intended shape. Runtime
+override preserves the flexibility operators need without requiring a new
+image build per environment-specific tweak (endpoints, TLS, auth tokens,
+queue sizes).
+
+Two override paths are supported:
+
+1. **Bind-mount replacement**: mount a different file at the default path.
+   ```bash
+   docker run --rm \
+     -v $(pwd)/my-config.yaml:/etc/otelcol-bazel/config.yaml:ro \
+     -e BES_LISTEN_ADDR=0.0.0.0 \
+     -e DD_AGENT_HOST=dd-agent \
+     -p 8082:8082 \
+     otelcol-bazel:ci-latest
+   ```
+2. **Alternative `--config` path**: mount at a different path and override the
+   command. Supports multiple configs (OTel Collector merges them):
+   ```bash
+   docker run --rm \
+     -v $(pwd)/overrides.yaml:/etc/otelcol-bazel/overrides.yaml:ro \
+     -e BES_LISTEN_ADDR=0.0.0.0 \
+     -e DD_AGENT_HOST=dd-agent \
+     otelcol-bazel:ci-latest \
+     --config=/etc/otelcol-bazel/config.yaml \
+     --config=/etc/otelcol-bazel/overrides.yaml
+   ```
+
+### Required environment variables
+
+| Name | Purpose |
+|---|---|
+| `BES_LISTEN_ADDR` | Interface for BES gRPC ingress. No safe default — the collector fails to start if unset. Use `POD_IP` (downward API) in Kubernetes, the container IP in Docker, or `127.0.0.1` for local testing. |
+| `DD_AGENT_HOST` | Datadog Agent host for OTLP egress. In Kubernetes set from the downward API to the node IP; in Docker use the agent's service name. |
+
+## Version-update procedure
+
+Four versions MUST stay in sync when bumping. Changing one without the
+others produces a broken OCB build, a Go-module resolution failure, or a
+silently wrong binary.
+
+1. **`besreceiver` gomod version** in `builder-config.yaml`
+   ```yaml
+   receivers:
+     - gomod: "github.com/chagui/besreceiver vX.Y.Z"
+   ```
+   Point at a tagged release of this repository.
+
+2. **`go.opentelemetry.io/collector/*` modules** in `builder-config.yaml`
+   All `go.opentelemetry.io/collector/...` entries must share one release
+   (e.g. all `v0.146.1`). Collector core modules refuse to cross-link across
+   versions.
+
+3. **Contrib release** in `builder-config.yaml`
+   All `github.com/open-telemetry/opentelemetry-collector-contrib/...`
+   entries must share one version (e.g. `v0.146.0`). The contrib release
+   number tracks the core release, usually one patch behind or at parity.
+
+4. **`OCB_VERSION` build arg** in `Dockerfile`
+   Must equal the beta (`v0.x.y`) version used for collector modules. OCB
+   refuses to build when its own version disagrees with the modules it
+   emits.
+
+After updating all four, rebuild locally to verify:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t otelcol-bazel:dev \
+  .
+```
+
+If OCB errors with "version mismatch" or Go fails to resolve a module, one
+of the four is out of sync.
+
+## Local build
+
+```bash
+# Single-arch (native)
+docker build -t otelcol-bazel:dev .
+
+# Multi-arch (requires buildx + QEMU for cross-build)
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t otelcol-bazel:dev \
+  .
+```
+
+### `GOPRIVATE` for newly tagged releases
+
+If the pinned `besreceiver` tag was just pushed, `sum.golang.org` may report a
+checksum mismatch until the proxy indexes it (or the mismatch may persist if a
+tag was force-moved). In that case build with `GOPRIVATE` so the Go toolchain
+skips the public sum database for this module:
+
+```bash
+docker build --build-arg GOPRIVATE='github.com/chagui/*' -t otelcol-bazel:dev .
+```
+
+Once `sum.golang.org` reflects the current tag, drop the flag. Never ship an
+image whose build process permanently bypasses sum checks for a dependency.
+
+## Image properties
+
+- **Base**: `gcr.io/distroless/static-debian12:nonroot` — no shell, no
+  package manager, runs as uid/gid 65532.
+- **Binary**: statically linked, `CGO_ENABLED=0`, built inside the Dockerfile
+  so `GOARCH` follows the target platform (multi-arch).
+- **Exposed port**: `8082` (BES gRPC). Health check (`13133`) and internal
+  prometheus (`8888`) bind to loopback and are not exposed.
+- **Entrypoint**: `/otelcol-bazel --config=/etc/otelcol-bazel/config.yaml`.

--- a/images/otelcol-bazel/builder-config.yaml
+++ b/images/otelcol-bazel/builder-config.yaml
@@ -1,0 +1,40 @@
+# OpenTelemetry Collector Builder (OCB) manifest for the otelcol-bazel image.
+#
+# This file is the source of truth for the image monorepo. All four version
+# axes below MUST stay in sync when bumping:
+#   1. `besreceiver` gomod version
+#   2. `go.opentelemetry.io/collector/*` stable   (v1.x)
+#   3. `go.opentelemetry.io/collector/*` beta     (v0.x) — MUST match OCB_VERSION
+#   4. `github.com/open-telemetry/opentelemetry-collector-contrib/*` release
+#
+# The OCB binary version (`OCB_VERSION` in Dockerfile) MUST equal the beta
+# version below. OCB refuses to build when its own version disagrees with the
+# collector-core modules it emits.
+#
+# Unlike the repo-local `builder-config.yaml` at the project root (which uses
+# `path: "."` for dev iteration), this manifest pins besreceiver to a remote
+# tagged version so the image can be built from the builder-config alone,
+# without needing the receiver source in the build context.
+
+dist:
+  name: otelcol-bazel
+  description: "OpenTelemetry Collector with besreceiver for Bazel BEP streams"
+  output_path: ./otelcol-bazel
+  version: 0.1.0
+
+receivers:
+  - gomod: "github.com/chagui/besreceiver v0.1.0"
+    import: "github.com/chagui/besreceiver/receiver/besreceiver"
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.146.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.146.1
+
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.146.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.146.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.146.0
+
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.146.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.146.0

--- a/images/otelcol-bazel/collector-config.yaml
+++ b/images/otelcol-bazel/collector-config.yaml
@@ -1,0 +1,82 @@
+# otelcol-bazel default configuration, CI / container-native.
+#
+# Bound interfaces (OTel security guidance — no 0.0.0.0):
+#   - `bes` (BES gRPC ingress) binds to ${env:BES_LISTEN_ADDR} which the
+#     operator MUST set. Recommended values:
+#       - In Kubernetes: ${env:POD_IP} from the downward API
+#       - In Docker: the container's interface IP, or a private network address
+#       - For local testing: 127.0.0.1
+#     There is no safe default for this variable because exposing BES
+#     unauthenticated on all interfaces in CI is precisely what the OTel
+#     security guidance warns against. The collector will fail to start
+#     rather than silently bind 0.0.0.0.
+#   - Health check and internal telemetry bind to 127.0.0.1 (in-pod only).
+#
+# Datadog Agent egress:
+#   - `${env:DD_AGENT_HOST}` points at the Datadog Agent (sidecar DaemonSet,
+#     or node-local agent). Set `DD_AGENT_HOST=$(NODE_IP)` from the downward
+#     API in Kubernetes, or `host.docker.internal` / service name in Docker.
+#
+# To override this config, bind-mount a replacement at
+# /etc/otelcol-bazel/config.yaml, or pass a different path via `--config`.
+
+extensions:
+  health_check:
+    endpoint: "127.0.0.1:13133"
+
+receivers:
+  bes:
+    endpoint: "${env:BES_LISTEN_ADDR}:8082"
+    # Enable bearer-token auth in production by extending this file.
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+    send_batch_size: 8192
+    send_batch_max_size: 8192
+    timeout: 200ms
+
+exporters:
+  otlp_grpc/datadog:
+    endpoint: "${env:DD_AGENT_HOST}:4317"
+    tls:
+      insecure: true # Acceptable only for same-host / sidecar agent topology.
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "127.0.0.1"
+                port: 8888
+  pipelines:
+    traces:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc/datadog]
+    logs:
+      receivers: [bes]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc/datadog]
+    # Note: the `metrics` pipeline is intentionally absent. The pinned
+    # besreceiver v0.1.0 exposes traces + logs only; metrics support landed
+    # after v0.1.0. Re-add the metrics pipeline when bumping the pin to
+    # a release that advertises `metrics: Alpha` (check via
+    # `otelcol-bazel components`).


### PR DESCRIPTION
Adds source-of-truth scaffolding under `images/otelcol-bazel/` for the external image monorepo to consume. The multi-stage Dockerfile builds the custom collector with OCB in a `golang` stage (honors `TARGETOS`/`TARGETARCH` for multi-arch) and copies the static binary into `gcr.io/distroless/static-debian12:nonroot`. The OCB manifest pins all `go.opentelemetry.io/collector/*` modules and the contrib extension to matching releases, and pulls `besreceiver` via remote `gomod` rather than `path: \".\"`. The bundled collector config binds the BES listener to `\${env:BES_LISTEN_ADDR}` (operator-supplied) so the image refuses to silently bind `0.0.0.0`, and exports to `\${env:DD_AGENT_HOST}:4317`. Runtime override via `--config` is supported; the README documents the four-axis version-update procedure the image monorepo needs to keep the OCB build, collector modules, contrib release, and besreceiver tag in sync.

Closes #27.