### PR TITLE
feat(besreceiver): reparent out-of-order action/test spans via span handles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/receiver/receivertest v0.146.1
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/metric v1.40.0
+	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d
@@ -67,7 +68,6 @@ require (
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -25,7 +25,9 @@ import (
 //  1. Events before BuildStarted are dropped (no invocationState exists yet).
 //  2. ActionExecuted/TestResult arriving before their TargetConfigured are
 //     initially parented to the root span, then reparented under the correct
-//     target when TargetConfigured arrives (see recordOrphan / reparentOrphans).
+//     target when TargetConfigured arrives (see recordPendingReparent /
+//     drainPendingReparent). Orphans whose TargetConfigured never arrives
+//     remain parented to root at finalize time.
 //  3. Events after BuildFinished (except BuildMetrics) are silently discarded
 //     because finalize sets flushed=true, and addTarget/addAction/addTestResult
 //     all short-circuit on that flag.
@@ -43,10 +45,12 @@ type invocationState struct {
 	scopeSpans    ptrace.ScopeSpans // reference into pendingTraces for span appending
 	flushed       bool              // true after BuildFinished flushes the batch
 
-	// orphanedSpans tracks spans whose target hadn't arrived yet at insertion time.
-	// Keyed by label, each entry is a list of span indices (into scopeSpans.Spans())
-	// that should be reparented when addTarget is called for that label.
-	orphanedSpans map[string][]int
+	// pendingReparent tracks spans whose target hadn't arrived yet at
+	// insertion time. Keyed by label, each entry is a list of span handles
+	// to be reparented when addTarget is called for that label. pdata spans
+	// are reference types, so the stored handle can be mutated in place via
+	// SetParentSpanID after creation.
+	pendingReparent map[string][]ptrace.Span
 
 	// abortRecorded is set on the first Aborted event. Subsequent aborts are
 	// logged but do not overwrite the original reason / description, which are
@@ -106,9 +110,13 @@ func newTracesPayload() (ptrace.Traces, ptrace.ScopeSpans) {
 	return traces, ss
 }
 
-func (s *invocationState) addTarget(label, ruleKind, configID string) {
+// addTarget creates the bazel.target span for label and reparents any
+// previously-buffered action/test spans that arrived before this target.
+// Returns the number of spans reparented, so the caller can track a
+// reparenting counter metric.
+func (s *invocationState) addTarget(label, ruleKind, configID string) int {
 	if s.flushed {
-		return
+		return 0
 	}
 
 	spanID := spanIDFromIdentity(s.uuid, "target", label)
@@ -133,7 +141,7 @@ func (s *invocationState) addTarget(label, ruleKind, configID string) {
 	s.targets[targetKey(label, "")] = span
 
 	// Reparent any actions/tests that arrived before this target.
-	s.reparentOrphans(label, spanID)
+	return s.drainPendingReparent(label, spanID)
 }
 
 func (s *invocationState) addAction(label, configID, primaryOutput string, action *bep.ActionExecuted) {
@@ -143,14 +151,15 @@ func (s *invocationState) addAction(label, configID, primaryOutput string, actio
 
 	parentSpanID, resolved := s.resolveTargetSpan(label, configID)
 
-	spanIdx := s.scopeSpans.Spans().Len()
 	span := s.appendSpan()
 	span.SetSpanID(spanIDFromIdentity(s.uuid, "action", label, action.GetType(), primaryOutput))
 
-	// If the target hasn't been configured yet, record this span for
-	// deferred reparenting when addTarget is called.
+	// If the target hasn't been configured yet, buffer the span handle for
+	// deferred reparenting when addTarget is called for this label. pdata
+	// spans are reference types — the stored handle remains valid until the
+	// batch is flushed.
 	if !resolved && label != "" {
-		s.recordOrphan(label, spanIdx)
+		s.recordPendingReparent(label, span)
 	}
 	span.SetParentSpanID(parentSpanID)
 	if mnemonic := action.GetType(); mnemonic != "" {
@@ -201,7 +210,6 @@ func (s *invocationState) addTestResult(label, configID string, tr *bep.BuildEve
 
 	parentSpanID, resolved := s.resolveTargetSpan(label, configID)
 
-	spanIdx := s.scopeSpans.Spans().Len()
 	span := s.appendSpan()
 	span.SetSpanID(spanIDFromIdentity(s.uuid, "test", label,
 		strconv.Itoa(int(tr.GetRun())),
@@ -210,7 +218,7 @@ func (s *invocationState) addTestResult(label, configID string, tr *bep.BuildEve
 	))
 
 	if !resolved && label != "" {
-		s.recordOrphan(label, spanIdx)
+		s.recordPendingReparent(label, span)
 	}
 	span.SetParentSpanID(parentSpanID)
 	span.SetName("bazel.test")
@@ -251,7 +259,10 @@ func (s *invocationState) finalize(finished *bep.BuildFinished) (ptrace.Traces, 
 	s.writeRootSpan(finished)
 
 	s.flushed = true
-	s.orphanedSpans = nil
+	// Any entries left in pendingReparent represent actions/tests whose
+	// TargetConfigured never arrived. Their spans stay parented to root
+	// (explicit orphan), matching prior behavior.
+	s.pendingReparent = nil
 	return s.pendingTraces, true
 }
 
@@ -635,8 +646,9 @@ func (s *invocationState) flushOrphaned() (ptrace.Traces, bool) {
 // and falls back to the root span if no target has been registered yet.
 //
 // The bool return indicates whether the target was found. When false, the
-// caller records the span as an orphan so that addTarget can reparent it
-// when the TargetConfigured event arrives. See recordOrphan / reparentOrphans.
+// caller buffers the span for deferred reparenting so that addTarget can
+// reparent it when the TargetConfigured event arrives. See
+// recordPendingReparent / drainPendingReparent.
 func (s *invocationState) resolveTargetSpan(label, configID string) (pcommon.SpanID, bool) {
 	if span, ok := s.targets[targetKey(label, configID)]; ok {
 		return span.SpanID(), true
@@ -647,28 +659,29 @@ func (s *invocationState) resolveTargetSpan(label, configID string) (pcommon.Spa
 	return s.rootSpanID, false
 }
 
-// recordOrphan tracks a span index that needs reparenting when its target arrives.
-func (s *invocationState) recordOrphan(label string, spanIdx int) {
-	if s.orphanedSpans == nil {
-		s.orphanedSpans = make(map[string][]int)
+// recordPendingReparent buffers a span handle that needs its parent updated
+// when TargetConfigured arrives for label. pdata spans are reference types,
+// so the handle stored here remains mutable via SetParentSpanID.
+func (s *invocationState) recordPendingReparent(label string, span ptrace.Span) {
+	if s.pendingReparent == nil {
+		s.pendingReparent = make(map[string][]ptrace.Span)
 	}
-	s.orphanedSpans[label] = append(s.orphanedSpans[label], spanIdx)
+	s.pendingReparent[label] = append(s.pendingReparent[label], span)
 }
 
-// reparentOrphans updates any previously-orphaned spans for the given label
-// to be children of the target span.
-func (s *invocationState) reparentOrphans(label string, targetSpanID pcommon.SpanID) {
-	indices, ok := s.orphanedSpans[label]
+// drainPendingReparent retroactively points any buffered spans for label at
+// targetSpanID, then clears the entry. Returns the number of spans reparented
+// so the caller can increment a counter metric.
+func (s *invocationState) drainPendingReparent(label string, targetSpanID pcommon.SpanID) int {
+	spans, ok := s.pendingReparent[label]
 	if !ok {
-		return
+		return 0
 	}
-	spans := s.scopeSpans.Spans()
-	for _, idx := range indices {
-		if idx < spans.Len() {
-			spans.At(idx).SetParentSpanID(targetSpanID)
-		}
+	for _, span := range spans {
+		span.SetParentSpanID(targetSpanID)
 	}
-	delete(s.orphanedSpans, label)
+	delete(s.pendingReparent, label)
+	return len(spans)
 }
 
 // appendSpan appends a new span to the invocation's pending batch.

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -74,6 +74,7 @@ type TraceBuilder struct {
 	// Internal metrics for observability.
 	activeInvocations metric.Int64UpDownCounter
 	eventsProcessed   metric.Int64Counter
+	eventsReparented  metric.Int64Counter
 	invocationsReaped metric.Int64Counter
 	consumerErrors    metric.Int64Counter
 }
@@ -98,6 +99,9 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 	eventsProcessed, _ := meter.Int64Counter("bes.events.processed",
 		metric.WithDescription("Total BEP events processed"),
 	)
+	eventsReparented, _ := meter.Int64Counter("bes.events.reparented",
+		metric.WithDescription("Total action/test spans reparented onto a late-arriving target span"),
+	)
 	invocationsReaped, _ := meter.Int64Counter("bes.invocations.reaped",
 		metric.WithDescription("Total invocations reaped by the stale-invocation reaper"),
 	)
@@ -115,6 +119,7 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		counters:          newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
 		activeInvocations: activeInvocations,
 		eventsProcessed:   eventsProcessed,
+		eventsReparented:  eventsReparented,
 		invocationsReaped: invocationsReaped,
 		consumerErrors:    consumerErrors,
 	}
@@ -367,7 +372,15 @@ func (tb *TraceBuilder) handleTargetConfigured(ctx context.Context, invocations 
 		}
 	}
 
-	state.addTarget(tc.GetLabel(), configured.GetTargetKind(), configID)
+	reparented := state.addTarget(tc.GetLabel(), configured.GetTargetKind(), configID)
+	if reparented > 0 {
+		tb.eventsReparented.Add(ctx, int64(reparented))
+		tb.logger.Debug("Reparented out-of-order spans under target",
+			zap.String("invocation_id", invocationID),
+			zap.String("label", tc.GetLabel()),
+			zap.Int("count", reparented),
+		)
+	}
 
 	tb.logger.Debug("Target configured",
 		zap.String("invocation_id", invocationID),

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -17,6 +17,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -1262,6 +1264,130 @@ func TestTestResultBeforeTarget(t *testing.T) {
 
 	assert.Equal(t, targetSpan.SpanID, testSpan.ParentSpanID,
 		"test should be child of target even when test result arrives first")
+}
+
+// TestReparent_CounterMetric verifies that bes.events.reparented is
+// incremented by one per action/test span reparented onto a late-arriving
+// target span, and is not incremented when events arrive in order.
+func TestReparent_CounterMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		MeterProvider: mp,
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Mixed: one action and one test both arrive before their target, a
+	// second target arrives in-order (no reparent). Expected counter = 2.
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-reparent", "uuid-reparent", "build", 1),
+		// Out-of-order: action + test arrive before //pkg:lib.
+		makeActionOBE(t, "inv-reparent", "//pkg:lib", "Javac", 2, true),
+		makeTestResultOBE(t, "inv-reparent", "//pkg:lib", 3, bep.TestStatus_PASSED),
+		makeTargetConfiguredOBE(t, "inv-reparent", "//pkg:lib", 4),
+		// In-order: target arrives before its action.
+		makeTargetConfiguredOBE(t, "inv-reparent", "//pkg:other", 5),
+		makeActionOBE(t, "inv-reparent", "//pkg:other", "GoCompile", 6, true),
+		makeBuildFinishedOBE(t, "inv-reparent", 7, 0, "SUCCESS"),
+	)
+
+	assert.Equal(t, int64(2), readCounter(t, reader, "bes.events.reparented"),
+		"expected 2 reparented spans (one action + one test for //pkg:lib)")
+}
+
+// TestReparent_CounterNotIncrementedWhenInOrder verifies that the
+// bes.events.reparented counter stays at zero for fully in-order streams.
+func TestReparent_CounterNotIncrementedWhenInOrder(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		MeterProvider: mp,
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-inorder", "uuid-inorder", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-inorder", "//pkg:lib", 2),
+		makeActionOBE(t, "inv-inorder", "//pkg:lib", "Javac", 3, true),
+		makeBuildFinishedOBE(t, "inv-inorder", 4, 0, "SUCCESS"),
+	)
+
+	assert.Equal(t, int64(0), readCounter(t, reader, "bes.events.reparented"),
+		"in-order streams must not increment the reparent counter")
+}
+
+// TestReparent_OrphanAtFinalize covers the case where an action arrives
+// before its target and TargetConfigured never arrives. The action span
+// stays parented to root (explicit orphan), no reparenting happens, and
+// the counter is not incremented.
+func TestReparent_OrphanAtFinalize(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		MeterProvider: mp,
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Action arrives, then BuildFinished — no TargetConfigured ever.
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-orphan", "uuid-orphan", "build", 1),
+		makeActionOBE(t, "inv-orphan", "//pkg:lib", "Javac", 2, true),
+		makeBuildFinishedOBE(t, "inv-orphan", 3, 0, "SUCCESS"),
+	)
+
+	require.Equal(t, 2, sink.SpanCount(), "expected 2 spans: root + orphaned action")
+
+	spans := collectSpans(t, sink)
+	var actionSpan, rootSpan spanInfo
+	for _, s := range spans {
+		switch {
+		case s.Name == "bazel.action Javac":
+			actionSpan = s
+		case strings.HasPrefix(s.Name, "bazel.build"):
+			rootSpan = s
+		}
+	}
+	require.NotEmpty(t, actionSpan.Name, "action span not found")
+	require.NotEmpty(t, rootSpan.Name, "root span not found")
+
+	assert.Equal(t, rootSpan.SpanID, actionSpan.ParentSpanID,
+		"orphan action without TargetConfigured must stay parented to root")
+	assert.Equal(t, int64(0), readCounter(t, reader, "bes.events.reparented"),
+		"orphan at finalize must not increment reparent counter")
+}
+
+// readCounter reads the int sum value of a counter metric by name from a
+// ManualReader. Returns 0 if the metric is not present.
+func readCounter(t testing.TB, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %s is not Sum[int64]: %T", name, m.Data)
+			}
+			var total int64
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+			return total
+		}
+	}
+	return 0
 }
 
 // --- Aborted event tests (issue #20) ---


### PR DESCRIPTION
Reparenting of action and test spans that arrive before their `TargetConfigured` event already existed via an index-based orphan map. This change switches the storage to span handles (`map[string][]ptrace.Span`) since pdata spans are reference types and can be mutated in place via `SetParentSpanID` after creation, which is simpler than tracking slice indices and resilient to scope-span layout changes. The helpers are renamed to `recordPendingReparent`/`drainPendingReparent` to match the issue design, and `addTarget` now returns the number of spans it reparented so the caller can bump a counter metric. Adds the `bes.events.reparented` counter metric emitted from `handleTargetConfigured`, plus tests for the in-order path (counter stays at zero) and the orphan-at-finalize path (target never arrives — span stays parented to root).

Closes #7.