### PR TITLE
feat(besreceiver): emit post-flush spans for late BEP events

### DIFF
--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -28,9 +28,14 @@ import (
 //     target when TargetConfigured arrives (see recordPendingReparent /
 //     drainPendingReparent). Orphans whose TargetConfigured never arrives
 //     remain parented to root at finalize time.
-//  3. Events after BuildFinished (except BuildMetrics) are silently discarded
-//     because finalize sets flushed=true, and addTarget/addAction/addTestResult
-//     all short-circuit on that flag.
+//  3. TargetConfigured/ActionExecuted/TestResult arriving after BuildFinished
+//     but before BuildMetrics (which deletes the state) are emitted in a
+//     standalone ptrace.Traces payload by the corresponding lateXSpan
+//     method — same pattern as buildMetricsSpan. The main span batch has
+//     already been flushed, so these late spans ride on the same traceID
+//     and parent into the existing target (if known) or the root. Orphan
+//     reparenting is disabled post-flush because the pre-flush batch is
+//     already out.
 //
 // Bazel has historically maintained this ordering in practice, and the BES gRPC
 // transport (OrderedBuildEvent) preserves stream order.
@@ -119,8 +124,23 @@ func (s *invocationState) addTarget(label, ruleKind, configID string) int {
 		return 0
 	}
 
-	spanID := spanIDFromIdentity(s.uuid, "target", label)
 	span := s.appendSpan()
+	spanID := s.populateTargetSpan(span, label, ruleKind, configID)
+
+	// Store the span handle so later TargetComplete / TestSummary events can
+	// mutate attributes on the existing target span.
+	s.targets[targetKey(label, "")] = span
+
+	// Reparent any actions/tests that arrived before this target.
+	return s.drainPendingReparent(label, spanID)
+}
+
+// populateTargetSpan stamps identity, parenting, and attributes on a
+// pre-appended target span. Returns the span id so callers can wire it into
+// the targets map and reparent orphans. Shared by the pre-flush addTarget
+// path and the post-flush lateTargetSpan path.
+func (s *invocationState) populateTargetSpan(span ptrace.Span, label, ruleKind, configID string) pcommon.SpanID {
+	spanID := spanIDFromIdentity(s.uuid, "target", label)
 	span.SetSpanID(spanID)
 	span.SetParentSpanID(s.rootSpanID)
 	span.SetName("bazel.target")
@@ -135,13 +155,7 @@ func (s *invocationState) addTarget(label, ruleKind, configID string) int {
 	// payload for this target's config id. No back-patching if it arrives
 	// later — Bazel emits Configuration before TargetConfigured in practice.
 	s.stampTargetConfig(span, configID)
-
-	// Store the span handle so later TargetComplete / TestSummary events can
-	// mutate attributes on the existing target span.
-	s.targets[targetKey(label, "")] = span
-
-	// Reparent any actions/tests that arrived before this target.
-	return s.drainPendingReparent(label, spanID)
+	return spanID
 }
 
 func (s *invocationState) addAction(label, configID, primaryOutput string, action *bep.ActionExecuted) {
@@ -152,7 +166,7 @@ func (s *invocationState) addAction(label, configID, primaryOutput string, actio
 	parentSpanID, resolved := s.resolveTargetSpan(label, configID)
 
 	span := s.appendSpan()
-	span.SetSpanID(spanIDFromIdentity(s.uuid, "action", label, action.GetType(), primaryOutput))
+	s.populateActionSpan(span, parentSpanID, label, primaryOutput, action)
 
 	// If the target hasn't been configured yet, buffer the span handle for
 	// deferred reparenting when addTarget is called for this label. pdata
@@ -161,6 +175,14 @@ func (s *invocationState) addAction(label, configID, primaryOutput string, actio
 	if !resolved && label != "" {
 		s.recordPendingReparent(label, span)
 	}
+}
+
+// populateActionSpan stamps identity, parenting, and attributes on a
+// pre-appended action span. Shared by the pre-flush addAction path and the
+// post-flush lateActionSpan path. Caller handles orphan recording (only
+// meaningful pre-flush).
+func (s *invocationState) populateActionSpan(span ptrace.Span, parentSpanID pcommon.SpanID, label, primaryOutput string, action *bep.ActionExecuted) {
+	span.SetSpanID(spanIDFromIdentity(s.uuid, "action", label, action.GetType(), primaryOutput))
 	span.SetParentSpanID(parentSpanID)
 	if mnemonic := action.GetType(); mnemonic != "" {
 		span.SetName("bazel.action " + mnemonic)
@@ -211,15 +233,23 @@ func (s *invocationState) addTestResult(label, configID string, tr *bep.BuildEve
 	parentSpanID, resolved := s.resolveTargetSpan(label, configID)
 
 	span := s.appendSpan()
+	s.populateTestResultSpan(span, parentSpanID, label, tr, result)
+
+	if !resolved && label != "" {
+		s.recordPendingReparent(label, span)
+	}
+}
+
+// populateTestResultSpan stamps identity, parenting, and attributes on a
+// pre-appended test span. Shared by the pre-flush addTestResult path and
+// the post-flush lateTestResultSpan path. Caller handles orphan recording
+// (only meaningful pre-flush).
+func (s *invocationState) populateTestResultSpan(span ptrace.Span, parentSpanID pcommon.SpanID, label string, tr *bep.BuildEventId_TestResultId, result *bep.TestResult) {
 	span.SetSpanID(spanIDFromIdentity(s.uuid, "test", label,
 		strconv.Itoa(int(tr.GetRun())),
 		strconv.Itoa(int(tr.GetShard())),
 		strconv.Itoa(int(tr.GetAttempt())),
 	))
-
-	if !resolved && label != "" {
-		s.recordPendingReparent(label, span)
-	}
 	span.SetParentSpanID(parentSpanID)
 	span.SetName("bazel.test")
 	span.SetKind(ptrace.SpanKindInternal)
@@ -592,6 +622,46 @@ func (s *invocationState) stampTargetConfig(span ptrace.Span, configID string) {
 		span.Attributes().PutStr("bazel.target.config.cpu", c)
 	}
 	span.Attributes().PutBool("bazel.target.config.is_tool", cfg.GetIsTool())
+}
+
+// lateTargetSpan emits a standalone bazel.target span for a TargetConfigured
+// event that arrived after the main batch was flushed. The target span handle
+// is recorded on s.targets so later post-flush actions/tests for the same
+// label can parent correctly. Orphan reparenting is a no-op here because the
+// pre-flush batch has already been handed to the consumer.
+func (s *invocationState) lateTargetSpan(label, ruleKind, configID string) ptrace.Traces {
+	traces, ss := newTracesPayload()
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(s.traceID)
+	s.populateTargetSpan(span, label, ruleKind, configID)
+	s.targets[targetKey(label, "")] = span
+	return traces
+}
+
+// lateActionSpan emits a standalone bazel.action span for an ActionExecuted
+// event that arrived after the main batch was flushed. Parent is resolved
+// against s.targets (which persists across flush); if unknown the span
+// parents to the root. Orphan recording is skipped because no future
+// TargetConfigured can reparent into an already-emitted batch.
+func (s *invocationState) lateActionSpan(label, configID, primaryOutput string, action *bep.ActionExecuted) ptrace.Traces {
+	traces, ss := newTracesPayload()
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(s.traceID)
+	parentSpanID, _ := s.resolveTargetSpan(label, configID)
+	s.populateActionSpan(span, parentSpanID, label, primaryOutput, action)
+	return traces
+}
+
+// lateTestResultSpan emits a standalone bazel.test span for a TestResult
+// event that arrived after the main batch was flushed. Parent resolution
+// follows the same rules as lateActionSpan.
+func (s *invocationState) lateTestResultSpan(label, configID string, tr *bep.BuildEventId_TestResultId, result *bep.TestResult) ptrace.Traces {
+	traces, ss := newTracesPayload()
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(s.traceID)
+	parentSpanID, _ := s.resolveTargetSpan(label, configID)
+	s.populateTestResultSpan(span, parentSpanID, label, tr, result)
+	return traces
 }
 
 // buildMetricsSpan creates a standalone Traces payload for BuildMetrics.

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -372,16 +372,6 @@ func (tb *TraceBuilder) handleTargetConfigured(ctx context.Context, invocations 
 		}
 	}
 
-	reparented := state.addTarget(tc.GetLabel(), configured.GetTargetKind(), configID)
-	if reparented > 0 {
-		tb.eventsReparented.Add(ctx, int64(reparented))
-		tb.logger.Debug("Reparented out-of-order spans under target",
-			zap.String("invocation_id", invocationID),
-			zap.String("label", tc.GetLabel()),
-			zap.Int("count", reparented),
-		)
-	}
-
 	tb.logger.Debug("Target configured",
 		zap.String("invocation_id", invocationID),
 		zap.String("label", tc.GetLabel()),
@@ -396,6 +386,24 @@ func (tb *TraceBuilder) handleTargetConfigured(ctx context.Context, invocations 
 		},
 	)
 
+	// Post-flush arrivals emit a standalone traces payload, matching the
+	// pattern established for BuildMetrics (see handleBuildMetrics). This
+	// preserves the span instead of silently dropping it when a future Bazel
+	// version emits TargetConfigured after BuildFinished.
+	if state.flushed {
+		traces := state.lateTargetSpan(tc.GetLabel(), configured.GetTargetKind(), configID)
+		return tb.consumeAndRecord(ctx, traces)
+	}
+
+	reparented := state.addTarget(tc.GetLabel(), configured.GetTargetKind(), configID)
+	if reparented > 0 {
+		tb.eventsReparented.Add(ctx, int64(reparented))
+		tb.logger.Debug("Reparented out-of-order spans under target",
+			zap.String("invocation_id", invocationID),
+			zap.String("label", tc.GetLabel()),
+			zap.Int("count", reparented),
+		)
+	}
 	return nil
 }
 
@@ -415,8 +423,6 @@ func (tb *TraceBuilder) handleActionExecuted(ctx context.Context, invocations ma
 		primaryOutput = ac.GetPrimaryOutput()
 	}
 
-	state.addAction(label, configID, primaryOutput, action)
-
 	severity := plog.SeverityNumberInfo
 	body := fmt.Sprintf("Action completed: %s %s", action.GetType(), label)
 	if !action.GetSuccess() {
@@ -435,6 +441,13 @@ func (tb *TraceBuilder) handleActionExecuted(ctx context.Context, invocations ma
 		},
 	)
 
+	// Post-flush arrivals emit a standalone traces payload (see handleBuildMetrics).
+	if state.flushed {
+		traces := state.lateActionSpan(label, configID, primaryOutput, action)
+		return tb.consumeAndRecord(ctx, traces)
+	}
+
+	state.addAction(label, configID, primaryOutput, action)
 	return nil
 }
 
@@ -451,8 +464,6 @@ func (tb *TraceBuilder) handleTestResult(ctx context.Context, invocations map[st
 		label = tr.GetLabel()
 		configID = tr.GetConfiguration().GetId()
 	}
-
-	state.addTestResult(label, configID, tr, result)
 
 	severity := plog.SeverityNumberInfo
 	body := fmt.Sprintf("Test passed: %s", label)
@@ -472,6 +483,13 @@ func (tb *TraceBuilder) handleTestResult(ctx context.Context, invocations map[st
 		},
 	)
 
+	// Post-flush arrivals emit a standalone traces payload (see handleBuildMetrics).
+	if state.flushed {
+		traces := state.lateTestResultSpan(label, configID, tr, result)
+		return tb.consumeAndRecord(ctx, traces)
+	}
+
+	state.addTestResult(label, configID, tr, result)
 	return nil
 }
 

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -1081,8 +1081,11 @@ func TestTraceBuilder_ActionBeforeTargetConfigured(t *testing.T) {
 }
 
 func TestTraceBuilder_TargetConfiguredAfterBuildFinished(t *testing.T) {
-	// TargetConfigured arriving after BuildFinished should be silently dropped
-	// because the invocation is already flushed.
+	// TargetConfigured arriving after BuildFinished should be emitted in a
+	// standalone ptrace.Traces payload (same pattern as BuildMetrics) rather
+	// than silently dropped. The late target span rides on the same traceID
+	// and parents to the root span so downstream backends stitch the build
+	// tree together.
 	sink := new(consumertest.TracesSink)
 	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
@@ -1096,52 +1099,148 @@ func TestTraceBuilder_TargetConfiguredAfterBuildFinished(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	spansBefore := sink.SpanCount()
+	preFlushBatches := len(sink.AllTraces())
+	preFlushSpans := sink.SpanCount()
 
-	// TargetConfigured arrives after flush — should be a no-op.
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeTargetConfiguredOBE(t, "inv-late-tc", "//pkg:lib", 3)); err != nil {
-		t.Fatal(err)
-	}
+	// TargetConfigured arrives after flush — should emit a standalone batch
+	// with the target span parented under the existing root span.
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeTargetConfiguredOBE(t, "inv-late-tc", "//pkg:lib", 3)))
 
-	if sink.SpanCount() != spansBefore {
-		t.Errorf("expected no new spans after flush, got %d new", sink.SpanCount()-spansBefore)
-	}
+	allTraces := sink.AllTraces()
+	require.Len(t, allTraces, preFlushBatches+1, "expected a separate ConsumeTraces call for the late TargetConfigured")
+	require.Equal(t, preFlushSpans+1, sink.SpanCount(), "expected exactly one new span for the late TargetConfigured")
+
+	lateBatch := allTraces[len(allTraces)-1]
+	lateSpans := lateBatch.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.Equal(t, 1, lateSpans.Len(), "late batch should carry exactly the target span")
+	lateTarget := lateSpans.At(0)
+	assert.Equal(t, "bazel.target", lateTarget.Name())
+	label, ok := lateTarget.Attributes().Get("bazel.target.label")
+	require.True(t, ok)
+	assert.Equal(t, "//pkg:lib", label.Str())
+
+	// Parent should be the root span of the original batch (deterministic
+	// SpanID derived from the invocation uuid).
+	rootSpanID := spanIDFromIdentity("uuid-late-tc", "root")
+	assert.Equal(t, rootSpanID, lateTarget.ParentSpanID())
+
+	// TraceID must match the flushed batch so the late span joins the trace.
+	flushedRoot := findRootSpan(t, sink)
+	assert.Equal(t, flushedRoot.TraceID(), lateTarget.TraceID())
 }
 
 func TestTraceBuilder_ActionAfterBuildFinishedBeforeMetrics(t *testing.T) {
 	// ActionExecuted arriving after BuildFinished (but before BuildMetrics
-	// cleans up state) should be silently dropped.
+	// cleans up state) should be emitted in a standalone ptrace.Traces
+	// payload. If the action's target was already seen pre-flush, the late
+	// span parents to the target span; otherwise it parents to the root.
 	sink := new(consumertest.TracesSink)
 	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
 	defer tb.Stop()
 	ctx := context.Background()
 
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-late-act", "uuid-late-act", "build", 1)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-late-act", 2, 0, "SUCCESS")); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-late-act", "uuid-late-act", "build", 1)))
+	// Include a TargetConfigured pre-flush so the late action has a resolvable parent.
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeTargetConfiguredOBE(t, "inv-late-act", "//pkg:lib", 2)))
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-late-act", 3, 0, "SUCCESS")))
 
-	spansBefore := sink.SpanCount()
+	preFlushBatches := len(sink.AllTraces())
+	preFlushSpans := sink.SpanCount()
 
-	// Action arrives after flush but before BuildMetrics — should be a no-op.
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeActionOBE(t, "inv-late-act", "//pkg:lib", "Javac", 3, true)); err != nil {
-		t.Fatal(err)
-	}
+	// Action arrives after flush but before BuildMetrics.
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeActionOBE(t, "inv-late-act", "//pkg:lib", "Javac", 4, true)))
 
-	if sink.SpanCount() != spansBefore {
-		t.Errorf("expected no new spans after flush, got %d new", sink.SpanCount()-spansBefore)
-	}
+	allTraces := sink.AllTraces()
+	require.Len(t, allTraces, preFlushBatches+1, "expected a separate ConsumeTraces call for the late action")
+	require.Equal(t, preFlushSpans+1, sink.SpanCount(), "expected exactly one new span for the late action")
 
-	// BuildMetrics should still work normally after the dropped action.
-	if err := tb.ProcessOrderedBuildEvent(ctx, makeBuildMetricsOBE(t, "inv-late-act", 4, 10000, 5000)); err != nil {
-		t.Fatal(err)
-	}
-	if sink.SpanCount() != spansBefore+1 {
-		t.Errorf("expected 1 new span from BuildMetrics, got %d", sink.SpanCount()-spansBefore)
-	}
+	lateBatch := allTraces[len(allTraces)-1]
+	lateSpans := lateBatch.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.Equal(t, 1, lateSpans.Len())
+	lateAction := lateSpans.At(0)
+	assert.Equal(t, "bazel.action Javac", lateAction.Name())
+	label, ok := lateAction.Attributes().Get("bazel.target.label")
+	require.True(t, ok)
+	assert.Equal(t, "//pkg:lib", label.Str())
+
+	// Parent should be the target span from the flushed batch (same SpanID,
+	// derived deterministically from the invocation uuid + label).
+	expectedParent := spanIDFromIdentity("uuid-late-act", "target", "//pkg:lib")
+	assert.Equal(t, expectedParent, lateAction.ParentSpanID(),
+		"late action should parent into the pre-flush target span")
+
+	// BuildMetrics should still work normally after the late action and
+	// increment the span count by one more batch.
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeBuildMetricsOBE(t, "inv-late-act", 5, 10000, 5000)))
+	require.Equal(t, preFlushSpans+2, sink.SpanCount(),
+		"expected one additional span from BuildMetrics on top of the late action")
+}
+
+func TestTraceBuilder_TestResultAfterBuildFinishedBeforeMetrics(t *testing.T) {
+	// TestResult arriving after BuildFinished (but before BuildMetrics)
+	// should emit a standalone bazel.test span parented under the existing
+	// target span when the target is known, mirroring the late-action path.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-late-tr", "uuid-late-tr", "test", 1)))
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeTargetConfiguredOBE(t, "inv-late-tr", "//pkg:test", 2)))
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-late-tr", 3, 0, "SUCCESS")))
+
+	preFlushBatches := len(sink.AllTraces())
+	preFlushSpans := sink.SpanCount()
+
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeTestResultOBE(t, "inv-late-tr", "//pkg:test", 4, bep.TestStatus_PASSED)))
+
+	allTraces := sink.AllTraces()
+	require.Len(t, allTraces, preFlushBatches+1)
+	require.Equal(t, preFlushSpans+1, sink.SpanCount())
+
+	lateSpans := allTraces[len(allTraces)-1].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.Equal(t, 1, lateSpans.Len())
+	lateTest := lateSpans.At(0)
+	assert.Equal(t, "bazel.test", lateTest.Name())
+	label, ok := lateTest.Attributes().Get("bazel.target.label")
+	require.True(t, ok)
+	assert.Equal(t, "//pkg:test", label.Str())
+
+	expectedParent := spanIDFromIdentity("uuid-late-tr", "target", "//pkg:test")
+	assert.Equal(t, expectedParent, lateTest.ParentSpanID())
+
+	// A second late TestResult (e.g., retry attempt) should also emit.
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeTestResultOBE(t, "inv-late-tr", "//pkg:test", 5, bep.TestStatus_PASSED)))
+	require.Equal(t, preFlushSpans+2, sink.SpanCount(),
+		"each late TestResult should produce a separate span")
+}
+
+func TestTraceBuilder_LateActionWithoutKnownTarget(t *testing.T) {
+	// When a late action arrives for a label whose TargetConfigured never
+	// appeared pre-flush, the span parents to the root rather than being
+	// dropped. No post-flush reparenting — orphan tracking is disabled once
+	// the batch is emitted.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeBuildStartedOBE(t, "inv-late-orphan", "uuid-late-orphan", "build", 1)))
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeBuildFinishedOBE(t, "inv-late-orphan", 2, 0, "SUCCESS")))
+
+	preFlushSpans := sink.SpanCount()
+
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx, makeActionOBE(t, "inv-late-orphan", "//unknown:lib", "Javac", 3, true)))
+
+	require.Equal(t, preFlushSpans+1, sink.SpanCount())
+	lateBatch := sink.AllTraces()[len(sink.AllTraces())-1]
+	lateAction := lateBatch.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	rootSpanID := spanIDFromIdentity("uuid-late-orphan", "root")
+	assert.Equal(t, rootSpanID, lateAction.ParentSpanID(),
+		"late action with no known target falls back to the root span")
 }
 
 func TestTraceBuilder_CumulativeCountersAcrossInvocations(t *testing.T) {


### PR DESCRIPTION
Previously `TargetConfigured`, `ActionExecuted`, and `TestResult` events that arrived after `BuildFinished` were silently discarded by the `flushed` guard on the mutator methods — the only post-flush code path was the one for `BuildMetrics`. No Bazel version today emits those events out of order, but the ordering is an implicit contract and releases tagged as "10.0.0-pre" explicitly mention BEP reordering, so dropping late spans silently is defensive debt.

This change generalises the existing `BuildMetrics` post-flush pattern to the three mutator types. The identity/attribute work in `addTarget`/`addAction`/`addTestResult` is extracted into `populateTargetSpan`/`populateActionSpan`/`populateTestResultSpan` helpers, and three new methods — `lateTargetSpan`, `lateActionSpan`, `lateTestResultSpan` — build a standalone `ptrace.Traces` payload keyed to the same `traceID`, populated via the shared helpers, and consumed through the normal `consumeAndRecord` path. Post-flush spans can parent into any target span still present in `s.targets` (which outlives the flush) and fall back to root otherwise. Reparenting is intentionally disabled on the late path because the pre-flush batch is already out the door.

Option B (delay flush until `BuildMetrics` or a timeout) was rejected — it couples flush timing to `BuildMetrics` arrival, adds latency, and introduces new timer machinery for a defensive guardrail against an event reorder that does not happen today.

Closes #8.