### PR TITLE
feat(besreceiver): extend bazel.metrics span with remaining BuildMetrics sub-messages

### DIFF
--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -1,6 +1,7 @@
 package besreceiver
 
 import (
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -752,6 +753,12 @@ func (s *invocationState) lateTestResultSpan(label, configID string, tr *bep.Bui
 
 // buildMetricsSpan creates a standalone Traces payload for BuildMetrics.
 // Used for post-flush events that arrive after the main batch is flushed.
+//
+// Sub-messages are stamped via dedicated helpers that each no-op on nil, so
+// partially-populated BuildMetrics payloads are safe. High-cardinality sub-
+// messages (GarbageMetrics, PackageLoadMetrics, WorkerMetrics, EvaluationStat,
+// RuleClassCount, AspectCount, RemoteAnalysisCacheStatistics) are intentionally
+// skipped; see issue #25 / #29 for rationale.
 func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) ptrace.Traces {
 	traces, ss := newTracesPayload()
 
@@ -762,39 +769,73 @@ func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) ptrace.Tra
 	span.SetName("bazel.metrics")
 	span.SetKind(ptrace.SpanKindInternal)
 
-	if tm := metrics.GetTimingMetrics(); tm != nil {
-		span.Attributes().PutInt("bazel.metrics.wall_time_ms", tm.GetWallTimeInMs())
-		span.Attributes().PutInt("bazel.metrics.cpu_time_ms", tm.GetCpuTimeInMs())
-		span.Attributes().PutInt("bazel.metrics.analysis_phase_time_ms", tm.GetAnalysisPhaseTimeInMs())
-		span.Attributes().PutInt("bazel.metrics.execution_phase_time_ms", tm.GetExecutionPhaseTimeInMs())
-	}
-	if as := metrics.GetActionSummary(); as != nil {
-		span.Attributes().PutInt("bazel.metrics.actions_created", as.GetActionsCreated())
-		span.Attributes().PutInt("bazel.metrics.actions_executed", as.GetActionsExecuted())
-		span.Attributes().PutInt("bazel.metrics.remote_cache_hits", as.GetRemoteCacheHits()) //nolint:staticcheck // SA1019: field deprecated upstream but still populated by current Bazel releases; issue #18 explicitly surfaces it.
-		applyActionCacheStatistics(span, as.GetActionCacheStatistics())
-		applyRunnerCounts(span, as.GetRunnerCount())
-	}
+	attrs := span.Attributes()
+	stampTimingAttrs(attrs, metrics.GetTimingMetrics())
+	stampActionSummaryAttrs(attrs, metrics.GetActionSummary())
+	stampMemoryAttrs(attrs, metrics.GetMemoryMetrics())
+	stampTargetAttrs(attrs, metrics.GetTargetMetrics())
+	stampPackageAttrs(attrs, metrics.GetPackageMetrics())
+	stampBuildGraphAttrs(attrs, metrics.GetBuildGraphMetrics())
+	stampArtifactAttrs(attrs, metrics.GetArtifactMetrics())
+	stampNetworkAttrs(attrs, metrics.GetNetworkMetrics())
+	stampCumulativeAttrs(attrs, metrics.GetCumulativeMetrics())
+	stampDynamicExecutionAttrs(attrs, metrics.GetDynamicExecutionMetrics())
+	stampWorkerPoolAttrs(attrs, metrics.GetWorkerPoolMetrics())
 
 	return traces
+}
+
+// maxBuildMetricsSliceEntries caps slice-of-map span attributes (DynamicExecutionMetrics,
+// WorkerPoolMetrics). Bazel can emit one entry per mnemonic; 20 is enough to capture
+// the common case without unbounded cardinality blowing up trace backends.
+const maxBuildMetricsSliceEntries = 20
+
+// stampTimingAttrs writes wall/cpu/phase timings plus the additional critical-path
+// and actions-execution-start fields added in issue #25.
+func stampTimingAttrs(attrs pcommon.Map, tm *bep.BuildMetrics_TimingMetrics) {
+	if tm == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.wall_time_ms", tm.GetWallTimeInMs())
+	attrs.PutInt("bazel.metrics.cpu_time_ms", tm.GetCpuTimeInMs())
+	attrs.PutInt("bazel.metrics.analysis_phase_time_ms", tm.GetAnalysisPhaseTimeInMs())
+	attrs.PutInt("bazel.metrics.execution_phase_time_ms", tm.GetExecutionPhaseTimeInMs())
+	attrs.PutInt("bazel.metrics.actions_execution_start_ms", tm.GetActionsExecutionStartInMs())
+	if cpt := tm.GetCriticalPathTime(); cpt != nil {
+		attrs.PutInt("bazel.metrics.critical_path_time_ms", cpt.AsDuration().Milliseconds())
+	}
+}
+
+// stampActionSummaryAttrs writes the scalar totals plus the remote-cache /
+// action-cache / runner-count enrichment established by issue #18.
+func stampActionSummaryAttrs(attrs pcommon.Map, as *bep.BuildMetrics_ActionSummary) {
+	if as == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.actions_created", as.GetActionsCreated())
+	attrs.PutInt("bazel.metrics.actions_created_not_including_aspects", as.GetActionsCreatedNotIncludingAspects())
+	attrs.PutInt("bazel.metrics.actions_executed", as.GetActionsExecuted())
+	attrs.PutInt("bazel.metrics.remote_cache_hits", as.GetRemoteCacheHits()) //nolint:staticcheck // SA1019: field deprecated upstream but still populated by current Bazel releases; issue #18 explicitly surfaces it.
+	applyActionCacheStatistics(attrs, as.GetActionCacheStatistics())
+	applyRunnerCounts(attrs, as.GetRunnerCount())
 }
 
 // applyActionCacheStatistics stamps ActionCacheStatistics onto the metrics span.
 // No-op on nil. Per-miss-reason counts are emitted as
 // bazel.metrics.action_cache.miss.<reason_lowercased>; only reasons present in
 // the payload are emitted (up to 8 enum values per Bazel spec).
-func applyActionCacheStatistics(span ptrace.Span, acs *actioncache.ActionCacheStatistics) {
+func applyActionCacheStatistics(attrs pcommon.Map, acs *actioncache.ActionCacheStatistics) {
 	if acs == nil {
 		return
 	}
-	span.Attributes().PutInt("bazel.metrics.action_cache.hits", int64(acs.GetHits()))
-	span.Attributes().PutInt("bazel.metrics.action_cache.misses", int64(acs.GetMisses()))
+	attrs.PutInt("bazel.metrics.action_cache.hits", int64(acs.GetHits()))
+	attrs.PutInt("bazel.metrics.action_cache.misses", int64(acs.GetMisses()))
 	// SizeInBytes / LoadTimeInMs / SaveTimeInMs are uint64 in the proto; in
 	// practice they fit comfortably in int64 (total build cache size, not a
 	// cumulative throughput counter). Cast is intentional.
-	span.Attributes().PutInt("bazel.metrics.action_cache.size_bytes", int64(acs.GetSizeInBytes()))    //nolint:gosec // G115: uint64 cache size within int64 range for all realistic builds.
-	span.Attributes().PutInt("bazel.metrics.action_cache.load_time_ms", int64(acs.GetLoadTimeInMs())) //nolint:gosec // G115: uint64 load time within int64 range for all realistic builds.
-	span.Attributes().PutInt("bazel.metrics.action_cache.save_time_ms", int64(acs.GetSaveTimeInMs())) //nolint:gosec // G115: uint64 save time within int64 range for all realistic builds.
+	attrs.PutInt("bazel.metrics.action_cache.size_bytes", int64(acs.GetSizeInBytes()))    //nolint:gosec // G115: uint64 cache size within int64 range for all realistic builds.
+	attrs.PutInt("bazel.metrics.action_cache.load_time_ms", int64(acs.GetLoadTimeInMs())) //nolint:gosec // G115: uint64 load time within int64 range for all realistic builds.
+	attrs.PutInt("bazel.metrics.action_cache.save_time_ms", int64(acs.GetSaveTimeInMs())) //nolint:gosec // G115: uint64 save time within int64 range for all realistic builds.
 
 	for _, md := range acs.GetMissDetails() {
 		if md == nil {
@@ -804,18 +845,17 @@ func applyActionCacheStatistics(span ptrace.Span, acs *actioncache.ActionCacheSt
 		if reason == "" {
 			continue
 		}
-		span.Attributes().PutInt("bazel.metrics.action_cache.miss."+reason, int64(md.GetCount()))
+		attrs.PutInt("bazel.metrics.action_cache.miss."+reason, int64(md.GetCount()))
 	}
 }
 
 // applyRunnerCounts emits bazel.metrics.runners as a slice of maps, one per
-// RunnerCount entry. Order mirrors the payload; empty slice yields an empty
-// attribute so downstream queries can assert presence without a special case.
-func applyRunnerCounts(span ptrace.Span, runners []*bep.BuildMetrics_ActionSummary_RunnerCount) {
+// RunnerCount entry. Order mirrors the payload.
+func applyRunnerCounts(attrs pcommon.Map, runners []*bep.BuildMetrics_ActionSummary_RunnerCount) {
 	if len(runners) == 0 {
 		return
 	}
-	slice := span.Attributes().PutEmptySlice("bazel.metrics.runners")
+	slice := attrs.PutEmptySlice("bazel.metrics.runners")
 	for _, rc := range runners {
 		if rc == nil {
 			continue
@@ -824,6 +864,160 @@ func applyRunnerCounts(span ptrace.Span, runners []*bep.BuildMetrics_ActionSumma
 		entry.PutStr("name", rc.GetName())
 		entry.PutInt("count", int64(rc.GetCount()))
 		entry.PutStr("exec_kind", rc.GetExecKind())
+	}
+}
+
+func stampMemoryAttrs(attrs pcommon.Map, mm *bep.BuildMetrics_MemoryMetrics) {
+	if mm == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.memory.used_heap_size_post_build", mm.GetUsedHeapSizePostBuild())
+	attrs.PutInt("bazel.metrics.memory.peak_post_gc_heap_size", mm.GetPeakPostGcHeapSize())
+	attrs.PutInt("bazel.metrics.memory.peak_post_gc_tenured_space_heap_size", mm.GetPeakPostGcTenuredSpaceHeapSize())
+}
+
+// stampTargetAttrs omits the deprecated targets_loaded field — it never measured
+// what the proto comment claims. See build_event_stream.proto:1011-1015.
+func stampTargetAttrs(attrs pcommon.Map, tm *bep.BuildMetrics_TargetMetrics) {
+	if tm == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.targets_configured", tm.GetTargetsConfigured())
+	attrs.PutInt("bazel.metrics.targets_configured_not_including_aspects", tm.GetTargetsConfiguredNotIncludingAspects())
+}
+
+func stampPackageAttrs(attrs pcommon.Map, pm *bep.BuildMetrics_PackageMetrics) {
+	if pm == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.packages_loaded", pm.GetPackagesLoaded())
+}
+
+func stampBuildGraphAttrs(attrs pcommon.Map, bgm *bep.BuildMetrics_BuildGraphMetrics) {
+	if bgm == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.graph.action_lookup_value_count", int64(bgm.GetActionLookupValueCount()))
+	attrs.PutInt("bazel.metrics.graph.action_lookup_value_count_not_including_aspects", int64(bgm.GetActionLookupValueCountNotIncludingAspects()))
+	attrs.PutInt("bazel.metrics.graph.action_count", int64(bgm.GetActionCount()))
+	attrs.PutInt("bazel.metrics.graph.action_count_not_including_aspects", int64(bgm.GetActionCountNotIncludingAspects()))
+	attrs.PutInt("bazel.metrics.graph.input_file_configured_target_count", int64(bgm.GetInputFileConfiguredTargetCount()))
+	attrs.PutInt("bazel.metrics.graph.output_file_configured_target_count", int64(bgm.GetOutputFileConfiguredTargetCount()))
+	attrs.PutInt("bazel.metrics.graph.other_configured_target_count", int64(bgm.GetOtherConfiguredTargetCount()))
+	attrs.PutInt("bazel.metrics.graph.output_artifact_count", int64(bgm.GetOutputArtifactCount()))
+	attrs.PutInt("bazel.metrics.graph.post_invocation_skyframe_node_count", int64(bgm.GetPostInvocationSkyframeNodeCount()))
+}
+
+// stampArtifactAttrs emits one count + one size attr per artifact category. A nil
+// FilesMetric leaves the pair unset — common for categories Bazel didn't populate
+// (e.g. top-level artifacts without --output_groups).
+func stampArtifactAttrs(attrs pcommon.Map, am *bep.BuildMetrics_ArtifactMetrics) {
+	if am == nil {
+		return
+	}
+	stampFilesMetric(attrs, "bazel.metrics.artifacts.source_read", am.GetSourceArtifactsRead())
+	stampFilesMetric(attrs, "bazel.metrics.artifacts.output", am.GetOutputArtifactsSeen())
+	stampFilesMetric(attrs, "bazel.metrics.artifacts.from_action_cache", am.GetOutputArtifactsFromActionCache())
+	stampFilesMetric(attrs, "bazel.metrics.artifacts.top_level", am.GetTopLevelArtifacts())
+}
+
+func stampFilesMetric(attrs pcommon.Map, prefix string, fm *bep.BuildMetrics_ArtifactMetrics_FilesMetric) {
+	if fm == nil {
+		return
+	}
+	attrs.PutInt(prefix+"_count", int64(fm.GetCount()))
+	attrs.PutInt(prefix+"_bytes", fm.GetSizeInBytes())
+}
+
+// stampNetworkAttrs reaches into the SystemNetworkStats sub-message for the 8
+// throughput + peak fields. NetworkMetrics itself being non-nil but
+// SystemNetworkStats nil is treated as "no network data collected". The proto
+// exposes uint64 counters; saturateUint64 avoids flipping them negative on the
+// (implausible but possible) overflow into int64.
+func stampNetworkAttrs(attrs pcommon.Map, nm *bep.BuildMetrics_NetworkMetrics) {
+	if nm == nil {
+		return
+	}
+	stats := nm.GetSystemNetworkStats()
+	if stats == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.network.bytes_sent", saturateUint64(stats.GetBytesSent()))
+	attrs.PutInt("bazel.metrics.network.bytes_recv", saturateUint64(stats.GetBytesRecv()))
+	attrs.PutInt("bazel.metrics.network.packets_sent", saturateUint64(stats.GetPacketsSent()))
+	attrs.PutInt("bazel.metrics.network.packets_recv", saturateUint64(stats.GetPacketsRecv()))
+	attrs.PutInt("bazel.metrics.network.peak_bytes_sent_per_sec", saturateUint64(stats.GetPeakBytesSentPerSec()))
+	attrs.PutInt("bazel.metrics.network.peak_bytes_recv_per_sec", saturateUint64(stats.GetPeakBytesRecvPerSec()))
+	attrs.PutInt("bazel.metrics.network.peak_packets_sent_per_sec", saturateUint64(stats.GetPeakPacketsSentPerSec()))
+	attrs.PutInt("bazel.metrics.network.peak_packets_recv_per_sec", saturateUint64(stats.GetPeakPacketsRecvPerSec()))
+}
+
+// saturateUint64 clamps a uint64 to math.MaxInt64 so we never emit a negative
+// "count" to metric backends. Real network counters should never approach this
+// boundary during a single invocation, but the conversion is worth making
+// explicit.
+func saturateUint64(v uint64) int64 {
+	if v > uint64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	return int64(v)
+}
+
+func stampCumulativeAttrs(attrs pcommon.Map, cm *bep.BuildMetrics_CumulativeMetrics) {
+	if cm == nil {
+		return
+	}
+	attrs.PutInt("bazel.metrics.cumulative.num_analyses", int64(cm.GetNumAnalyses()))
+	attrs.PutInt("bazel.metrics.cumulative.num_builds", int64(cm.GetNumBuilds()))
+}
+
+// stampDynamicExecutionAttrs emits a slice-of-map attribute so each mnemonic's
+// race outcome stays together. Capped at maxBuildMetricsSliceEntries to bound
+// attribute payload size even if Bazel emits one entry per mnemonic in a large
+// workspace.
+func stampDynamicExecutionAttrs(attrs pcommon.Map, dem *bep.BuildMetrics_DynamicExecutionMetrics) {
+	if dem == nil {
+		return
+	}
+	stats := dem.GetRaceStatistics()
+	if len(stats) == 0 {
+		return
+	}
+	slice := attrs.PutEmptySlice("bazel.metrics.dynamic_execution")
+	for i, rs := range stats {
+		if i >= maxBuildMetricsSliceEntries {
+			break
+		}
+		entry := slice.AppendEmpty().SetEmptyMap()
+		entry.PutStr("mnemonic", rs.GetMnemonic())
+		entry.PutStr("local_runner", rs.GetLocalRunner())
+		entry.PutStr("remote_runner", rs.GetRemoteRunner())
+		entry.PutInt("local_wins", int64(rs.GetLocalWins()))
+		entry.PutInt("remote_wins", int64(rs.GetRemoteWins()))
+	}
+}
+
+// stampWorkerPoolAttrs emits a slice-of-map attribute for per-mnemonic worker
+// pool lifecycle stats. Same cap rationale as DynamicExecutionMetrics.
+func stampWorkerPoolAttrs(attrs pcommon.Map, wpm *bep.BuildMetrics_WorkerPoolMetrics) {
+	if wpm == nil {
+		return
+	}
+	stats := wpm.GetWorkerPoolStats()
+	if len(stats) == 0 {
+		return
+	}
+	slice := attrs.PutEmptySlice("bazel.metrics.worker_pool")
+	for i, ws := range stats {
+		if i >= maxBuildMetricsSliceEntries {
+			break
+		}
+		entry := slice.AppendEmpty().SetEmptyMap()
+		entry.PutStr("mnemonic", ws.GetMnemonic())
+		entry.PutInt("created_count", ws.GetCreatedCount())
+		entry.PutInt("destroyed_count", ws.GetDestroyedCount())
+		entry.PutInt("evicted_count", ws.GetEvictedCount())
+		entry.PutInt("alive_count", ws.GetAliveCount())
 	}
 }
 

--- a/receiver/besreceiver/invocation_test.go
+++ b/receiver/besreceiver/invocation_test.go
@@ -1,0 +1,448 @@
+package besreceiver
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+)
+
+// newMetricsSpanState constructs the minimal invocationState needed to exercise
+// buildMetricsSpan. Shared across the extended-metrics attribute tests below.
+func newMetricsSpanState() *invocationState {
+	return &invocationState{
+		traceID:    pcommon.TraceID{1},
+		rootSpanID: pcommon.SpanID{1},
+		uuid:       "uuid-metrics",
+		createdAt:  time.Now(),
+	}
+}
+
+func metricsSpanAttrs(t *testing.T, metrics *bep.BuildMetrics) pcommon.Map {
+	t.Helper()
+	state := newMetricsSpanState()
+	traces := state.buildMetricsSpan(metrics)
+	if traces.SpanCount() != 1 {
+		t.Fatalf("expected 1 span, got %d", traces.SpanCount())
+	}
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	if got := span.Name(); got != "bazel.metrics" {
+		t.Fatalf("expected span name bazel.metrics, got %q", got)
+	}
+	return span.Attributes()
+}
+
+func mustInt(t *testing.T, attrs pcommon.Map, key string, want int64) {
+	t.Helper()
+	v, ok := attrs.Get(key)
+	if !ok {
+		t.Errorf("missing attribute %q", key)
+		return
+	}
+	if v.Int() != want {
+		t.Errorf("attr %q: got %d, want %d", key, v.Int(), want)
+	}
+}
+
+func mustAbsent(t *testing.T, attrs pcommon.Map, key string) {
+	t.Helper()
+	if _, ok := attrs.Get(key); ok {
+		t.Errorf("attribute %q unexpectedly present", key)
+	}
+}
+
+func TestBuildMetricsSpan_NilBuildMetricsEmitsEmptySpan(t *testing.T) {
+	attrs := metricsSpanAttrs(t, &bep.BuildMetrics{})
+	if attrs.Len() != 0 {
+		t.Errorf("expected no attributes when all sub-messages nil, got %d", attrs.Len())
+	}
+}
+
+func TestBuildMetricsSpan_TimingExtras(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+			WallTimeInMs:              10000,
+			CpuTimeInMs:               5000,
+			AnalysisPhaseTimeInMs:     1000,
+			ExecutionPhaseTimeInMs:    2000,
+			ActionsExecutionStartInMs: 500,
+			CriticalPathTime:          durationpb.New(3 * time.Second),
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.wall_time_ms", 10000)
+	mustInt(t, attrs, "bazel.metrics.cpu_time_ms", 5000)
+	mustInt(t, attrs, "bazel.metrics.analysis_phase_time_ms", 1000)
+	mustInt(t, attrs, "bazel.metrics.execution_phase_time_ms", 2000)
+	mustInt(t, attrs, "bazel.metrics.actions_execution_start_ms", 500)
+	mustInt(t, attrs, "bazel.metrics.critical_path_time_ms", 3000)
+}
+
+// Critical-path duration is a proto sub-message; missing means "unmeasured".
+// We don't want to emit a misleading zero, so ensure the attribute is absent.
+func TestBuildMetricsSpan_TimingWithoutCriticalPath(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		TimingMetrics: &bep.BuildMetrics_TimingMetrics{
+			WallTimeInMs: 100,
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.wall_time_ms", 100)
+	mustAbsent(t, attrs, "bazel.metrics.critical_path_time_ms")
+}
+
+func TestBuildMetricsSpan_ActionSummary(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:                    500,
+			ActionsCreatedNotIncludingAspects: 480,
+			ActionsExecuted:                   42,
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.actions_created", 500)
+	mustInt(t, attrs, "bazel.metrics.actions_created_not_including_aspects", 480)
+	mustInt(t, attrs, "bazel.metrics.actions_executed", 42)
+}
+
+func TestBuildMetricsSpan_Memory(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
+			UsedHeapSizePostBuild:          1 << 30,
+			PeakPostGcHeapSize:             2 << 30,
+			PeakPostGcTenuredSpaceHeapSize: 3 << 30,
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.memory.used_heap_size_post_build", 1<<30)
+	mustInt(t, attrs, "bazel.metrics.memory.peak_post_gc_heap_size", 2<<30)
+	mustInt(t, attrs, "bazel.metrics.memory.peak_post_gc_tenured_space_heap_size", 3<<30)
+}
+
+// Deprecated targets_loaded stays off the span — verify it is absent even when
+// populated upstream (Bazel versions still set it).
+func TestBuildMetricsSpan_TargetSkipsDeprecatedTargetsLoaded(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		TargetMetrics: &bep.BuildMetrics_TargetMetrics{
+			TargetsLoaded:                        9999,
+			TargetsConfigured:                    1234,
+			TargetsConfiguredNotIncludingAspects: 1200,
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustAbsent(t, attrs, "bazel.metrics.targets_loaded")
+	mustInt(t, attrs, "bazel.metrics.targets_configured", 1234)
+	mustInt(t, attrs, "bazel.metrics.targets_configured_not_including_aspects", 1200)
+}
+
+func TestBuildMetricsSpan_Package(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		PackageMetrics: &bep.BuildMetrics_PackageMetrics{
+			PackagesLoaded: 321,
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.packages_loaded", 321)
+}
+
+func TestBuildMetricsSpan_BuildGraph(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		BuildGraphMetrics: &bep.BuildMetrics_BuildGraphMetrics{
+			ActionLookupValueCount:                    10,
+			ActionLookupValueCountNotIncludingAspects: 9,
+			ActionCount:                     100,
+			ActionCountNotIncludingAspects:  95,
+			InputFileConfiguredTargetCount:  50,
+			OutputFileConfiguredTargetCount: 25,
+			OtherConfiguredTargetCount:      5,
+			OutputArtifactCount:             200,
+			PostInvocationSkyframeNodeCount: 5000,
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.graph.action_lookup_value_count", 10)
+	mustInt(t, attrs, "bazel.metrics.graph.action_lookup_value_count_not_including_aspects", 9)
+	mustInt(t, attrs, "bazel.metrics.graph.action_count", 100)
+	mustInt(t, attrs, "bazel.metrics.graph.action_count_not_including_aspects", 95)
+	mustInt(t, attrs, "bazel.metrics.graph.input_file_configured_target_count", 50)
+	mustInt(t, attrs, "bazel.metrics.graph.output_file_configured_target_count", 25)
+	mustInt(t, attrs, "bazel.metrics.graph.other_configured_target_count", 5)
+	mustInt(t, attrs, "bazel.metrics.graph.output_artifact_count", 200)
+	mustInt(t, attrs, "bazel.metrics.graph.post_invocation_skyframe_node_count", 5000)
+}
+
+func TestBuildMetricsSpan_Artifacts(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		ArtifactMetrics: &bep.BuildMetrics_ArtifactMetrics{
+			SourceArtifactsRead: &bep.BuildMetrics_ArtifactMetrics_FilesMetric{
+				SizeInBytes: 1000, Count: 10,
+			},
+			OutputArtifactsSeen: &bep.BuildMetrics_ArtifactMetrics_FilesMetric{
+				SizeInBytes: 2000, Count: 20,
+			},
+			OutputArtifactsFromActionCache: &bep.BuildMetrics_ArtifactMetrics_FilesMetric{
+				SizeInBytes: 3000, Count: 30,
+			},
+			TopLevelArtifacts: &bep.BuildMetrics_ArtifactMetrics_FilesMetric{
+				SizeInBytes: 4000, Count: 4,
+			},
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.artifacts.source_read_count", 10)
+	mustInt(t, attrs, "bazel.metrics.artifacts.source_read_bytes", 1000)
+	mustInt(t, attrs, "bazel.metrics.artifacts.output_count", 20)
+	mustInt(t, attrs, "bazel.metrics.artifacts.output_bytes", 2000)
+	mustInt(t, attrs, "bazel.metrics.artifacts.from_action_cache_count", 30)
+	mustInt(t, attrs, "bazel.metrics.artifacts.from_action_cache_bytes", 3000)
+	mustInt(t, attrs, "bazel.metrics.artifacts.top_level_count", 4)
+	mustInt(t, attrs, "bazel.metrics.artifacts.top_level_bytes", 4000)
+}
+
+func TestBuildMetricsSpan_ArtifactsPartial(t *testing.T) {
+	// Only one FilesMetric populated — the others must remain absent, not zero-filled.
+	metrics := &bep.BuildMetrics{
+		ArtifactMetrics: &bep.BuildMetrics_ArtifactMetrics{
+			SourceArtifactsRead: &bep.BuildMetrics_ArtifactMetrics_FilesMetric{
+				SizeInBytes: 42, Count: 2,
+			},
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.artifacts.source_read_count", 2)
+	mustInt(t, attrs, "bazel.metrics.artifacts.source_read_bytes", 42)
+	mustAbsent(t, attrs, "bazel.metrics.artifacts.output_count")
+	mustAbsent(t, attrs, "bazel.metrics.artifacts.output_bytes")
+	mustAbsent(t, attrs, "bazel.metrics.artifacts.from_action_cache_count")
+	mustAbsent(t, attrs, "bazel.metrics.artifacts.top_level_count")
+}
+
+func TestBuildMetricsSpan_Network(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		NetworkMetrics: &bep.BuildMetrics_NetworkMetrics{
+			SystemNetworkStats: &bep.BuildMetrics_NetworkMetrics_SystemNetworkStats{
+				BytesSent:             100,
+				BytesRecv:             200,
+				PacketsSent:           10,
+				PacketsRecv:           20,
+				PeakBytesSentPerSec:   1000,
+				PeakBytesRecvPerSec:   2000,
+				PeakPacketsSentPerSec: 100,
+				PeakPacketsRecvPerSec: 200,
+			},
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.network.bytes_sent", 100)
+	mustInt(t, attrs, "bazel.metrics.network.bytes_recv", 200)
+	mustInt(t, attrs, "bazel.metrics.network.packets_sent", 10)
+	mustInt(t, attrs, "bazel.metrics.network.packets_recv", 20)
+	mustInt(t, attrs, "bazel.metrics.network.peak_bytes_sent_per_sec", 1000)
+	mustInt(t, attrs, "bazel.metrics.network.peak_bytes_recv_per_sec", 2000)
+	mustInt(t, attrs, "bazel.metrics.network.peak_packets_sent_per_sec", 100)
+	mustInt(t, attrs, "bazel.metrics.network.peak_packets_recv_per_sec", 200)
+}
+
+// NetworkMetrics present but SystemNetworkStats nil is indistinguishable from
+// "Bazel didn't collect network data"; emitting zeros would mislead dashboards.
+func TestBuildMetricsSpan_NetworkWithoutSystemStats(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		NetworkMetrics: &bep.BuildMetrics_NetworkMetrics{},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustAbsent(t, attrs, "bazel.metrics.network.bytes_sent")
+	mustAbsent(t, attrs, "bazel.metrics.network.peak_bytes_sent_per_sec")
+}
+
+func TestBuildMetricsSpan_Cumulative(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		CumulativeMetrics: &bep.BuildMetrics_CumulativeMetrics{
+			NumAnalyses: 3,
+			NumBuilds:   2,
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustInt(t, attrs, "bazel.metrics.cumulative.num_analyses", 3)
+	mustInt(t, attrs, "bazel.metrics.cumulative.num_builds", 2)
+}
+
+func TestBuildMetricsSpan_DynamicExecution(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		DynamicExecutionMetrics: &bep.BuildMetrics_DynamicExecutionMetrics{
+			RaceStatistics: []*bep.BuildMetrics_DynamicExecutionMetrics_RaceStatistics{
+				{Mnemonic: "Javac", LocalRunner: "local", RemoteRunner: "remote", LocalWins: 5, RemoteWins: 10},
+				{Mnemonic: "CppCompile", LocalRunner: "local", RemoteRunner: "remote", LocalWins: 3, RemoteWins: 7},
+			},
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	v, ok := attrs.Get("bazel.metrics.dynamic_execution")
+	if !ok {
+		t.Fatal("missing bazel.metrics.dynamic_execution")
+	}
+	slice := v.Slice()
+	if slice.Len() != 2 {
+		t.Fatalf("expected 2 race stats, got %d", slice.Len())
+	}
+	first := slice.At(0).Map()
+	if m, _ := first.Get("mnemonic"); m.Str() != "Javac" {
+		t.Errorf("expected first mnemonic Javac, got %q", m.Str())
+	}
+	if w, _ := first.Get("local_wins"); w.Int() != 5 {
+		t.Errorf("expected local_wins=5, got %d", w.Int())
+	}
+	if w, _ := first.Get("remote_wins"); w.Int() != 10 {
+		t.Errorf("expected remote_wins=10, got %d", w.Int())
+	}
+	if r, _ := first.Get("local_runner"); r.Str() != "local" {
+		t.Errorf("expected local_runner=local, got %q", r.Str())
+	}
+	if r, _ := first.Get("remote_runner"); r.Str() != "remote" {
+		t.Errorf("expected remote_runner=remote, got %q", r.Str())
+	}
+}
+
+// Cardinality cap: 25 incoming entries -> 20 emitted. Protects trace backends
+// against pathological Bazel workspaces with thousands of distinct mnemonics.
+func TestBuildMetricsSpan_DynamicExecutionCap(t *testing.T) {
+	var stats []*bep.BuildMetrics_DynamicExecutionMetrics_RaceStatistics
+	for i := range 25 {
+		stats = append(stats, &bep.BuildMetrics_DynamicExecutionMetrics_RaceStatistics{
+			Mnemonic: "m", LocalWins: int32(i),
+		})
+	}
+	metrics := &bep.BuildMetrics{
+		DynamicExecutionMetrics: &bep.BuildMetrics_DynamicExecutionMetrics{RaceStatistics: stats},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	v, ok := attrs.Get("bazel.metrics.dynamic_execution")
+	if !ok {
+		t.Fatal("missing bazel.metrics.dynamic_execution")
+	}
+	if v.Slice().Len() != maxBuildMetricsSliceEntries {
+		t.Errorf("expected slice capped at %d, got %d", maxBuildMetricsSliceEntries, v.Slice().Len())
+	}
+}
+
+// Empty RaceStatistics should leave the attr unset, not emit an empty slice.
+func TestBuildMetricsSpan_DynamicExecutionEmpty(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		DynamicExecutionMetrics: &bep.BuildMetrics_DynamicExecutionMetrics{},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustAbsent(t, attrs, "bazel.metrics.dynamic_execution")
+}
+
+func TestBuildMetricsSpan_WorkerPool(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		WorkerPoolMetrics: &bep.BuildMetrics_WorkerPoolMetrics{
+			WorkerPoolStats: []*bep.BuildMetrics_WorkerPoolMetrics_WorkerPoolStats{
+				{Mnemonic: "Javac", CreatedCount: 5, DestroyedCount: 2, EvictedCount: 1, AliveCount: 3},
+			},
+		},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	v, ok := attrs.Get("bazel.metrics.worker_pool")
+	if !ok {
+		t.Fatal("missing bazel.metrics.worker_pool")
+	}
+	slice := v.Slice()
+	if slice.Len() != 1 {
+		t.Fatalf("expected 1 worker pool stat, got %d", slice.Len())
+	}
+	first := slice.At(0).Map()
+	if m, _ := first.Get("mnemonic"); m.Str() != "Javac" {
+		t.Errorf("expected mnemonic=Javac, got %q", m.Str())
+	}
+	if c, _ := first.Get("created_count"); c.Int() != 5 {
+		t.Errorf("expected created_count=5, got %d", c.Int())
+	}
+	if c, _ := first.Get("destroyed_count"); c.Int() != 2 {
+		t.Errorf("expected destroyed_count=2, got %d", c.Int())
+	}
+	if c, _ := first.Get("evicted_count"); c.Int() != 1 {
+		t.Errorf("expected evicted_count=1, got %d", c.Int())
+	}
+	if c, _ := first.Get("alive_count"); c.Int() != 3 {
+		t.Errorf("expected alive_count=3, got %d", c.Int())
+	}
+}
+
+func TestBuildMetricsSpan_WorkerPoolCap(t *testing.T) {
+	var stats []*bep.BuildMetrics_WorkerPoolMetrics_WorkerPoolStats
+	for range 50 {
+		stats = append(stats, &bep.BuildMetrics_WorkerPoolMetrics_WorkerPoolStats{Mnemonic: "m"})
+	}
+	metrics := &bep.BuildMetrics{
+		WorkerPoolMetrics: &bep.BuildMetrics_WorkerPoolMetrics{WorkerPoolStats: stats},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	v, ok := attrs.Get("bazel.metrics.worker_pool")
+	if !ok {
+		t.Fatal("missing bazel.metrics.worker_pool")
+	}
+	if v.Slice().Len() != maxBuildMetricsSliceEntries {
+		t.Errorf("expected slice capped at %d, got %d", maxBuildMetricsSliceEntries, v.Slice().Len())
+	}
+}
+
+func TestBuildMetricsSpan_WorkerPoolEmpty(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		WorkerPoolMetrics: &bep.BuildMetrics_WorkerPoolMetrics{},
+	}
+	attrs := metricsSpanAttrs(t, metrics)
+	mustAbsent(t, attrs, "bazel.metrics.worker_pool")
+}
+
+// Intentionally-skipped sub-messages: GarbageMetrics (under MemoryMetrics),
+// PackageLoadMetrics (under PackageMetrics), WorkerMetrics, EvaluationStat
+// slices on BuildGraphMetrics, RuleClassCount, AspectCount, and
+// RemoteAnalysisCacheStatistics. None should produce span attrs.
+func TestBuildMetricsSpan_SkipsHighCardinalitySubMessages(t *testing.T) {
+	metrics := &bep.BuildMetrics{
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
+			UsedHeapSizePostBuild: 1,
+			GarbageMetrics: []*bep.BuildMetrics_MemoryMetrics_GarbageMetrics{
+				{Type: "G1 Young"},
+			},
+		},
+		BuildGraphMetrics: &bep.BuildMetrics_BuildGraphMetrics{
+			ActionCount:     1,
+			DirtiedValues:   []*bep.BuildMetrics_EvaluationStat{{SkyfunctionName: "x", Count: 1}},
+			ChangedValues:   []*bep.BuildMetrics_EvaluationStat{{SkyfunctionName: "x", Count: 1}},
+			BuiltValues:     []*bep.BuildMetrics_EvaluationStat{{SkyfunctionName: "x", Count: 1}},
+			EvaluatedValues: []*bep.BuildMetrics_EvaluationStat{{SkyfunctionName: "x", Count: 1}},
+			RuleClass:       []*bep.BuildMetrics_BuildGraphMetrics_RuleClassCount{{RuleClass: "rule", Count: 1}},
+			Aspect:          []*bep.BuildMetrics_BuildGraphMetrics_AspectCount{{AspectName: "a", Count: 1}},
+		},
+		WorkerMetrics: []*bep.BuildMetrics_WorkerMetrics{
+			{WorkerIds: []uint32{1}, Mnemonic: "Javac"},
+		},
+		RemoteAnalysisCacheStatistics: &bep.BuildMetrics_RemoteAnalysisCacheStatistics{
+			CacheHits: 1,
+		},
+	}
+
+	attrs := metricsSpanAttrs(t, metrics)
+	// Scalar fields from Memory + BuildGraph ARE present; slices ARE NOT.
+	mustInt(t, attrs, "bazel.metrics.memory.used_heap_size_post_build", 1)
+	mustInt(t, attrs, "bazel.metrics.graph.action_count", 1)
+
+	skippedKeys := []string{
+		"bazel.metrics.memory.garbage_metrics",
+		"bazel.metrics.graph.dirtied_values",
+		"bazel.metrics.graph.changed_values",
+		"bazel.metrics.graph.built_values",
+		"bazel.metrics.graph.evaluated_values",
+		"bazel.metrics.graph.rule_class",
+		"bazel.metrics.graph.aspect",
+		"bazel.metrics.worker_metrics",
+		"bazel.metrics.remote_analysis_cache",
+	}
+	for _, k := range skippedKeys {
+		mustAbsent(t, attrs, k)
+	}
+}

--- a/receiver/besreceiver/metricsbuilder.go
+++ b/receiver/besreceiver/metricsbuilder.go
@@ -50,6 +50,7 @@ func addActionSummaryGauges(sm pmetric.ScopeMetrics, as *bep.BuildMetrics_Action
 		return
 	}
 	addGaugeInt64(sm, "bazel.invocation.actions_created", "{action}", "Total actions created during the build", ts, as.GetActionsCreated(), attrs)
+	addGaugeInt64(sm, "bazel.invocation.actions_created_not_including_aspects", "{action}", "Actions created for configured targets (excluding aspects)", ts, as.GetActionsCreatedNotIncludingAspects(), attrs)
 	addGaugeInt64(sm, "bazel.invocation.actions_executed", "{action}", "Total actions executed during the build", ts, as.GetActionsExecuted(), attrs)
 }
 

--- a/receiver/besreceiver/metricsbuilder_test.go
+++ b/receiver/besreceiver/metricsbuilder_test.go
@@ -81,21 +81,23 @@ func TestBuildInvocationMetrics_ActionSummary(t *testing.T) {
 	}
 	metrics := &bep.BuildMetrics{
 		ActionSummary: &bep.BuildMetrics_ActionSummary{
-			ActionsCreated:  500,
-			ActionsExecuted: 42,
+			ActionsCreated:                    500,
+			ActionsCreatedNotIncludingAspects: 480,
+			ActionsExecuted:                   42,
 		},
 	}
 
 	md := buildInvocationGauges("inv-2", state, metrics, ts)
 
-	if md.MetricCount() != 2 {
-		t.Fatalf("expected 2 metrics, got %d", md.MetricCount())
+	if md.MetricCount() != 3 {
+		t.Fatalf("expected 3 metrics, got %d", md.MetricCount())
 	}
 
 	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
 	wantGauges := map[string]int64{
-		"bazel.invocation.actions_created":  500,
-		"bazel.invocation.actions_executed": 42,
+		"bazel.invocation.actions_created":                       500,
+		"bazel.invocation.actions_created_not_including_aspects": 480,
+		"bazel.invocation.actions_executed":                      42,
 	}
 
 	for i := range sm.Metrics().Len() {
@@ -336,8 +338,8 @@ func TestBuildInvocationMetrics_AllCategories(t *testing.T) {
 
 	md := buildInvocationGauges("inv-all", state, metrics, ts)
 
-	// 5 timing (no CriticalPathTime since it's nil) + 2 action + 2 memory = 9.
-	if md.MetricCount() != 9 {
-		t.Fatalf("expected 9 metrics, got %d", md.MetricCount())
+	// 5 timing (no CriticalPathTime since it's nil) + 3 action + 2 memory = 10.
+	if md.MetricCount() != 10 {
+		t.Fatalf("expected 10 metrics, got %d", md.MetricCount())
 	}
 }


### PR DESCRIPTION
Surfaces the BuildMetrics sub-messages that were still being dropped: memory, target, package, build graph, artifact, network (totals + peaks inside `SystemNetworkStats`), cumulative analyses/builds, and timing additions (`critical_path_time_ms`, `actions_execution_start_ms`). Slice-valued `DynamicExecutionMetrics` and `WorkerPoolMetrics` are emitted as Slice[Map] span attributes capped at 20 entries each so per-mnemonic race/pool stats stay legible without unbounded cardinality. `ActionSummary` also gains `actions_created_not_including_aspects` as both a span attribute and a new invocation-scoped gauge. The deprecated `targets_loaded` is explicitly omitted — the proto notes it never measured what it claimed.

The span-body emission is refactored into a dispatch of small `stamp*Attrs` helpers, one per sub-message, each a no-op on nil. The rebase folded #18's action-cache and runner-count enrichment into `stampActionSummaryAttrs`, so the single ActionSummary helper now owns the full enrichment surface. `saturateUint64` clamps the uint64 network counters so we never emit negative values if they somehow overflow `int64`.

High-cardinality sub-messages (`GarbageMetrics`, `PackageLoadMetrics`, `EvaluationStat`/`RuleClassCount`/`AspectCount`, `WorkerMetrics`, `RemoteAnalysisCacheStatistics`) are left for #29, and a `TestBuildMetricsSpan_SkipsHighCardinalitySubMessages` test pins the boundary.

Closes #25.