### PR TITLE
feat(besreceiver): emit high-cardinality BuildMetrics sub-messages as span attributes

### DIFF
--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -24,6 +24,66 @@ type Config struct {
 	// false; enabling a flag surfaces the matching attribute on the root or
 	// action span. See PIIConfig.
 	PII PIIConfig `mapstructure:"pii"`
+
+	// HighCardinalityCaps bounds the size of Slice[Map] attributes emitted on
+	// the bazel.metrics span from high-cardinality BuildMetrics sub-messages
+	// (GarbageMetrics, PackageLoadMetrics, EvaluationStat lists). Zero-valued
+	// fields fall back to defaults (see defaultHighCardinalityCaps). Exceeding
+	// a cap truncates the list and emits a Warn-level log.
+	HighCardinalityCaps HighCardinalityCaps `mapstructure:"high_cardinality_caps"`
+}
+
+// HighCardinalityCaps configures per-attribute limits on the Slice[Map]
+// attributes emitted on the bazel.metrics span for high-cardinality
+// BuildMetrics sub-messages. Emission is span-attribute-only (no standalone
+// metrics) to avoid series explosion in metrics backends. A value of 0 is
+// treated as "use default".
+type HighCardinalityCaps struct {
+	// Garbage caps the number of entries in bazel.metrics.garbage derived from
+	// MemoryMetrics.garbage_metrics. Default: 20.
+	Garbage int `mapstructure:"garbage"`
+	// PackageLoad caps the number of entries in bazel.metrics.package_load
+	// derived from PackageMetrics.package_load_metrics. Default: 100.
+	PackageLoad int `mapstructure:"package_load"`
+	// GraphValues caps the number of entries in each of the five
+	// bazel.metrics.graph.{dirtied,changed,built,cleaned,evaluated}_values
+	// attributes derived from BuildGraphMetrics. Default: 50.
+	GraphValues int `mapstructure:"graph_values"`
+}
+
+// defaultHighCardinalityCaps returns the documented default caps. Mirrored on
+// Config via createDefaultConfig so operator-supplied configs see the defaults
+// without having to opt in explicitly.
+// Default caps chosen for typical Bazel invocations; see HighCardinalityCaps
+// for rationale.
+const (
+	defaultCapGarbage     = 20
+	defaultCapPackageLoad = 100
+	defaultCapGraphValues = 50
+)
+
+func defaultHighCardinalityCaps() HighCardinalityCaps {
+	return HighCardinalityCaps{
+		Garbage:     defaultCapGarbage,
+		PackageLoad: defaultCapPackageLoad,
+		GraphValues: defaultCapGraphValues,
+	}
+}
+
+// withDefaults returns a copy of c where any zero-valued field is replaced
+// with the corresponding default.
+func (c HighCardinalityCaps) withDefaults() HighCardinalityCaps {
+	d := defaultHighCardinalityCaps()
+	if c.Garbage <= 0 {
+		c.Garbage = d.Garbage
+	}
+	if c.PackageLoad <= 0 {
+		c.PackageLoad = d.PackageLoad
+	}
+	if c.GraphValues <= 0 {
+		c.GraphValues = d.GraphValues
+	}
+	return c
 }
 
 // PIIConfig controls which potentially-sensitive fields from BEP events are
@@ -85,6 +145,15 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.InvocationTimeout > 0 && cfg.ReaperInterval > 0 && cfg.ReaperInterval >= cfg.InvocationTimeout {
 		return fmt.Errorf("reaper_interval (%s) must be less than invocation_timeout (%s)", cfg.ReaperInterval, cfg.InvocationTimeout)
+	}
+	if cfg.HighCardinalityCaps.Garbage < 0 {
+		return fmt.Errorf("high_cardinality_caps.garbage must not be negative, got %d", cfg.HighCardinalityCaps.Garbage)
+	}
+	if cfg.HighCardinalityCaps.PackageLoad < 0 {
+		return fmt.Errorf("high_cardinality_caps.package_load must not be negative, got %d", cfg.HighCardinalityCaps.PackageLoad)
+	}
+	if cfg.HighCardinalityCaps.GraphValues < 0 {
+		return fmt.Errorf("high_cardinality_caps.graph_values must not be negative, got %d", cfg.HighCardinalityCaps.GraphValues)
 	}
 	return nil
 }

--- a/receiver/besreceiver/factory.go
+++ b/receiver/besreceiver/factory.go
@@ -38,9 +38,10 @@ func createDefaultConfig() component.Config {
 				Transport: confignet.TransportTypeTCP,
 			},
 		},
-		InvocationTimeout: defaultInvocationTimeout,
-		ReaperInterval:    defaultReaperInterval,
-		PII:               PIIConfig{},
+		InvocationTimeout:   defaultInvocationTimeout,
+		ReaperInterval:      defaultReaperInterval,
+		PII:                 PIIConfig{},
+		HighCardinalityCaps: defaultHighCardinalityCaps(),
 	}
 }
 

--- a/receiver/besreceiver/highcard_test.go
+++ b/receiver/besreceiver/highcard_test.go
@@ -1,0 +1,432 @@
+package besreceiver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+	pkgmetrics "github.com/chagui/besreceiver/internal/bep/packagemetrics"
+)
+
+// newInvocationStateForHighCardTest creates a minimal invocation state suitable
+// for exercising buildMetricsSpan in isolation.
+func newInvocationStateForHighCardTest(caps HighCardinalityCaps) *invocationState {
+	var traceID pcommon.TraceID
+	copy(traceID[:], "0123456789abcdef")
+	var rootSpanID pcommon.SpanID
+	copy(rootSpanID[:], "01234567")
+	return &invocationState{
+		traceID:    traceID,
+		rootSpanID: rootSpanID,
+		uuid:       "uuid-test",
+		started:    &bep.BuildStarted{Command: "build", Uuid: "uuid-test"},
+		createdAt:  time.Now(),
+		caps:       caps,
+	}
+}
+
+func TestBuildMetricsSpan_GarbageMetrics(t *testing.T) {
+	state := newInvocationStateForHighCardTest(defaultHighCardinalityCaps())
+	metrics := &bep.BuildMetrics{
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
+			GarbageMetrics: []*bep.BuildMetrics_MemoryMetrics_GarbageMetrics{
+				{Type: "G1 Old Gen", GarbageCollected: 1000},
+				{Type: "G1 Young Gen", GarbageCollected: 2000},
+			},
+		},
+	}
+
+	traces, _ := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	attr, ok := span.Attributes().Get("bazel.metrics.garbage")
+	if !ok {
+		t.Fatal("expected bazel.metrics.garbage attribute")
+	}
+	if attr.Type() != pcommon.ValueTypeSlice {
+		t.Fatalf("expected slice type, got %s", attr.Type())
+	}
+	slice := attr.Slice()
+	if slice.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", slice.Len())
+	}
+
+	// Validate first entry.
+	entry0 := slice.At(0).Map()
+	gotType, _ := entry0.Get("type")
+	if gotType.Str() != "G1 Old Gen" {
+		t.Errorf("entry 0: expected type=%q, got %q", "G1 Old Gen", gotType.Str())
+	}
+	gotBytes, _ := entry0.Get("garbage_collected_bytes")
+	if gotBytes.Int() != 1000 {
+		t.Errorf("entry 0: expected garbage_collected_bytes=1000, got %d", gotBytes.Int())
+	}
+}
+
+func TestBuildMetricsSpan_PackageLoad(t *testing.T) {
+	state := newInvocationStateForHighCardTest(defaultHighCardinalityCaps())
+	metrics := &bep.BuildMetrics{
+		PackageMetrics: &bep.BuildMetrics_PackageMetrics{
+			PackageLoadMetrics: []*pkgmetrics.PackageLoadMetrics{
+				{
+					Name:                        new("//pkg:a"),
+					LoadDuration:                durationpb.New(250 * time.Millisecond),
+					NumTargets:                  new(uint64(7)),
+					ComputationSteps:            new(uint64(42)),
+					NumTransitiveLoads:          new(uint64(3)),
+					PackageOverhead:             new(uint64(123)),
+					GlobFilesystemOperationCost: new(uint64(9)),
+				},
+			},
+		},
+	}
+
+	traces, _ := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	attr, ok := span.Attributes().Get("bazel.metrics.package_load")
+	if !ok {
+		t.Fatal("expected bazel.metrics.package_load attribute")
+	}
+	slice := attr.Slice()
+	if slice.Len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", slice.Len())
+	}
+	entry := slice.At(0).Map()
+	if v, _ := entry.Get("name"); v.Str() != "//pkg:a" {
+		t.Errorf("name: got %q", v.Str())
+	}
+	if v, _ := entry.Get("load_duration_ms"); v.Int() != 250 {
+		t.Errorf("load_duration_ms: got %d, want 250", v.Int())
+	}
+	if v, _ := entry.Get("num_targets"); v.Int() != 7 {
+		t.Errorf("num_targets: got %d", v.Int())
+	}
+	if v, _ := entry.Get("computation_steps"); v.Int() != 42 {
+		t.Errorf("computation_steps: got %d", v.Int())
+	}
+	if v, _ := entry.Get("num_transitive_loads"); v.Int() != 3 {
+		t.Errorf("num_transitive_loads: got %d", v.Int())
+	}
+	if v, _ := entry.Get("package_overhead"); v.Int() != 123 {
+		t.Errorf("package_overhead: got %d", v.Int())
+	}
+	if v, _ := entry.Get("glob_filesystem_operation_cost"); v.Int() != 9 {
+		t.Errorf("glob_filesystem_operation_cost: got %d", v.Int())
+	}
+}
+
+func TestBuildMetricsSpan_PackageLoad_NilDuration(t *testing.T) {
+	state := newInvocationStateForHighCardTest(defaultHighCardinalityCaps())
+	metrics := &bep.BuildMetrics{
+		PackageMetrics: &bep.BuildMetrics_PackageMetrics{
+			PackageLoadMetrics: []*pkgmetrics.PackageLoadMetrics{
+				{
+					Name:       new("//pkg:a"),
+					NumTargets: new(uint64(1)),
+					// LoadDuration explicitly nil.
+				},
+			},
+		},
+	}
+
+	traces, _ := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	attr, ok := span.Attributes().Get("bazel.metrics.package_load")
+	if !ok {
+		t.Fatal("expected bazel.metrics.package_load attribute")
+	}
+	entry := attr.Slice().At(0).Map()
+	if v, ok := entry.Get("load_duration_ms"); ok && v.Int() != 0 {
+		t.Errorf("expected load_duration_ms to be 0 or absent for nil duration, got %d", v.Int())
+	}
+}
+
+func TestBuildMetricsSpan_GraphValues(t *testing.T) {
+	state := newInvocationStateForHighCardTest(defaultHighCardinalityCaps())
+	metrics := &bep.BuildMetrics{
+		BuildGraphMetrics: &bep.BuildMetrics_BuildGraphMetrics{
+			DirtiedValues: []*bep.BuildMetrics_EvaluationStat{
+				{SkyfunctionName: "FILE", Count: 10},
+			},
+			ChangedValues: []*bep.BuildMetrics_EvaluationStat{
+				{SkyfunctionName: "FILE_STATE", Count: 5},
+			},
+			BuiltValues: []*bep.BuildMetrics_EvaluationStat{
+				{SkyfunctionName: "ACTION_EXECUTION", Count: 20},
+			},
+			CleanedValues: []*bep.BuildMetrics_EvaluationStat{
+				{SkyfunctionName: "GLOB", Count: 2},
+			},
+			EvaluatedValues: []*bep.BuildMetrics_EvaluationStat{
+				{SkyfunctionName: "CONFIGURED_TARGET", Count: 100},
+			},
+		},
+	}
+
+	traces, _ := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+
+	cases := map[string]struct {
+		skyFn string
+		count int64
+	}{
+		"bazel.metrics.graph.dirtied_values":   {"FILE", 10},
+		"bazel.metrics.graph.changed_values":   {"FILE_STATE", 5},
+		"bazel.metrics.graph.built_values":     {"ACTION_EXECUTION", 20},
+		"bazel.metrics.graph.cleaned_values":   {"GLOB", 2},
+		"bazel.metrics.graph.evaluated_values": {"CONFIGURED_TARGET", 100},
+	}
+	for name, want := range cases {
+		attr, ok := span.Attributes().Get(name)
+		if !ok {
+			t.Errorf("missing attribute %s", name)
+			continue
+		}
+		slice := attr.Slice()
+		if slice.Len() != 1 {
+			t.Errorf("%s: expected 1 entry, got %d", name, slice.Len())
+			continue
+		}
+		entry := slice.At(0).Map()
+		if v, _ := entry.Get("skyfunction"); v.Str() != want.skyFn {
+			t.Errorf("%s: skyfunction got %q want %q", name, v.Str(), want.skyFn)
+		}
+		if v, _ := entry.Get("count"); v.Int() != want.count {
+			t.Errorf("%s: count got %d want %d", name, v.Int(), want.count)
+		}
+	}
+}
+
+func TestBuildMetricsSpan_NilSubMessages(t *testing.T) {
+	state := newInvocationStateForHighCardTest(defaultHighCardinalityCaps())
+	// BuildMetrics with only non-high-cardinality sub-messages present and
+	// nil MemoryMetrics / PackageMetrics / BuildGraphMetrics.
+	metrics := &bep.BuildMetrics{}
+
+	traces, truncs := state.buildMetricsSpan(metrics)
+	if len(truncs) != 0 {
+		t.Errorf("expected no truncations, got %v", truncs)
+	}
+
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	for _, name := range []string{
+		"bazel.metrics.garbage",
+		"bazel.metrics.package_load",
+		"bazel.metrics.graph.dirtied_values",
+		"bazel.metrics.graph.changed_values",
+		"bazel.metrics.graph.built_values",
+		"bazel.metrics.graph.cleaned_values",
+		"bazel.metrics.graph.evaluated_values",
+	} {
+		if _, ok := span.Attributes().Get(name); ok {
+			t.Errorf("expected attribute %s to be absent for nil sub-messages", name)
+		}
+	}
+}
+
+func TestBuildMetricsSpan_EmptyLists(t *testing.T) {
+	state := newInvocationStateForHighCardTest(defaultHighCardinalityCaps())
+	metrics := &bep.BuildMetrics{
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
+			GarbageMetrics: []*bep.BuildMetrics_MemoryMetrics_GarbageMetrics{},
+		},
+		PackageMetrics: &bep.BuildMetrics_PackageMetrics{
+			PackageLoadMetrics: []*pkgmetrics.PackageLoadMetrics{},
+		},
+		BuildGraphMetrics: &bep.BuildMetrics_BuildGraphMetrics{
+			DirtiedValues:   []*bep.BuildMetrics_EvaluationStat{},
+			ChangedValues:   []*bep.BuildMetrics_EvaluationStat{},
+			BuiltValues:     []*bep.BuildMetrics_EvaluationStat{},
+			CleanedValues:   []*bep.BuildMetrics_EvaluationStat{},
+			EvaluatedValues: []*bep.BuildMetrics_EvaluationStat{},
+		},
+	}
+
+	traces, _ := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+
+	for _, name := range []string{
+		"bazel.metrics.garbage",
+		"bazel.metrics.package_load",
+		"bazel.metrics.graph.dirtied_values",
+		"bazel.metrics.graph.changed_values",
+		"bazel.metrics.graph.built_values",
+		"bazel.metrics.graph.cleaned_values",
+		"bazel.metrics.graph.evaluated_values",
+	} {
+		if _, ok := span.Attributes().Get(name); ok {
+			t.Errorf("expected attribute %s to be absent for empty list", name)
+		}
+	}
+}
+
+func TestBuildMetricsSpan_CapEnforcement_Garbage(t *testing.T) {
+	caps := HighCardinalityCaps{Garbage: 2, PackageLoad: 100, GraphValues: 50}
+	state := newInvocationStateForHighCardTest(caps)
+
+	var garbage []*bep.BuildMetrics_MemoryMetrics_GarbageMetrics
+	for i := range 5 {
+		garbage = append(garbage, &bep.BuildMetrics_MemoryMetrics_GarbageMetrics{
+			Type: "gen", GarbageCollected: int64(i),
+		})
+	}
+	metrics := &bep.BuildMetrics{
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{GarbageMetrics: garbage},
+	}
+
+	traces, truncs := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	attr, ok := span.Attributes().Get("bazel.metrics.garbage")
+	if !ok {
+		t.Fatal("expected bazel.metrics.garbage attribute")
+	}
+	if got := attr.Slice().Len(); got != 2 {
+		t.Errorf("expected capped length 2, got %d", got)
+	}
+	if len(truncs) != 1 {
+		t.Fatalf("expected 1 truncation, got %d: %v", len(truncs), truncs)
+	}
+	got := truncs[0]
+	if got.attribute != "bazel.metrics.garbage" {
+		t.Errorf("truncation: attribute=%q", got.attribute)
+	}
+	if got.original != 5 || got.kept != 2 {
+		t.Errorf("truncation: original=%d kept=%d (want 5,2)", got.original, got.kept)
+	}
+}
+
+func TestBuildMetricsSpan_CapEnforcement_Graph(t *testing.T) {
+	caps := HighCardinalityCaps{Garbage: 20, PackageLoad: 100, GraphValues: 3}
+	state := newInvocationStateForHighCardTest(caps)
+
+	var stats []*bep.BuildMetrics_EvaluationStat
+	for i := range 10 {
+		stats = append(stats, &bep.BuildMetrics_EvaluationStat{SkyfunctionName: "FN", Count: int64(i)})
+	}
+	metrics := &bep.BuildMetrics{
+		BuildGraphMetrics: &bep.BuildMetrics_BuildGraphMetrics{
+			DirtiedValues: stats,
+		},
+	}
+
+	traces, truncs := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	attr, _ := span.Attributes().Get("bazel.metrics.graph.dirtied_values")
+	if got := attr.Slice().Len(); got != 3 {
+		t.Errorf("expected capped length 3, got %d", got)
+	}
+	if len(truncs) != 1 {
+		t.Fatalf("expected 1 truncation, got %d", len(truncs))
+	}
+	if truncs[0].attribute != "bazel.metrics.graph.dirtied_values" {
+		t.Errorf("truncation: attribute=%q", truncs[0].attribute)
+	}
+	if truncs[0].original != 10 || truncs[0].kept != 3 {
+		t.Errorf("truncation: original=%d kept=%d (want 10,3)", truncs[0].original, truncs[0].kept)
+	}
+}
+
+func TestBuildMetricsSpan_CapEnforcement_PackageLoad(t *testing.T) {
+	caps := HighCardinalityCaps{Garbage: 20, PackageLoad: 1, GraphValues: 50}
+	state := newInvocationStateForHighCardTest(caps)
+
+	pkgs := []*pkgmetrics.PackageLoadMetrics{
+		{Name: new("//a")},
+		{Name: new("//b")},
+		{Name: new("//c")},
+	}
+	metrics := &bep.BuildMetrics{
+		PackageMetrics: &bep.BuildMetrics_PackageMetrics{PackageLoadMetrics: pkgs},
+	}
+
+	traces, truncs := state.buildMetricsSpan(metrics)
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	attr, _ := span.Attributes().Get("bazel.metrics.package_load")
+	if got := attr.Slice().Len(); got != 1 {
+		t.Errorf("expected capped length 1, got %d", got)
+	}
+	if len(truncs) != 1 {
+		t.Fatalf("expected 1 truncation, got %d", len(truncs))
+	}
+	if truncs[0].original != 3 || truncs[0].kept != 1 {
+		t.Errorf("truncation: original=%d kept=%d", truncs[0].original, truncs[0].kept)
+	}
+}
+
+func TestHandleBuildMetrics_LogsTruncationWarning(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	caps := HighCardinalityCaps{Garbage: 1, PackageLoad: 100, GraphValues: 50}
+	tb := NewTraceBuilder(nil, nil, nil, logger, TraceBuilderConfig{Caps: caps})
+	tb.Start()
+	defer tb.Stop()
+
+	state := newInvocationStateForHighCardTest(caps)
+	state.pii = tb.pii
+	invocations := map[string]*invocationState{"inv-trunc": state}
+
+	metrics := &bep.BuildMetrics{
+		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
+			GarbageMetrics: []*bep.BuildMetrics_MemoryMetrics_GarbageMetrics{
+				{Type: "A", GarbageCollected: 1},
+				{Type: "B", GarbageCollected: 2},
+				{Type: "C", GarbageCollected: 3},
+			},
+		},
+	}
+
+	// Directly invoke handleBuildMetrics to avoid going through gRPC path.
+	if err := tb.handleBuildMetrics(context.Background(), invocations, "inv-trunc", metrics); err != nil {
+		t.Fatalf("handleBuildMetrics: %v", err)
+	}
+
+	entries := logs.FilterMessageSnippet("high-cardinality").All()
+	if len(entries) == 0 {
+		t.Fatal("expected a warning log about high-cardinality truncation")
+	}
+	fields := entries[0].ContextMap()
+	if fields["invocation_id"] != "inv-trunc" {
+		t.Errorf("expected invocation_id=inv-trunc in warning, got %v", fields["invocation_id"])
+	}
+	if fields["attribute"] != "bazel.metrics.garbage" {
+		t.Errorf("expected attribute=bazel.metrics.garbage, got %v", fields["attribute"])
+	}
+	if fields["original_count"] != int64(3) {
+		t.Errorf("expected original_count=3, got %v", fields["original_count"])
+	}
+	if fields["kept"] != int64(1) {
+		t.Errorf("expected kept=1, got %v", fields["kept"])
+	}
+}
+
+func TestDefaultHighCardinalityCaps(t *testing.T) {
+	caps := defaultHighCardinalityCaps()
+	if caps.Garbage != 20 {
+		t.Errorf("Garbage default: got %d want 20", caps.Garbage)
+	}
+	if caps.PackageLoad != 100 {
+		t.Errorf("PackageLoad default: got %d want 100", caps.PackageLoad)
+	}
+	if caps.GraphValues != 50 {
+		t.Errorf("GraphValues default: got %d want 50", caps.GraphValues)
+	}
+}
+
+func TestConfigDefault_IncludesHighCardinalityCaps(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	if cfg.HighCardinalityCaps.Garbage != 20 {
+		t.Errorf("HighCardinalityCaps.Garbage: got %d want 20", cfg.HighCardinalityCaps.Garbage)
+	}
+	if cfg.HighCardinalityCaps.PackageLoad != 100 {
+		t.Errorf("HighCardinalityCaps.PackageLoad: got %d want 100", cfg.HighCardinalityCaps.PackageLoad)
+	}
+	if cfg.HighCardinalityCaps.GraphValues != 50 {
+		t.Errorf("HighCardinalityCaps.GraphValues: got %d want 50", cfg.HighCardinalityCaps.GraphValues)
+	}
+}

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -100,9 +100,13 @@ type invocationState struct {
 
 	// pii opts specific BEP fields into span emission; see PIIConfig.
 	pii PIIConfig
+
+	// caps bounds the size of Slice[Map] attributes emitted on the
+	// bazel.metrics span for high-cardinality BuildMetrics sub-messages.
+	caps HighCardinalityCaps
 }
 
-func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time, pii PIIConfig) *invocationState {
+func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time, pii PIIConfig, caps HighCardinalityCaps) *invocationState {
 	traces, ss := newTracesPayload()
 	return &invocationState{
 		traceID:       traceID,
@@ -114,6 +118,7 @@ func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, star
 		pendingTraces: traces,
 		scopeSpans:    ss,
 		pii:           pii,
+		caps:          caps,
 	}
 }
 
@@ -751,15 +756,24 @@ func (s *invocationState) lateTestResultSpan(label, configID string, tr *bep.Bui
 	return traces
 }
 
+// truncationRecord describes one high-cardinality list that exceeded its
+// configured cap. Emitted by buildMetricsSpan so callers can log a warning
+// with invocation context.
+type truncationRecord struct {
+	attribute string
+	original  int
+	kept      int
+}
+
 // buildMetricsSpan creates a standalone Traces payload for BuildMetrics.
 // Used for post-flush events that arrive after the main batch is flushed.
 //
 // Sub-messages are stamped via dedicated helpers that each no-op on nil, so
-// partially-populated BuildMetrics payloads are safe. High-cardinality sub-
-// messages (GarbageMetrics, PackageLoadMetrics, WorkerMetrics, EvaluationStat,
-// RuleClassCount, AspectCount, RemoteAnalysisCacheStatistics) are intentionally
-// skipped; see issue #25 / #29 for rationale.
-func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) ptrace.Traces {
+// partially-populated BuildMetrics payloads are safe. The returned
+// []truncationRecord is non-empty when one or more high-cardinality Slice[Map]
+// attributes was truncated to the configured cap; the caller is expected to
+// emit a warning log per record.
+func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) (ptrace.Traces, []truncationRecord) {
 	traces, ss := newTracesPayload()
 
 	span := ss.Spans().AppendEmpty()
@@ -782,7 +796,137 @@ func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) ptrace.Tra
 	stampDynamicExecutionAttrs(attrs, metrics.GetDynamicExecutionMetrics())
 	stampWorkerPoolAttrs(attrs, metrics.GetWorkerPoolMetrics())
 
-	return traces
+	caps := s.caps.withDefaults()
+	var truncs []truncationRecord
+	truncs = appendGarbageMetrics(span, metrics.GetMemoryMetrics(), caps.Garbage, truncs)
+	truncs = appendPackageLoadMetrics(span, metrics.GetPackageMetrics(), caps.PackageLoad, truncs)
+	truncs = appendGraphMetrics(span, metrics.GetBuildGraphMetrics(), caps.GraphValues, truncs)
+
+	return traces, truncs
+}
+
+// appendGarbageMetrics emits bazel.metrics.garbage as a Slice[Map] from
+// MemoryMetrics.garbage_metrics. Empty/nil lists are skipped (no attribute).
+// Entries beyond cap are dropped and one truncationRecord is appended.
+func appendGarbageMetrics(span ptrace.Span, mm *bep.BuildMetrics_MemoryMetrics, limit int, truncs []truncationRecord) []truncationRecord {
+	if mm == nil {
+		return truncs
+	}
+	entries := mm.GetGarbageMetrics()
+	if len(entries) == 0 {
+		return truncs
+	}
+	original := len(entries)
+	kept := original
+	if limit > 0 && original > limit {
+		entries = entries[:limit]
+		kept = limit
+	}
+	slice := span.Attributes().PutEmptySlice("bazel.metrics.garbage")
+	for _, g := range entries {
+		m := slice.AppendEmpty().SetEmptyMap()
+		m.PutStr("type", g.GetType())
+		m.PutInt("garbage_collected_bytes", g.GetGarbageCollected())
+	}
+	if kept < original {
+		truncs = append(truncs, truncationRecord{
+			attribute: "bazel.metrics.garbage",
+			original:  original,
+			kept:      kept,
+		})
+	}
+	return truncs
+}
+
+// appendPackageLoadMetrics emits bazel.metrics.package_load as a Slice[Map]
+// from PackageMetrics.package_load_metrics. Durations are normalized to
+// milliseconds.
+func appendPackageLoadMetrics(span ptrace.Span, pm *bep.BuildMetrics_PackageMetrics, limit int, truncs []truncationRecord) []truncationRecord {
+	if pm == nil {
+		return truncs
+	}
+	entries := pm.GetPackageLoadMetrics()
+	if len(entries) == 0 {
+		return truncs
+	}
+	original := len(entries)
+	kept := original
+	if limit > 0 && original > limit {
+		entries = entries[:limit]
+		kept = limit
+	}
+	slice := span.Attributes().PutEmptySlice("bazel.metrics.package_load")
+	for _, p := range entries {
+		m := slice.AppendEmpty().SetEmptyMap()
+		m.PutStr("name", p.GetName())
+		// LoadDuration is a google.protobuf.Duration — convert to ms to match
+		// sibling attributes like bazel.metrics.wall_time_ms. Missing duration
+		// renders as 0 via the generated getter.
+		if d := p.GetLoadDuration(); d != nil {
+			m.PutInt("load_duration_ms", d.AsDuration().Milliseconds())
+		} else {
+			m.PutInt("load_duration_ms", 0)
+		}
+		m.PutInt("num_targets", int64(p.GetNumTargets()))                                     //nolint:gosec // G115: per-package target count within int64 range for all realistic packages.
+		m.PutInt("computation_steps", int64(p.GetComputationSteps()))                         //nolint:gosec // G115: per-package computation steps within int64 range for all realistic packages.
+		m.PutInt("num_transitive_loads", int64(p.GetNumTransitiveLoads()))                    //nolint:gosec // G115: per-package transitive load count within int64 range for all realistic packages.
+		m.PutInt("package_overhead", int64(p.GetPackageOverhead()))                           //nolint:gosec // G115: per-package overhead within int64 range for all realistic packages.
+		m.PutInt("glob_filesystem_operation_cost", int64(p.GetGlobFilesystemOperationCost())) //nolint:gosec // G115: per-package glob cost within int64 range for all realistic packages.
+	}
+	if kept < original {
+		truncs = append(truncs, truncationRecord{
+			attribute: "bazel.metrics.package_load",
+			original:  original,
+			kept:      kept,
+		})
+	}
+	return truncs
+}
+
+// appendGraphMetrics emits the five bazel.metrics.graph.*_values Slice[Map]
+// attributes. Each applies the same cap independently.
+func appendGraphMetrics(span ptrace.Span, bgm *bep.BuildMetrics_BuildGraphMetrics, limit int, truncs []truncationRecord) []truncationRecord {
+	if bgm == nil {
+		return truncs
+	}
+	categories := []struct {
+		attr    string
+		entries []*bep.BuildMetrics_EvaluationStat
+	}{
+		{"bazel.metrics.graph.dirtied_values", bgm.GetDirtiedValues()},
+		{"bazel.metrics.graph.changed_values", bgm.GetChangedValues()},
+		{"bazel.metrics.graph.built_values", bgm.GetBuiltValues()},
+		{"bazel.metrics.graph.cleaned_values", bgm.GetCleanedValues()},
+		{"bazel.metrics.graph.evaluated_values", bgm.GetEvaluatedValues()},
+	}
+	for _, c := range categories {
+		if len(c.entries) == 0 {
+			continue
+		}
+		original := len(c.entries)
+		kept := original
+		entries := c.entries
+		if limit > 0 && original > limit {
+			entries = entries[:limit]
+			kept = limit
+		}
+		slice := span.Attributes().PutEmptySlice(c.attr)
+		for _, e := range entries {
+			m := slice.AppendEmpty().SetEmptyMap()
+			// Issue #29 attribute keys: "skyfunction" (not the proto's
+			// skyfunction_name) for backend-agnostic query ergonomics.
+			m.PutStr("skyfunction", e.GetSkyfunctionName())
+			m.PutInt("count", e.GetCount())
+		}
+		if kept < original {
+			truncs = append(truncs, truncationRecord{
+				attribute: c.attr,
+				original:  original,
+				kept:      kept,
+			})
+		}
+	}
+	return truncs
 }
 
 // maxBuildMetricsSliceEntries caps slice-of-map span attributes (DynamicExecutionMetrics,

--- a/receiver/besreceiver/invocation_test.go
+++ b/receiver/besreceiver/invocation_test.go
@@ -24,7 +24,7 @@ func newMetricsSpanState() *invocationState {
 func metricsSpanAttrs(t *testing.T, metrics *bep.BuildMetrics) pcommon.Map {
 	t.Helper()
 	state := newMetricsSpanState()
-	traces := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics)
 	if traces.SpanCount() != 1 {
 		t.Fatalf("expected 1 span, got %d", traces.SpanCount())
 	}
@@ -397,10 +397,10 @@ func TestBuildMetricsSpan_WorkerPoolEmpty(t *testing.T) {
 	mustAbsent(t, attrs, "bazel.metrics.worker_pool")
 }
 
-// Intentionally-skipped sub-messages: GarbageMetrics (under MemoryMetrics),
-// PackageLoadMetrics (under PackageMetrics), WorkerMetrics, EvaluationStat
-// slices on BuildGraphMetrics, RuleClassCount, AspectCount, and
-// RemoteAnalysisCacheStatistics. None should produce span attrs.
+// Intentionally-skipped sub-messages after #29 landed: RuleClassCount and
+// AspectCount on BuildGraphMetrics, WorkerMetrics, and
+// RemoteAnalysisCacheStatistics. GarbageMetrics / PackageLoadMetrics /
+// EvaluationStat slices are now surfaced by #29 and covered by highcard_test.go.
 func TestBuildMetricsSpan_SkipsHighCardinalitySubMessages(t *testing.T) {
 	metrics := &bep.BuildMetrics{
 		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{
@@ -432,11 +432,6 @@ func TestBuildMetricsSpan_SkipsHighCardinalitySubMessages(t *testing.T) {
 	mustInt(t, attrs, "bazel.metrics.graph.action_count", 1)
 
 	skippedKeys := []string{
-		"bazel.metrics.memory.garbage_metrics",
-		"bazel.metrics.graph.dirtied_values",
-		"bazel.metrics.graph.changed_values",
-		"bazel.metrics.graph.built_values",
-		"bazel.metrics.graph.evaluated_values",
 		"bazel.metrics.graph.rule_class",
 		"bazel.metrics.graph.aspect",
 		"bazel.metrics.worker_metrics",

--- a/receiver/besreceiver/receiver.go
+++ b/receiver/besreceiver/receiver.go
@@ -44,6 +44,7 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 			ReaperInterval:    r.config.ReaperInterval,
 			MeterProvider:     r.settings.MeterProvider,
 			PII:               r.config.PII,
+			Caps:              r.config.HighCardinalityCaps,
 		})
 		r.traceBuilder.Start()
 

--- a/receiver/besreceiver/remote_cache_test.go
+++ b/receiver/besreceiver/remote_cache_test.go
@@ -342,7 +342,7 @@ func TestBuildMetricsSpan_NilActionCacheStatistics(t *testing.T) {
 		},
 	}
 
-	traces := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics)
 	require.Equal(t, 1, traces.SpanCount())
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	assert.Equal(t, "bazel.metrics", span.Name())
@@ -372,7 +372,7 @@ func TestBuildMetricsSpan_NilActionSummary(t *testing.T) {
 	}
 	metrics := &bep.BuildMetrics{} // all sub-messages nil
 
-	traces := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics)
 	require.Equal(t, 1, traces.SpanCount())
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
@@ -408,7 +408,7 @@ func TestBuildMetricsSpan_ActionCacheStatistics(t *testing.T) {
 		},
 	}
 
-	traces := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics)
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	hits, ok := span.Attributes().Get("bazel.metrics.action_cache.hits")
@@ -479,7 +479,7 @@ func TestBuildMetricsSpan_ActionCacheStatistics_AllEightMissReasons(t *testing.T
 		},
 	}
 
-	traces := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics)
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	for i, r := range reasons {
@@ -521,7 +521,7 @@ func TestBuildMetricsSpan_Runners(t *testing.T) {
 		},
 	}
 
-	traces := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics)
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	runners, ok := span.Attributes().Get("bazel.metrics.runners")
@@ -558,7 +558,7 @@ func TestBuildMetricsSpan_Runners_Empty(t *testing.T) {
 		},
 	}
 
-	traces := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics)
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	// No bazel.metrics.runners attribute emitted when there are no runners.

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -47,6 +47,10 @@ type TraceBuilderConfig struct {
 	ReaperInterval    time.Duration
 	MeterProvider     metric.MeterProvider
 	PII               PIIConfig
+	// Caps bounds Slice[Map] attributes on the bazel.metrics span for
+	// high-cardinality BuildMetrics sub-messages. Zero-valued fields fall back
+	// to defaults via HighCardinalityCaps.withDefaults.
+	Caps HighCardinalityCaps
 }
 
 // TraceBuilder converts BEP events into OTel traces, logs, and metrics.
@@ -67,6 +71,10 @@ type TraceBuilder struct {
 	// state so finalize/addAction can make the decision locally without re-
 	// reaching into the builder.
 	pii PIIConfig
+
+	// caps bounds high-cardinality Slice[Map] attributes on bazel.metrics.
+	// Threaded into per-invocation state for local truncation decisions.
+	caps HighCardinalityCaps
 
 	// Cumulative counters for cross-invocation metrics.
 	counters *cumulativeCounters
@@ -116,6 +124,7 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		invocationTimeout: cfg.InvocationTimeout,
 		reaperInterval:    cfg.ReaperInterval,
 		pii:               cfg.PII,
+		caps:              cfg.Caps.withDefaults(),
 		counters:          newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
 		activeInvocations: activeInvocations,
 		eventsProcessed:   eventsProcessed,
@@ -322,7 +331,7 @@ func eventTypeName(event *bep.BuildEvent) string {
 func (tb *TraceBuilder) handleBuildStarted(ctx context.Context, invocations map[string]*invocationState, invocationID string, started *bep.BuildStarted) error {
 	traceID := traceIDFromUUID(started.GetUuid())
 	rootSpanID := spanIDFromIdentity(started.GetUuid(), "root")
-	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now(), tb.pii)
+	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now(), tb.pii, tb.caps)
 	tb.activeInvocations.Add(ctx, 1)
 
 	tb.logger.Debug("Build started",
@@ -743,7 +752,15 @@ func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[
 		return nil
 	}
 
-	traces := state.buildMetricsSpan(metrics)
+	traces, truncs := state.buildMetricsSpan(metrics)
+	for _, tr := range truncs {
+		tb.logger.Warn("Truncated high-cardinality bazel.metrics attribute",
+			zap.String("invocation_id", invocationID),
+			zap.String("attribute", tr.attribute),
+			zap.Int("original_count", tr.original),
+			zap.Int("kept", tr.kept),
+		)
+	}
 
 	tb.emitLog(ctx, state, invocationID, "bazel.build.metrics",
 		"Build metrics",

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -589,6 +589,7 @@ func TestReapStale(t *testing.T) {
 		&bep.BuildStarted{Uuid: "uuid-stale", Command: "build"},
 		time.Now().Add(-time.Hour),
 		PIIConfig{},
+		HighCardinalityCaps{},
 	)
 	span := state.appendSpan()
 	span.SetSpanID(spanIDFromIdentity("uuid-stale", "action", "//pkg:lib", "Javac", ""))
@@ -1585,6 +1586,7 @@ func TestTraceBuilder_Aborted_WithoutBuildFinished(t *testing.T) {
 		&bep.BuildStarted{Uuid: "uuid-abort-3", Command: "build"},
 		time.Now().Add(-time.Hour),
 		PIIConfig{},
+		HighCardinalityCaps{},
 	)
 	state.recordAbort(&bep.Aborted{Reason: bep.Aborted_TIME_OUT, Description: "deadline"})
 


### PR DESCRIPTION
Surfaces the sub-messages intentionally excluded from #25: `MemoryMetrics.garbage_metrics` (JVM GC generations), `PackageMetrics.package_load_metrics` (per-package load cost and glob I/O), and the five `BuildGraphMetrics` evaluation-stat slices (`dirtied_values`/`changed_values`/`built_values`/`cleaned_values`/`evaluated_values`). Each is emitted as a Slice[Map] span attribute on `bazel.metrics` only — no standalone metrics, because these are per-generation, per-package, and per-skyfunction dimensions that would explode series cardinality in a metrics pipeline. Whether the data becomes queryable depends on the trace backend: stores that index structured attributes (Datadog, Honeycomb) make them useful; others keep them as opaque payload.

Each attribute has a configurable cap exposed through a new `HighCardinalityCaps` config block with documented defaults (20 / 100 / 50). Empty lists produce no attribute at all rather than an empty slice. When truncation fires, `buildMetricsSpan` now returns a `[]truncationRecord` alongside the traces and `handleBuildMetrics` logs one warning per truncated attribute with the invocation ID, attribute name, original count, and kept count. Callers (and tests) were updated for the new `(ptrace.Traces, []truncationRecord)` signature. `durationpb` fields (`PackageLoadMetrics.load_duration`) are normalized to milliseconds to match sibling attributes.

Closes #29.