### PR TITLE
feat(besreceiver): emit per-mnemonic ActionData on bazel.metrics span and gauges

### DIFF
--- a/receiver/besreceiver/actiondata_test.go
+++ b/receiver/besreceiver/actiondata_test.go
@@ -1,0 +1,447 @@
+package besreceiver
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+)
+
+// buildActionDataEntries is a tiny helper for constructing a list of N
+// distinct ActionData entries with deterministic, inspectable values.
+func buildActionDataEntries(mnemonics ...string) []*bep.BuildMetrics_ActionSummary_ActionData {
+	out := make([]*bep.BuildMetrics_ActionSummary_ActionData, 0, len(mnemonics))
+	for i, m := range mnemonics {
+		i64 := int64(i + 1)
+		out = append(out, &bep.BuildMetrics_ActionSummary_ActionData{
+			Mnemonic:        m,
+			ActionsExecuted: 10 * i64,
+			ActionsCreated:  20 * i64,
+			FirstStartedMs:  1000 * i64,
+			LastEndedMs:     2000 * i64,
+			SystemTime:      durationpb.New(time.Duration(i64) * 100 * time.Millisecond),
+			UserTime:        durationpb.New(time.Duration(i64) * 200 * time.Millisecond),
+		})
+	}
+	return out
+}
+
+func TestApplyActionDataAttrs_AllSevenFields(t *testing.T) {
+	entries := []*bep.BuildMetrics_ActionSummary_ActionData{
+		{
+			Mnemonic:        "Javac",
+			ActionsExecuted: 42,
+			ActionsCreated:  50,
+			FirstStartedMs:  1000,
+			LastEndedMs:     2000,
+			SystemTime:      durationpb.New(150 * time.Millisecond),
+			UserTime:        durationpb.New(350 * time.Millisecond),
+		},
+	}
+	attrs := pcommon.NewMap()
+
+	applyActionDataAttrs(attrs, entries, actionDataOptions{maxEntries: 50, logger: zap.NewNop()})
+
+	raw, ok := attrs.Get("bazel.metrics.action_data")
+	if !ok {
+		t.Fatal("expected bazel.metrics.action_data attribute")
+	}
+	slice := raw.Slice()
+	if slice.Len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", slice.Len())
+	}
+	m := slice.At(0).Map()
+	want := map[string]any{
+		"mnemonic":         "Javac",
+		"actions_executed": int64(42),
+		"actions_created":  int64(50),
+		"first_started_ms": int64(1000),
+		"last_ended_ms":    int64(2000),
+		"system_time_ms":   int64(150),
+		"user_time_ms":     int64(350),
+	}
+	if m.Len() != len(want) {
+		t.Errorf("expected %d fields per entry, got %d", len(want), m.Len())
+	}
+	for k, v := range want {
+		got, ok := m.Get(k)
+		if !ok {
+			t.Errorf("missing field %q", k)
+			continue
+		}
+		switch expected := v.(type) {
+		case string:
+			if got.Str() != expected {
+				t.Errorf("%s: got %q, want %q", k, got.Str(), expected)
+			}
+		case int64:
+			if got.Int() != expected {
+				t.Errorf("%s: got %d, want %d", k, got.Int(), expected)
+			}
+		}
+	}
+}
+
+func TestApplyActionDataAttrs_NilDurationsBecomeZero(t *testing.T) {
+	entries := []*bep.BuildMetrics_ActionSummary_ActionData{
+		{
+			Mnemonic:        "GoCompile",
+			ActionsExecuted: 1,
+			// SystemTime and UserTime left nil — must surface as 0, not the
+			// attribute being absent.
+		},
+	}
+	attrs := pcommon.NewMap()
+
+	applyActionDataAttrs(attrs, entries, actionDataOptions{maxEntries: 50, logger: zap.NewNop()})
+
+	raw, ok := attrs.Get("bazel.metrics.action_data")
+	if !ok {
+		t.Fatal("expected bazel.metrics.action_data attribute")
+	}
+	m := raw.Slice().At(0).Map()
+	sys, ok := m.Get("system_time_ms")
+	if !ok || sys.Int() != 0 {
+		t.Errorf("expected system_time_ms=0 for nil Duration, got %v", sys)
+	}
+	usr, ok := m.Get("user_time_ms")
+	if !ok || usr.Int() != 0 {
+		t.Errorf("expected user_time_ms=0 for nil Duration, got %v", usr)
+	}
+}
+
+func TestApplyActionDataAttrs_EmptyListEmitsNothing(t *testing.T) {
+	attrs := pcommon.NewMap()
+	applyActionDataAttrs(attrs, nil, actionDataOptions{maxEntries: 50, logger: zap.NewNop()})
+	if _, ok := attrs.Get("bazel.metrics.action_data"); ok {
+		t.Error("expected no bazel.metrics.action_data attribute for empty list")
+	}
+
+	applyActionDataAttrs(attrs, []*bep.BuildMetrics_ActionSummary_ActionData{}, actionDataOptions{maxEntries: 50, logger: zap.NewNop()})
+	if _, ok := attrs.Get("bazel.metrics.action_data"); ok {
+		t.Error("expected no bazel.metrics.action_data attribute for zero-length slice")
+	}
+}
+
+func TestApplyActionDataAttrs_TruncationWithWarning(t *testing.T) {
+	entries := buildActionDataEntries("M1", "M2", "M3", "M4", "M5")
+
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	attrs := pcommon.NewMap()
+	applyActionDataAttrs(attrs, entries, actionDataOptions{maxEntries: 3, logger: logger, invocationID: "inv-trunc"})
+
+	raw, ok := attrs.Get("bazel.metrics.action_data")
+	if !ok {
+		t.Fatal("expected bazel.metrics.action_data attribute")
+	}
+	if got := raw.Slice().Len(); got != 3 {
+		t.Errorf("expected 3 entries after truncation, got %d", got)
+	}
+	// Keep the first N so queries match Bazel's top-N ranking.
+	first := raw.Slice().At(0).Map()
+	mnemonic, _ := first.Get("mnemonic")
+	if mnemonic.Str() != "M1" {
+		t.Errorf("expected first entry mnemonic=M1, got %s", mnemonic.Str())
+	}
+
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 warning log, got %d", logs.Len())
+	}
+	entry := logs.All()[0]
+	if entry.Level != zap.WarnLevel {
+		t.Errorf("expected warn level, got %s", entry.Level)
+	}
+	ctx := entry.ContextMap()
+	if ctx["invocation_id"] != "inv-trunc" {
+		t.Errorf("expected invocation_id=inv-trunc in log context, got %v", ctx["invocation_id"])
+	}
+	if ctx["original_count"] != int64(5) {
+		t.Errorf("expected original_count=5 in log context, got %v", ctx["original_count"])
+	}
+}
+
+func TestApplyActionDataAttrs_NoTruncationNoWarning(t *testing.T) {
+	entries := buildActionDataEntries("M1", "M2")
+
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	attrs := pcommon.NewMap()
+	applyActionDataAttrs(attrs, entries, actionDataOptions{maxEntries: 50, logger: logger, invocationID: "inv-quiet"})
+
+	raw, _ := attrs.Get("bazel.metrics.action_data")
+	if raw.Slice().Len() != 2 {
+		t.Errorf("expected 2 entries (under cap), got %d", raw.Slice().Len())
+	}
+	if logs.Len() != 0 {
+		t.Errorf("expected 0 warnings, got %d", logs.Len())
+	}
+}
+
+func TestDurationToMs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *durationpb.Duration
+		want int64
+	}{
+		{"nil", nil, 0},
+		{"zero", durationpb.New(0), 0},
+		{"whole_ms", durationpb.New(250 * time.Millisecond), 250},
+		{"seconds", durationpb.New(3 * time.Second), 3000},
+		{"sub_ms_truncates", durationpb.New(999 * time.Microsecond), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := durationToMs(tc.in); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddActionDataGauges_FourMetricsPerMnemonic(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{started: &bep.BuildStarted{Command: "build"}}
+	entries := []*bep.BuildMetrics_ActionSummary_ActionData{
+		{
+			Mnemonic:        "Javac",
+			ActionsExecuted: 42,
+			ActionsCreated:  50,
+			SystemTime:      durationpb.New(150 * time.Millisecond),
+			UserTime:        durationpb.New(350 * time.Millisecond),
+		},
+		{
+			Mnemonic:        "GoCompile",
+			ActionsExecuted: 7,
+			ActionsCreated:  9,
+			// nil durations → 0
+		},
+	}
+	metrics := &bep.BuildMetrics{
+		ActionSummary: &bep.BuildMetrics_ActionSummary{ActionData: entries},
+	}
+
+	md := buildInvocationGauges("inv-gauges", state, metrics, ts, actionDataOptions{maxEntries: 50, logger: zap.NewNop(), invocationID: "inv-gauges"})
+
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+
+	// Expected: per mnemonic -> 4 gauges. Two mnemonics -> 8 ActionData
+	// gauges. ActionSummary scalar gauges add 2 more (actions_created,
+	// actions_executed) because ActionSummary is non-nil. Total 10.
+	gaugesByName := make(map[string][]map[string]pcommon.Value)
+	for i := range sm.Metrics().Len() {
+		m := sm.Metrics().At(i)
+		dps := m.Gauge().DataPoints()
+		for j := range dps.Len() {
+			dp := dps.At(j)
+			attrs := make(map[string]pcommon.Value)
+			dp.Attributes().Range(func(k string, v pcommon.Value) bool {
+				attrs[k] = v
+				return true
+			})
+			attrs["__value__"] = pcommon.NewValueInt(dp.IntValue())
+			gaugesByName[m.Name()] = append(gaugesByName[m.Name()], attrs)
+		}
+	}
+
+	// Verify the four per-mnemonic metric names are present, each with two
+	// data points (one per mnemonic).
+	wantNames := []string{
+		"bazel.invocation.action.actions_executed",
+		"bazel.invocation.action.actions_created",
+		"bazel.invocation.action.system_time",
+		"bazel.invocation.action.user_time",
+	}
+	for _, name := range wantNames {
+		dps, ok := gaugesByName[name]
+		if !ok {
+			t.Errorf("missing gauge %q", name)
+			continue
+		}
+		if len(dps) != 2 {
+			t.Errorf("gauge %q: expected 2 data points (one per mnemonic), got %d", name, len(dps))
+		}
+		for _, dp := range dps {
+			// Shared attributes from baseAttrs plus the mnemonic.
+			invID, ok := dp["bazel.invocation_id"]
+			if !ok || invID.Str() != "inv-gauges" {
+				t.Errorf("gauge %q dp: expected bazel.invocation_id=inv-gauges, got %v", name, invID)
+			}
+			cmd, ok := dp["bazel.command"]
+			if !ok || cmd.Str() != "build" {
+				t.Errorf("gauge %q dp: expected bazel.command=build, got %v", name, cmd)
+			}
+			if _, ok := dp["bazel.action.mnemonic"]; !ok {
+				t.Errorf("gauge %q dp: missing bazel.action.mnemonic", name)
+			}
+		}
+	}
+
+	// Verify values for a specific mnemonic (Javac).
+	assertJavac := func(name string, want int64) {
+		t.Helper()
+		for _, dp := range gaugesByName[name] {
+			mnemonic := dp["bazel.action.mnemonic"]
+			if mnemonic.Str() == "Javac" {
+				if dp["__value__"].Int() != want {
+					t.Errorf("%s Javac: got %d, want %d", name, dp["__value__"].Int(), want)
+				}
+				return
+			}
+		}
+		t.Errorf("%s: no Javac data point", name)
+	}
+	assertJavac("bazel.invocation.action.actions_executed", 42)
+	assertJavac("bazel.invocation.action.actions_created", 50)
+	assertJavac("bazel.invocation.action.system_time", 150)
+	assertJavac("bazel.invocation.action.user_time", 350)
+
+	// Verify nil durations in GoCompile surface as 0.
+	assertGoCompile := func(name string, want int64) {
+		t.Helper()
+		for _, dp := range gaugesByName[name] {
+			mnemonic := dp["bazel.action.mnemonic"]
+			if mnemonic.Str() == "GoCompile" {
+				if dp["__value__"].Int() != want {
+					t.Errorf("%s GoCompile: got %d, want %d", name, dp["__value__"].Int(), want)
+				}
+				return
+			}
+		}
+		t.Errorf("%s: no GoCompile data point", name)
+	}
+	assertGoCompile("bazel.invocation.action.system_time", 0)
+	assertGoCompile("bazel.invocation.action.user_time", 0)
+}
+
+func TestAddActionDataGauges_EmptyListEmitsNothing(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{started: &bep.BuildStarted{Command: "build"}}
+	metrics := &bep.BuildMetrics{
+		// ActionSummary present but no ActionData.
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  10,
+			ActionsExecuted: 5,
+		},
+	}
+
+	md := buildInvocationGauges("inv-noad", state, metrics, ts, actionDataOptions{maxEntries: 50, logger: zap.NewNop()})
+
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	for i := range sm.Metrics().Len() {
+		name := sm.Metrics().At(i).Name()
+		switch name {
+		case "bazel.invocation.action.actions_executed",
+			"bazel.invocation.action.actions_created",
+			"bazel.invocation.action.system_time",
+			"bazel.invocation.action.user_time":
+			t.Errorf("did not expect per-mnemonic gauge %q for empty ActionData", name)
+		}
+	}
+}
+
+func TestAddActionDataGauges_Truncation(t *testing.T) {
+	ts := pcommon.NewTimestampFromTime(time.Now())
+	state := &invocationState{started: &bep.BuildStarted{Command: "build"}}
+	entries := buildActionDataEntries("A", "B", "C", "D", "E")
+	metrics := &bep.BuildMetrics{
+		ActionSummary: &bep.BuildMetrics_ActionSummary{ActionData: entries},
+	}
+
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	md := buildInvocationGauges("inv-trunc-gauge", state, metrics, ts, actionDataOptions{maxEntries: 2, logger: logger, invocationID: "inv-trunc-gauge"})
+
+	// Expect 2 mnemonics kept * 4 metric names = 8 data points, spread
+	// across 4 named metrics. Count unique mnemonics.
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	mnemonics := make(map[string]struct{})
+	for i := range sm.Metrics().Len() {
+		m := sm.Metrics().At(i)
+		if m.Name() != "bazel.invocation.action.actions_executed" {
+			continue
+		}
+		dps := m.Gauge().DataPoints()
+		for j := range dps.Len() {
+			mn, _ := dps.At(j).Attributes().Get("bazel.action.mnemonic")
+			mnemonics[mn.Str()] = struct{}{}
+		}
+	}
+	if len(mnemonics) != 2 {
+		t.Errorf("expected 2 mnemonics after cap=2, got %d (%v)", len(mnemonics), mnemonics)
+	}
+
+	// Warning was logged with original count.
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 warning, got %d", logs.Len())
+	}
+	ctx := logs.All()[0].ContextMap()
+	if ctx["invocation_id"] != "inv-trunc-gauge" {
+		t.Errorf("expected invocation_id=inv-trunc-gauge, got %v", ctx["invocation_id"])
+	}
+	if ctx["original_count"] != int64(5) {
+		t.Errorf("expected original_count=5, got %v", ctx["original_count"])
+	}
+}
+
+func TestBuildMetricsSpan_ActionData(t *testing.T) {
+	s := &invocationState{
+		traceID:    pcommon.TraceID{1, 2, 3},
+		rootSpanID: pcommon.SpanID{1, 2, 3},
+		uuid:       "uuid-x",
+	}
+	entries := buildActionDataEntries("Javac", "GoCompile")
+	metrics := &bep.BuildMetrics{
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  100,
+			ActionsExecuted: 80,
+			ActionData:      entries,
+		},
+	}
+
+	traces, _ := s.buildMetricsSpan(metrics, actionDataOptions{maxEntries: 50, logger: zap.NewNop()})
+
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	raw, ok := span.Attributes().Get("bazel.metrics.action_data")
+	if !ok {
+		t.Fatal("expected bazel.metrics.action_data on bazel.metrics span")
+	}
+	if raw.Slice().Len() != 2 {
+		t.Errorf("expected 2 entries, got %d", raw.Slice().Len())
+	}
+
+	// Scalar ActionSummary fields still emitted.
+	ac, ok := span.Attributes().Get("bazel.metrics.actions_created")
+	if !ok || ac.Int() != 100 {
+		t.Errorf("expected bazel.metrics.actions_created=100, got %v", ac)
+	}
+}
+
+func TestBuildMetricsSpan_NoActionData(t *testing.T) {
+	s := &invocationState{
+		traceID:    pcommon.TraceID{1, 2, 3},
+		rootSpanID: pcommon.SpanID{1, 2, 3},
+		uuid:       "uuid-x",
+	}
+	metrics := &bep.BuildMetrics{
+		ActionSummary: &bep.BuildMetrics_ActionSummary{
+			ActionsCreated:  1,
+			ActionsExecuted: 1,
+		},
+	}
+
+	traces, _ := s.buildMetricsSpan(metrics, actionDataOptions{maxEntries: 50, logger: zap.NewNop()})
+
+	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	if _, ok := span.Attributes().Get("bazel.metrics.action_data"); ok {
+		t.Error("did not expect bazel.metrics.action_data with empty ActionData list")
+	}
+}

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -31,6 +31,14 @@ type Config struct {
 	// fields fall back to defaults (see defaultHighCardinalityCaps). Exceeding
 	// a cap truncates the list and emits a Warn-level log.
 	HighCardinalityCaps HighCardinalityCaps `mapstructure:"high_cardinality_caps"`
+
+	// MaxActionDataEntries caps the number of per-mnemonic ActionData entries
+	// emitted on the bazel.metrics span attribute and as standalone gauges.
+	// Bazel already ranks the list by execution count (top-N at source); this
+	// cap is a cardinality guard for downstream backends. Default: 50. When
+	// Bazel emits more entries than the cap, the first N (source order) are
+	// kept and a warning is logged with the invocation ID and original count.
+	MaxActionDataEntries int `mapstructure:"max_action_data_entries"`
 }
 
 // HighCardinalityCaps configures per-attribute limits on the Slice[Map]
@@ -51,9 +59,6 @@ type HighCardinalityCaps struct {
 	GraphValues int `mapstructure:"graph_values"`
 }
 
-// defaultHighCardinalityCaps returns the documented default caps. Mirrored on
-// Config via createDefaultConfig so operator-supplied configs see the defaults
-// without having to opt in explicitly.
 // Default caps chosen for typical Bazel invocations; see HighCardinalityCaps
 // for rationale.
 const (
@@ -62,6 +67,9 @@ const (
 	defaultCapGraphValues = 50
 )
 
+// defaultHighCardinalityCaps returns the documented default caps. Mirrored on
+// Config via createDefaultConfig so operator-supplied configs see the defaults
+// without having to opt in explicitly.
 func defaultHighCardinalityCaps() HighCardinalityCaps {
 	return HighCardinalityCaps{
 		Garbage:     defaultCapGarbage,
@@ -154,6 +162,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.HighCardinalityCaps.GraphValues < 0 {
 		return fmt.Errorf("high_cardinality_caps.graph_values must not be negative, got %d", cfg.HighCardinalityCaps.GraphValues)
+	}
+	if cfg.MaxActionDataEntries < 0 {
+		return fmt.Errorf("max_action_data_entries must not be negative, got %d", cfg.MaxActionDataEntries)
 	}
 	return nil
 }

--- a/receiver/besreceiver/config_test.go
+++ b/receiver/besreceiver/config_test.go
@@ -124,3 +124,18 @@ func TestConfigValidate_ReaperIntervalExceedsTimeout(t *testing.T) {
 		t.Error("expected error when reaper_interval >= invocation_timeout")
 	}
 }
+
+func TestConfigDefaults_MaxActionDataEntries(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	if cfg.MaxActionDataEntries != defaultMaxActionDataEntries {
+		t.Errorf("expected default max_action_data_entries=%d, got %d", defaultMaxActionDataEntries, cfg.MaxActionDataEntries)
+	}
+}
+
+func TestConfigValidate_NegativeMaxActionDataEntries(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.MaxActionDataEntries = -1
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for negative max_action_data_entries")
+	}
+}

--- a/receiver/besreceiver/factory.go
+++ b/receiver/besreceiver/factory.go
@@ -38,10 +38,11 @@ func createDefaultConfig() component.Config {
 				Transport: confignet.TransportTypeTCP,
 			},
 		},
-		InvocationTimeout:   defaultInvocationTimeout,
-		ReaperInterval:      defaultReaperInterval,
-		PII:                 PIIConfig{},
-		HighCardinalityCaps: defaultHighCardinalityCaps(),
+		InvocationTimeout:    defaultInvocationTimeout,
+		ReaperInterval:       defaultReaperInterval,
+		PII:                  PIIConfig{},
+		HighCardinalityCaps:  defaultHighCardinalityCaps(),
+		MaxActionDataEntries: defaultMaxActionDataEntries,
 	}
 }
 

--- a/receiver/besreceiver/highcard_test.go
+++ b/receiver/besreceiver/highcard_test.go
@@ -42,7 +42,7 @@ func TestBuildMetricsSpan_GarbageMetrics(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	attr, ok := span.Attributes().Get("bazel.metrics.garbage")
 	if !ok {
@@ -86,7 +86,7 @@ func TestBuildMetricsSpan_PackageLoad(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	attr, ok := span.Attributes().Get("bazel.metrics.package_load")
 	if !ok {
@@ -134,7 +134,7 @@ func TestBuildMetricsSpan_PackageLoad_NilDuration(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	attr, ok := span.Attributes().Get("bazel.metrics.package_load")
 	if !ok {
@@ -168,7 +168,7 @@ func TestBuildMetricsSpan_GraphValues(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	cases := map[string]struct {
@@ -208,7 +208,7 @@ func TestBuildMetricsSpan_NilSubMessages(t *testing.T) {
 	// nil MemoryMetrics / PackageMetrics / BuildGraphMetrics.
 	metrics := &bep.BuildMetrics{}
 
-	traces, truncs := state.buildMetricsSpan(metrics)
+	traces, truncs := state.buildMetricsSpan(metrics, actionDataOptions{})
 	if len(truncs) != 0 {
 		t.Errorf("expected no truncations, got %v", truncs)
 	}
@@ -247,7 +247,7 @@ func TestBuildMetricsSpan_EmptyLists(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	for _, name := range []string{
@@ -279,7 +279,7 @@ func TestBuildMetricsSpan_CapEnforcement_Garbage(t *testing.T) {
 		MemoryMetrics: &bep.BuildMetrics_MemoryMetrics{GarbageMetrics: garbage},
 	}
 
-	traces, truncs := state.buildMetricsSpan(metrics)
+	traces, truncs := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	attr, ok := span.Attributes().Get("bazel.metrics.garbage")
 	if !ok {
@@ -314,7 +314,7 @@ func TestBuildMetricsSpan_CapEnforcement_Graph(t *testing.T) {
 		},
 	}
 
-	traces, truncs := state.buildMetricsSpan(metrics)
+	traces, truncs := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	attr, _ := span.Attributes().Get("bazel.metrics.graph.dirtied_values")
 	if got := attr.Slice().Len(); got != 3 {
@@ -344,7 +344,7 @@ func TestBuildMetricsSpan_CapEnforcement_PackageLoad(t *testing.T) {
 		PackageMetrics: &bep.BuildMetrics_PackageMetrics{PackageLoadMetrics: pkgs},
 	}
 
-	traces, truncs := state.buildMetricsSpan(metrics)
+	traces, truncs := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	attr, _ := span.Attributes().Get("bazel.metrics.package_load")
 	if got := attr.Slice().Len(); got != 1 {

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -9,6 +9,8 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/chagui/besreceiver/internal/bep/actioncache"
 	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
@@ -769,11 +771,12 @@ type truncationRecord struct {
 // Used for post-flush events that arrive after the main batch is flushed.
 //
 // Sub-messages are stamped via dedicated helpers that each no-op on nil, so
-// partially-populated BuildMetrics payloads are safe. The returned
+// partially-populated BuildMetrics payloads are safe. `opts` configures the
+// per-mnemonic ActionData emission (cap, logger, invocation id). The returned
 // []truncationRecord is non-empty when one or more high-cardinality Slice[Map]
 // attributes was truncated to the configured cap; the caller is expected to
 // emit a warning log per record.
-func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) (ptrace.Traces, []truncationRecord) {
+func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics, opts actionDataOptions) (ptrace.Traces, []truncationRecord) {
 	traces, ss := newTracesPayload()
 
 	span := ss.Spans().AppendEmpty()
@@ -786,6 +789,7 @@ func (s *invocationState) buildMetricsSpan(metrics *bep.BuildMetrics) (ptrace.Tr
 	attrs := span.Attributes()
 	stampTimingAttrs(attrs, metrics.GetTimingMetrics())
 	stampActionSummaryAttrs(attrs, metrics.GetActionSummary())
+	applyActionDataAttrs(attrs, metrics.GetActionSummary().GetActionData(), opts)
 	stampMemoryAttrs(attrs, metrics.GetMemoryMetrics())
 	stampTargetAttrs(attrs, metrics.GetTargetMetrics())
 	stampPackageAttrs(attrs, metrics.GetPackageMetrics())
@@ -1163,6 +1167,61 @@ func stampWorkerPoolAttrs(attrs pcommon.Map, wpm *bep.BuildMetrics_WorkerPoolMet
 		entry.PutInt("evicted_count", ws.GetEvictedCount())
 		entry.PutInt("alive_count", ws.GetAliveCount())
 	}
+}
+
+// actionDataOptions bundles the cap and the context needed to log truncation
+// warnings when emitting ActionData as span attributes / gauges. Threaded
+// together so the two emission paths (span attribute + gauges) truncate
+// identically and log from the same source.
+type actionDataOptions struct {
+	maxEntries   int
+	logger       *zap.Logger
+	invocationID string
+}
+
+// applyActionDataAttrs emits the per-mnemonic ActionData breakdown as a
+// Slice[Map] attribute on the bazel.metrics span. Empty input → no attribute,
+// so downstream queries can distinguish "absent" from "present but empty".
+// When len(entries) > opts.maxEntries the list is truncated to the first N
+// (Bazel already ranks by execution count at the source) and a warning log
+// carries the invocation id plus original count so operators know data was
+// dropped.
+func applyActionDataAttrs(attrs pcommon.Map, entries []*bep.BuildMetrics_ActionSummary_ActionData, opts actionDataOptions) {
+	if len(entries) == 0 {
+		return
+	}
+	limit := len(entries)
+	if opts.maxEntries > 0 && limit > opts.maxEntries {
+		limit = opts.maxEntries
+		if opts.logger != nil {
+			opts.logger.Warn("Truncating ActionData entries on bazel.metrics span",
+				zap.String("invocation_id", opts.invocationID),
+				zap.Int("original_count", len(entries)),
+				zap.Int("limit", opts.maxEntries),
+			)
+		}
+	}
+	slice := attrs.PutEmptySlice("bazel.metrics.action_data")
+	for i := range limit {
+		ad := entries[i] //nolint:gosec // G602: limit <= len(entries) by the clamp above.
+		m := slice.AppendEmpty().SetEmptyMap()
+		m.PutStr("mnemonic", ad.GetMnemonic())
+		m.PutInt("actions_executed", ad.GetActionsExecuted())
+		m.PutInt("actions_created", ad.GetActionsCreated())
+		m.PutInt("first_started_ms", ad.GetFirstStartedMs())
+		m.PutInt("last_ended_ms", ad.GetLastEndedMs())
+		m.PutInt("system_time_ms", durationToMs(ad.GetSystemTime()))
+		m.PutInt("user_time_ms", durationToMs(ad.GetUserTime()))
+	}
+}
+
+// durationToMs converts a protobuf Duration to milliseconds, mapping nil to 0.
+// Used for ActionData.system_time / user_time where Bazel may omit the field.
+func durationToMs(d *durationpb.Duration) int64 {
+	if d == nil {
+		return 0
+	}
+	return d.AsDuration().Milliseconds()
 }
 
 // flushOrphaned returns pending traces for invocations that were never finished.

--- a/receiver/besreceiver/invocation_test.go
+++ b/receiver/besreceiver/invocation_test.go
@@ -24,7 +24,7 @@ func newMetricsSpanState() *invocationState {
 func metricsSpanAttrs(t *testing.T, metrics *bep.BuildMetrics) pcommon.Map {
 	t.Helper()
 	state := newMetricsSpanState()
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	if traces.SpanCount() != 1 {
 		t.Fatalf("expected 1 span, got %d", traces.SpanCount())
 	}

--- a/receiver/besreceiver/metricsbuilder.go
+++ b/receiver/besreceiver/metricsbuilder.go
@@ -3,6 +3,7 @@ package besreceiver
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 
 	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
 )
@@ -10,7 +11,8 @@ import (
 // buildInvocationGauges constructs per-invocation gauge metrics from a
 // BuildMetrics event. Returns a pmetric.Metrics containing gauges for timing,
 // action summary, and memory sub-messages. Nil sub-messages are skipped.
-func buildInvocationGauges(invocationID string, state *invocationState, metrics *bep.BuildMetrics, ts pcommon.Timestamp) pmetric.Metrics {
+// Per-mnemonic ActionData gauges are capped per opts to bound cardinality.
+func buildInvocationGauges(invocationID string, state *invocationState, metrics *bep.BuildMetrics, ts pcommon.Timestamp, opts actionDataOptions) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	rm := md.ResourceMetrics().AppendEmpty()
 	rm.Resource().Attributes().PutStr("service.name", "bazel")
@@ -25,6 +27,7 @@ func buildInvocationGauges(invocationID string, state *invocationState, metrics 
 
 	addTimingGauges(sm, metrics.GetTimingMetrics(), ts, attrs)
 	addActionSummaryGauges(sm, metrics.GetActionSummary(), ts, attrs)
+	addActionDataGauges(sm, metrics.GetActionSummary().GetActionData(), ts, attrs, opts)
 	addMemoryGauges(sm, metrics.GetMemoryMetrics(), ts, attrs)
 
 	return md
@@ -52,6 +55,44 @@ func addActionSummaryGauges(sm pmetric.ScopeMetrics, as *bep.BuildMetrics_Action
 	addGaugeInt64(sm, "bazel.invocation.actions_created", "{action}", "Total actions created during the build", ts, as.GetActionsCreated(), attrs)
 	addGaugeInt64(sm, "bazel.invocation.actions_created_not_including_aspects", "{action}", "Actions created for configured targets (excluding aspects)", ts, as.GetActionsCreatedNotIncludingAspects(), attrs)
 	addGaugeInt64(sm, "bazel.invocation.actions_executed", "{action}", "Total actions executed during the build", ts, as.GetActionsExecuted(), attrs)
+}
+
+// addActionDataGauges emits four gauges per mnemonic (actions_executed,
+// actions_created, system_time, user_time) as separate metric streams, each
+// data point carrying a bazel.action.mnemonic attribute on top of the shared
+// invocation attrs. Empty input → no metrics; nil Duration → 0. When the
+// list exceeds opts.maxEntries the first N are kept (Bazel ranks at source)
+// and a warning is logged to match the span-attribute truncation behavior.
+func addActionDataGauges(sm pmetric.ScopeMetrics, entries []*bep.BuildMetrics_ActionSummary_ActionData, ts pcommon.Timestamp, baseAttrs pcommon.Map, opts actionDataOptions) {
+	if len(entries) == 0 {
+		return
+	}
+	limit := len(entries)
+	if opts.maxEntries > 0 && limit > opts.maxEntries {
+		limit = opts.maxEntries
+		if opts.logger != nil {
+			opts.logger.Warn("Truncating ActionData entries on per-mnemonic gauges",
+				zap.String("invocation_id", opts.invocationID),
+				zap.Int("original_count", len(entries)),
+				zap.Int("limit", opts.maxEntries),
+			)
+		}
+	}
+	for i := range limit {
+		ad := entries[i]
+		attrs := pcommon.NewMap()
+		baseAttrs.CopyTo(attrs)
+		attrs.PutStr("bazel.action.mnemonic", ad.GetMnemonic())
+
+		addGaugeInt64(sm, "bazel.invocation.action.actions_executed", "{action}",
+			"Per-mnemonic actions executed during the build", ts, ad.GetActionsExecuted(), attrs)
+		addGaugeInt64(sm, "bazel.invocation.action.actions_created", "{action}",
+			"Per-mnemonic actions created during the build", ts, ad.GetActionsCreated(), attrs)
+		addGaugeInt64(sm, "bazel.invocation.action.system_time", "ms",
+			"Per-mnemonic kernel-mode CPU time", ts, durationToMs(ad.GetSystemTime()), attrs)
+		addGaugeInt64(sm, "bazel.invocation.action.user_time", "ms",
+			"Per-mnemonic user-mode CPU time", ts, durationToMs(ad.GetUserTime()), attrs)
+	}
 }
 
 func addMemoryGauges(sm pmetric.ScopeMetrics, mm *bep.BuildMetrics_MemoryMetrics, ts pcommon.Timestamp, attrs pcommon.Map) {

--- a/receiver/besreceiver/metricsbuilder_test.go
+++ b/receiver/besreceiver/metricsbuilder_test.go
@@ -27,7 +27,7 @@ func TestBuildInvocationMetrics_Timing(t *testing.T) {
 		},
 	}
 
-	md := buildInvocationGauges("inv-1", state, metrics, ts)
+	md := buildInvocationGauges("inv-1", state, metrics, ts, actionDataOptions{})
 
 	// 6 timing gauges.
 	if md.MetricCount() != 6 {
@@ -87,7 +87,7 @@ func TestBuildInvocationMetrics_ActionSummary(t *testing.T) {
 		},
 	}
 
-	md := buildInvocationGauges("inv-2", state, metrics, ts)
+	md := buildInvocationGauges("inv-2", state, metrics, ts, actionDataOptions{})
 
 	if md.MetricCount() != 3 {
 		t.Fatalf("expected 3 metrics, got %d", md.MetricCount())
@@ -129,7 +129,7 @@ func TestBuildInvocationMetrics_Memory(t *testing.T) {
 		},
 	}
 
-	md := buildInvocationGauges("inv-3", state, metrics, ts)
+	md := buildInvocationGauges("inv-3", state, metrics, ts, actionDataOptions{})
 
 	if md.MetricCount() != 2 {
 		t.Fatalf("expected 2 metrics, got %d", md.MetricCount())
@@ -165,7 +165,7 @@ func TestBuildInvocationMetrics_NilSubMessages(t *testing.T) {
 	}
 	metrics := &bep.BuildMetrics{} // all sub-messages nil
 
-	md := buildInvocationGauges("inv-nil", state, metrics, ts)
+	md := buildInvocationGauges("inv-nil", state, metrics, ts, actionDataOptions{})
 
 	if md.MetricCount() != 0 {
 		t.Fatalf("expected 0 metrics for nil sub-messages, got %d", md.MetricCount())
@@ -336,7 +336,7 @@ func TestBuildInvocationMetrics_AllCategories(t *testing.T) {
 		},
 	}
 
-	md := buildInvocationGauges("inv-all", state, metrics, ts)
+	md := buildInvocationGauges("inv-all", state, metrics, ts, actionDataOptions{})
 
 	// 5 timing (no CriticalPathTime since it's nil) + 3 action + 2 memory = 10.
 	if md.MetricCount() != 10 {

--- a/receiver/besreceiver/receiver.go
+++ b/receiver/besreceiver/receiver.go
@@ -40,11 +40,12 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 	var startErr error
 	r.startOnce.Do(func() {
 		r.traceBuilder = NewTraceBuilder(r.tracesConsumer, r.logsConsumer, r.metricsConsumer, r.logger, TraceBuilderConfig{
-			InvocationTimeout: r.config.InvocationTimeout,
-			ReaperInterval:    r.config.ReaperInterval,
-			MeterProvider:     r.settings.MeterProvider,
-			PII:               r.config.PII,
-			Caps:              r.config.HighCardinalityCaps,
+			InvocationTimeout:    r.config.InvocationTimeout,
+			ReaperInterval:       r.config.ReaperInterval,
+			MeterProvider:        r.settings.MeterProvider,
+			PII:                  r.config.PII,
+			Caps:                 r.config.HighCardinalityCaps,
+			MaxActionDataEntries: r.config.MaxActionDataEntries,
 		})
 		r.traceBuilder.Start()
 

--- a/receiver/besreceiver/remote_cache_test.go
+++ b/receiver/besreceiver/remote_cache_test.go
@@ -342,7 +342,7 @@ func TestBuildMetricsSpan_NilActionCacheStatistics(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	require.Equal(t, 1, traces.SpanCount())
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	assert.Equal(t, "bazel.metrics", span.Name())
@@ -372,7 +372,7 @@ func TestBuildMetricsSpan_NilActionSummary(t *testing.T) {
 	}
 	metrics := &bep.BuildMetrics{} // all sub-messages nil
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	require.Equal(t, 1, traces.SpanCount())
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
@@ -408,7 +408,7 @@ func TestBuildMetricsSpan_ActionCacheStatistics(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	hits, ok := span.Attributes().Get("bazel.metrics.action_cache.hits")
@@ -479,7 +479,7 @@ func TestBuildMetricsSpan_ActionCacheStatistics_AllEightMissReasons(t *testing.T
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	for i, r := range reasons {
@@ -521,7 +521,7 @@ func TestBuildMetricsSpan_Runners(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	runners, ok := span.Attributes().Get("bazel.metrics.runners")
@@ -558,7 +558,7 @@ func TestBuildMetricsSpan_Runners_Empty(t *testing.T) {
 		},
 	}
 
-	traces, _ := state.buildMetricsSpan(metrics)
+	traces, _ := state.buildMetricsSpan(metrics, actionDataOptions{})
 	span := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
 	// No bazel.metrics.runners attribute emitted when there are no runners.

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -31,6 +31,11 @@ import (
 const (
 	defaultInvocationTimeout = 1 * time.Hour
 	defaultReaperInterval    = 5 * time.Minute
+	// defaultMaxActionDataEntries caps per-mnemonic ActionData emission to 50
+	// entries by default. Bazel ranks the list by execution count at source, so
+	// the first 50 cover the heavy hitters; the cap limits attribute/metric
+	// cardinality for downstream backends. See Config.MaxActionDataEntries.
+	defaultMaxActionDataEntries = 50
 )
 
 // eventMsg is sent from gRPC handler goroutines to the owner goroutine.
@@ -51,6 +56,10 @@ type TraceBuilderConfig struct {
 	// high-cardinality BuildMetrics sub-messages. Zero-valued fields fall back
 	// to defaults via HighCardinalityCaps.withDefaults.
 	Caps HighCardinalityCaps
+	// MaxActionDataEntries caps per-mnemonic ActionData emission on the
+	// bazel.metrics span and as per-mnemonic gauges. Zero selects the default
+	// (defaultMaxActionDataEntries).
+	MaxActionDataEntries int
 }
 
 // TraceBuilder converts BEP events into OTel traces, logs, and metrics.
@@ -76,6 +85,11 @@ type TraceBuilder struct {
 	// Threaded into per-invocation state for local truncation decisions.
 	caps HighCardinalityCaps
 
+	// maxActionDataEntries caps per-mnemonic ActionData emission. Set from
+	// TraceBuilderConfig.MaxActionDataEntries with defaultMaxActionDataEntries
+	// as the zero-value fallback.
+	maxActionDataEntries int
+
 	// Cumulative counters for cross-invocation metrics.
 	counters *cumulativeCounters
 
@@ -90,6 +104,8 @@ type TraceBuilder struct {
 // NewTraceBuilder creates a new TraceBuilder.
 // Any consumer may be nil if that signal is not configured.
 // Zero-value fields in cfg get sensible defaults.
+//
+//nolint:gocritic // hugeParam: TraceBuilderConfig is intentionally passed by value — it is built once at startup and defaulted in place.
 func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs, metricsConsumer consumer.Metrics, logger *zap.Logger, cfg TraceBuilderConfig) *TraceBuilder {
 	if cfg.InvocationTimeout <= 0 {
 		cfg.InvocationTimeout = defaultInvocationTimeout
@@ -99,6 +115,9 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 	}
 	if cfg.MeterProvider == nil {
 		cfg.MeterProvider = noop.NewMeterProvider()
+	}
+	if cfg.MaxActionDataEntries == 0 {
+		cfg.MaxActionDataEntries = defaultMaxActionDataEntries
 	}
 	meter := cfg.MeterProvider.Meter("besreceiver")
 	activeInvocations, _ := meter.Int64UpDownCounter("bes.invocations.active",
@@ -117,20 +136,21 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		metric.WithDescription("Total errors from the traces consumer"),
 	)
 	return &TraceBuilder{
-		tracesConsumer:    tracesConsumer,
-		logsConsumer:      logsConsumer,
-		metricsConsumer:   metricsConsumer,
-		logger:            logger,
-		invocationTimeout: cfg.InvocationTimeout,
-		reaperInterval:    cfg.ReaperInterval,
-		pii:               cfg.PII,
-		caps:              cfg.Caps.withDefaults(),
-		counters:          newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
-		activeInvocations: activeInvocations,
-		eventsProcessed:   eventsProcessed,
-		eventsReparented:  eventsReparented,
-		invocationsReaped: invocationsReaped,
-		consumerErrors:    consumerErrors,
+		tracesConsumer:       tracesConsumer,
+		logsConsumer:         logsConsumer,
+		metricsConsumer:      metricsConsumer,
+		logger:               logger,
+		invocationTimeout:    cfg.InvocationTimeout,
+		reaperInterval:       cfg.ReaperInterval,
+		pii:                  cfg.PII,
+		caps:                 cfg.Caps.withDefaults(),
+		maxActionDataEntries: cfg.MaxActionDataEntries,
+		counters:             newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
+		activeInvocations:    activeInvocations,
+		eventsProcessed:      eventsProcessed,
+		eventsReparented:     eventsReparented,
+		invocationsReaped:    invocationsReaped,
+		consumerErrors:       consumerErrors,
 	}
 }
 
@@ -752,7 +772,11 @@ func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[
 		return nil
 	}
 
-	traces, truncs := state.buildMetricsSpan(metrics)
+	traces, truncs := state.buildMetricsSpan(metrics, actionDataOptions{
+		maxEntries:   tb.maxActionDataEntries,
+		logger:       tb.logger,
+		invocationID: invocationID,
+	})
 	for _, tr := range truncs {
 		tb.logger.Warn("Truncated high-cardinality bazel.metrics attribute",
 			zap.String("invocation_id", invocationID),
@@ -769,7 +793,11 @@ func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[
 	)
 
 	ts := pcommon.NewTimestampFromTime(time.Now())
-	md := buildInvocationGauges(invocationID, state, metrics, ts)
+	md := buildInvocationGauges(invocationID, state, metrics, ts, actionDataOptions{
+		maxEntries:   tb.maxActionDataEntries,
+		logger:       tb.logger,
+		invocationID: invocationID,
+	})
 
 	// Update cumulative counters and merge into the same metrics payload.
 	tb.counters.record(metrics)


### PR DESCRIPTION
`ActionSummary.action_data` is the top-N per-mnemonic breakdown Bazel already ranks at the source (`first_started_ms`, `last_ended_ms`, plus `actions_executed`, `actions_created`, and `system_time`/`user_time` durations). It was being read partially — only the two totals landed on the span — and the per-mnemonic structure was dropped, so questions like "which action types dominated wall time?" required scraping Bazel logs.

This change surfaces the full breakdown on two paths. On the `bazel.metrics` span, `bazel.metrics.action_data` is a Slice[Map] with one entry per mnemonic carrying all seven fields (durations converted to milliseconds via a `durationToMs` helper that maps nil to 0). Alongside, four standalone per-invocation gauges are emitted — `bazel.invocation.action.actions_executed`, `.actions_created`, `.system_time`, `.user_time` — each stamped with `bazel.invocation_id`, `bazel.command`, and `bazel.action.mnemonic` so Datadog/PromQL-style queries can slice by mnemonic without depending on trace attribute indexing. The rebase folded `applyActionDataAttrs` into `buildMetricsSpan`'s unified `(opts, ) (traces, truncs)` signature alongside #29's truncation-record return.

`MaxActionDataEntries` in `Config` (default 50) caps both emission paths. When Bazel sends more entries than the cap, the first N (source-order, already execution-count-ranked) are kept and a warning log carries the invocation ID and original count so operators know data was dropped. Empty `action_data` produces no attribute and no metrics rather than empty shells.

Closes #28.