### PR TITLE
feat(besreceiver): add per-target detail level filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ make fuzz       # Run fuzz tests
 
 - [Architecture](docs/architecture.md) -- system overview, internal components, and span hierarchy
 - [Sequence diagrams](docs/sequence.md) -- BEP stream processing flow
+- [Attributes](docs/attributes.md) -- span attributes and PII controls
+- [Filtering](docs/filter.md) -- per-target detail levels to control trace verbosity
 
 ## License
 

--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -39,6 +39,21 @@ receivers:
     #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
     #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
     #   include_command_line: false        # bazel.command_line (coarse only)
+    # Per-target detail level filtering. default_level applies when no rule
+    # matches; rules are evaluated in order and first match wins. Levels:
+    #   drop       emits only the root bazel.build and bazel.metrics spans
+    #   build_only same as drop for per-target emission
+    #   targets    also emits bazel.target, skips actions/tests
+    #   verbose    emits everything (default, preserves pre-filter behaviour)
+    # Patterns: "//pkg:target" (exact), "//pkg:*" (all targets in pkg),
+    # "//pkg/..." (all targets under pkg and descendants). See docs/filter.md.
+    # filter:
+    #   default_level: verbose
+    #   rules:
+    #     - pattern: "//third_party/..."
+    #       detail_level: build_only
+    #     - pattern: "//src/main/..."
+    #       detail_level: verbose
 
 processors:
   memory_limiter:

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -1,0 +1,68 @@
+# Detail level filtering
+
+Large Bazel builds produce dense traces — a full monorepo invocation can emit
+tens of thousands of spans, most of them uninteresting third-party compilations.
+The receiver's `filter` block lets operators dial span verbosity per-target so
+the trace view stays focused on the code under active investigation while still
+preserving top-level build metrics for everything else.
+
+Filtering runs at event-processing time, before a span is allocated. Dropped
+targets cost nothing in memory or export bandwidth.
+
+## Configuration
+
+```yaml
+receivers:
+  bes:
+    filter:
+      default_level: verbose
+      rules:
+        - pattern: "//third_party/..."
+          detail_level: build_only
+        - pattern: "//src/main/..."
+          detail_level: verbose
+```
+
+A missing or empty `filter` block preserves the pre-filter behaviour (`verbose`
+everywhere). `default_level` applies when no rule matches the target label.
+Rules are evaluated in declaration order and the first match wins.
+
+## Detail levels
+
+| Level        | Spans emitted for matching targets          |
+|--------------|---------------------------------------------|
+| `drop`       | none (root `bazel.build` + `bazel.metrics` only, which bypass the filter) |
+| `build_only` | same as `drop` — operator-friendly alias when used as `default_level` |
+| `targets`    | `bazel.target` only — no `bazel.action`, no `bazel.test` |
+| `verbose`    | everything (default) — `bazel.target`, `bazel.action`, `bazel.test` |
+
+The root `bazel.build` and aggregate `bazel.metrics` spans are always emitted
+regardless of filter configuration so invocation-level metrics and the build
+summary on the root span remain intact.
+
+## Pattern syntax
+
+Patterns match the canonical target label Bazel emits in BEP
+(`//pkg:target`). Three forms are accepted:
+
+| Pattern            | Matches                                               |
+|--------------------|-------------------------------------------------------|
+| `//pkg:target`     | exact label only                                      |
+| `//pkg:*`          | every target inside package `//pkg`                   |
+| `//pkg/...`        | every target under `//pkg` and any descendant package |
+
+Relative labels (`pkg:t`) and external-repo labels (`@repo//...`) are rejected
+at config load time. Malformed patterns fail fast via `Config.Validate` with a
+clear error pointing at the offending rule.
+
+## Interaction with other features
+
+- **PII controls** apply per-attribute and are orthogonal. A span dropped by
+  the filter never reaches PII gating, but a span that survives the filter is
+  still subject to PII-configured attribute redaction.
+- **Cardinality caps** (`high_cardinality_caps`, `max_action_data_entries`)
+  apply on the `bazel.metrics` span which the filter does not touch; they
+  remain effective under every detail level.
+- **Reparenting** (`bes.events.reparented` counter) keys on target label. If
+  both an action and its owning target are dropped by the same rule, no
+  reparenting happens and the counter is not incremented.

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -39,6 +39,11 @@ type Config struct {
 	// Bazel emits more entries than the cap, the first N (source order) are
 	// kept and a warning is logged with the invocation ID and original count.
 	MaxActionDataEntries int `mapstructure:"max_action_data_entries"`
+
+	// Filter configures per-target detail level filtering. When absent or
+	// empty, the receiver emits every span (pre-filter behaviour). See
+	// FilterConfig.
+	Filter FilterConfig `mapstructure:"filter"`
 }
 
 // HighCardinalityCaps configures per-attribute limits on the Slice[Map]
@@ -165,6 +170,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.MaxActionDataEntries < 0 {
 		return fmt.Errorf("max_action_data_entries must not be negative, got %d", cfg.MaxActionDataEntries)
+	}
+	if err := cfg.Filter.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/receiver/besreceiver/factory.go
+++ b/receiver/besreceiver/factory.go
@@ -43,6 +43,11 @@ func createDefaultConfig() component.Config {
 		PII:                  PIIConfig{},
 		HighCardinalityCaps:  defaultHighCardinalityCaps(),
 		MaxActionDataEntries: defaultMaxActionDataEntries,
+		Filter: FilterConfig{
+			// Default preserves pre-filter behaviour: every span is emitted
+			// unless the operator opts into a stricter level or adds rules.
+			DefaultLevel: DetailLevelVerbose,
+		},
 	}
 }
 

--- a/receiver/besreceiver/filter.go
+++ b/receiver/besreceiver/filter.go
@@ -1,0 +1,237 @@
+package besreceiver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DetailLevel controls how many spans a target produces. Levels form a
+// strict hierarchy from least to most verbose: drop < build_only < targets <
+// verbose. The root bazel.build span and the bazel.metrics span are always
+// emitted regardless of level — filtering only applies to per-target work.
+type DetailLevel string
+
+const (
+	// DetailLevelDrop suppresses every per-target span (target / action /
+	// test). Matched targets contribute nothing except via the always-on
+	// root span and BuildMetrics.
+	DetailLevelDrop DetailLevel = "drop"
+	// DetailLevelBuildOnly emits only the root bazel.build span. Semantically
+	// identical to DetailLevelDrop at the per-target level; kept as a
+	// distinct name because the default_level knob applies to the whole
+	// invocation, where "build_only" reads more naturally than "drop".
+	DetailLevelBuildOnly DetailLevel = "build_only"
+	// DetailLevelTargets emits bazel.target spans but suppresses child
+	// bazel.action and bazel.test spans.
+	DetailLevelTargets DetailLevel = "targets"
+	// DetailLevelVerbose emits every span (target + action + test). Matches
+	// the pre-filter behaviour of the receiver.
+	DetailLevelVerbose DetailLevel = "verbose"
+)
+
+// validDetailLevels enumerates the accepted DetailLevel values for config
+// validation. Kept as a set so Validate can produce a deterministic,
+// sorted error message.
+//
+//nolint:gochecknoglobals // immutable lookup table; Go has no map const
+var validDetailLevels = map[DetailLevel]struct{}{
+	DetailLevelDrop:      {},
+	DetailLevelBuildOnly: {},
+	DetailLevelTargets:   {},
+	DetailLevelVerbose:   {},
+}
+
+// allowTarget returns true if the level permits emission of bazel.target
+// spans.
+func (d DetailLevel) allowTarget() bool {
+	switch d {
+	case DetailLevelTargets, DetailLevelVerbose:
+		return true
+	case DetailLevelDrop, DetailLevelBuildOnly:
+		return false
+	}
+	return false
+}
+
+// allowAction returns true if the level permits emission of bazel.action
+// and bazel.test spans.
+func (d DetailLevel) allowAction() bool {
+	return d == DetailLevelVerbose
+}
+
+// FilterConfig configures per-target detail level filtering. When the
+// surrounding receiver config omits this block entirely, DefaultLevel is
+// empty and Rules is nil; NewFilter treats that as verbose (current
+// behaviour unchanged).
+type FilterConfig struct {
+	// DefaultLevel applies when no rule matches. Empty string is normalised
+	// to verbose at Filter construction time so an omitted block keeps
+	// pre-existing behaviour.
+	DefaultLevel DetailLevel `mapstructure:"default_level"`
+	// Rules are evaluated in order; the first rule whose pattern matches
+	// the target label wins. Later rules are not consulted.
+	Rules []FilterRule `mapstructure:"rules"`
+}
+
+// FilterRule pairs a target label pattern with the detail level to apply
+// when the pattern matches.
+type FilterRule struct {
+	Pattern     string      `mapstructure:"pattern"`
+	DetailLevel DetailLevel `mapstructure:"detail_level"`
+}
+
+// Validate checks the FilterConfig for unknown detail levels and malformed
+// patterns. An empty DefaultLevel is accepted — Filter will normalise it.
+func (fc *FilterConfig) Validate() error {
+	if fc.DefaultLevel != "" {
+		if _, ok := validDetailLevels[fc.DefaultLevel]; !ok {
+			return fmt.Errorf("filter.default_level: invalid detail level %q (allowed: drop, build_only, targets, verbose)", fc.DefaultLevel)
+		}
+	}
+	for i, rule := range fc.Rules {
+		if rule.Pattern == "" {
+			return fmt.Errorf("filter.rules[%d]: pattern must not be empty", i)
+		}
+		if _, ok := validDetailLevels[rule.DetailLevel]; !ok {
+			return fmt.Errorf("filter.rules[%d]: invalid detail level %q (allowed: drop, build_only, targets, verbose)", i, rule.DetailLevel)
+		}
+		if err := validatePattern(rule.Pattern); err != nil {
+			return fmt.Errorf("filter.rules[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// patternKind enumerates the three supported Bazel label pattern shapes.
+// Kept internal — callers interact with Filter, not with compiled patterns
+// directly.
+type patternKind int
+
+const (
+	patternExact   patternKind = iota // //pkg:target — exact match
+	patternPkgAll                     // //pkg:*     — all targets in one package
+	patternSubtree                    // //pkg/...   — package and all sub-packages
+)
+
+// compiledRule is a FilterRule with its pattern pre-parsed for fast matching.
+type compiledRule struct {
+	kind   patternKind
+	prefix string // for patternPkgAll / patternSubtree; empty for exact
+	exact  string // for patternExact; empty otherwise
+	level  DetailLevel
+}
+
+func (r compiledRule) match(label string) bool {
+	switch r.kind {
+	case patternExact:
+		return label == r.exact
+	case patternPkgAll:
+		// //pkg:*  → match anything in //pkg:, including //pkg: itself.
+		return strings.HasPrefix(label, r.prefix)
+	case patternSubtree:
+		// //pkg/... → match //pkg:target, //pkg/sub:target, //pkg/sub/more:t.
+		// The pkg itself is matched by either //pkg: or //pkg/ prefix.
+		return strings.HasPrefix(label, r.prefix+":") || strings.HasPrefix(label, r.prefix+"/")
+	}
+	return false
+}
+
+// Filter applies FilterConfig rules to target labels. It is immutable after
+// construction and safe for concurrent reads — which the single-goroutine
+// owner of TraceBuilder doesn't need, but keeps the type trivially
+// shareable for future multi-goroutine refactors.
+type Filter struct {
+	defaultLevel DetailLevel
+	rules        []compiledRule
+}
+
+// NewFilter compiles a FilterConfig into a reusable Filter. Patterns are
+// assumed valid; callers should have already run FilterConfig.Validate (the
+// Collector does so via Config.Validate before Start).
+func NewFilter(cfg FilterConfig) *Filter {
+	level := cfg.DefaultLevel
+	if level == "" {
+		level = DetailLevelVerbose
+	}
+	rules := make([]compiledRule, 0, len(cfg.Rules))
+	for _, r := range cfg.Rules {
+		c, err := compilePattern(r.Pattern)
+		if err != nil {
+			// Validate() is expected to have caught this; skipping defensively.
+			continue
+		}
+		c.level = r.DetailLevel
+		rules = append(rules, c)
+	}
+	return &Filter{defaultLevel: level, rules: rules}
+}
+
+// LevelForTarget returns the detail level to apply to the given target
+// label. An empty label is treated the same as an unmatched label — the
+// default level applies. The first matching rule wins; later rules do not
+// override.
+func (f *Filter) LevelForTarget(label string) DetailLevel {
+	if f == nil {
+		return DetailLevelVerbose
+	}
+	for _, r := range f.rules {
+		if r.match(label) {
+			return r.level
+		}
+	}
+	return f.defaultLevel
+}
+
+// validatePattern runs pattern compilation purely for its error result.
+func validatePattern(pattern string) error {
+	_, err := compilePattern(pattern)
+	return err
+}
+
+// compilePattern parses a Bazel label pattern into a compiledRule. The
+// accepted forms are:
+//
+//   - //pkg/...       — subtree match (package and all sub-packages)
+//   - //pkg:*         — all targets in a single package
+//   - //pkg:target    — exact match on one label
+//
+// External repo patterns (@repo//pkg:t) and relative patterns (pkg:t) are
+// intentionally rejected: Bazel emits canonicalised absolute labels in BEP,
+// so accepting looser forms would silently never match.
+func compilePattern(pattern string) (compiledRule, error) {
+	if !strings.HasPrefix(pattern, "//") {
+		return compiledRule{}, fmt.Errorf("pattern %q: must start with // (external repos like @repo//... are not supported)", pattern)
+	}
+
+	// //pkg/... form: match a whole subtree.
+	if prefix, ok := strings.CutSuffix(pattern, "/..."); ok {
+		// Reject empty or single-slash packages: "//..." and "///..." provide
+		// no useful filter (the first is an all-targets glob, the second is
+		// malformed). We require at least //<non-empty-segment>/...
+		if prefix == "//" || prefix == "///" || prefix == "/" || prefix == "" {
+			return compiledRule{}, fmt.Errorf("pattern %q: package path before /... must not be empty", pattern)
+		}
+		return compiledRule{kind: patternSubtree, prefix: prefix}, nil
+	}
+
+	// //pkg:* form: match every target in a single package.
+	if _, ok := strings.CutSuffix(pattern, ":*"); ok {
+		prefix := strings.TrimSuffix(pattern, "*")
+		// prefix now ends with ":" — strings.HasPrefix(label, prefix) requires
+		// the same ':' anchor so "//pkga:*" does not match "//pkgabc:t".
+		if prefix == "//:" {
+			return compiledRule{}, fmt.Errorf("pattern %q: package path before :* must not be empty", pattern)
+		}
+		return compiledRule{kind: patternPkgAll, prefix: prefix}, nil
+	}
+
+	// //pkg:target form: exact label — requires ':' to separate package and target.
+	if !strings.Contains(pattern, ":") {
+		return compiledRule{}, fmt.Errorf("pattern %q: exact labels must include ':target' (did you mean %q/...?)", pattern, pattern)
+	}
+	// Reject //:target — empty package.
+	if strings.HasPrefix(pattern, "//:") {
+		return compiledRule{}, fmt.Errorf("pattern %q: package path must not be empty", pattern)
+	}
+	return compiledRule{kind: patternExact, exact: pattern}, nil
+}

--- a/receiver/besreceiver/filter_test.go
+++ b/receiver/besreceiver/filter_test.go
@@ -1,0 +1,246 @@
+package besreceiver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilter_NilAndEmptyDefaultsToVerbose(t *testing.T) {
+	var f *Filter
+	if got := f.LevelForTarget("//any:label"); got != DetailLevelVerbose {
+		t.Errorf("nil filter: expected verbose, got %q", got)
+	}
+
+	// Empty FilterConfig (as produced by no YAML block) must preserve
+	// pre-filter behaviour.
+	f = NewFilter(FilterConfig{})
+	if got := f.LevelForTarget("//any:label"); got != DetailLevelVerbose {
+		t.Errorf("empty FilterConfig: expected verbose, got %q", got)
+	}
+}
+
+func TestFilter_DefaultLevelAppliesWhenNoRuleMatches(t *testing.T) {
+	f := NewFilter(FilterConfig{DefaultLevel: DetailLevelTargets})
+	if got := f.LevelForTarget("//unmatched:label"); got != DetailLevelTargets {
+		t.Errorf("expected default=targets, got %q", got)
+	}
+}
+
+func TestFilter_ExactPatternMatching(t *testing.T) {
+	f := NewFilter(FilterConfig{
+		DefaultLevel: DetailLevelVerbose,
+		Rules: []FilterRule{
+			{Pattern: "//pkg:target", DetailLevel: DetailLevelDrop},
+		},
+	})
+
+	cases := map[string]DetailLevel{
+		"//pkg:target":       DetailLevelDrop,    // exact match
+		"//pkg:target_other": DetailLevelVerbose, // different target
+		"//pkg2:target":      DetailLevelVerbose, // different package
+		"//pkg/sub:target":   DetailLevelVerbose, // subpath is not covered by exact match
+	}
+	for label, want := range cases {
+		if got := f.LevelForTarget(label); got != want {
+			t.Errorf("LevelForTarget(%q) = %q, want %q", label, got, want)
+		}
+	}
+}
+
+func TestFilter_PackageWildcardMatching(t *testing.T) {
+	// //pkg:* matches every target in //pkg but not sub-packages.
+	f := NewFilter(FilterConfig{
+		DefaultLevel: DetailLevelVerbose,
+		Rules: []FilterRule{
+			{Pattern: "//pkg:*", DetailLevel: DetailLevelDrop},
+		},
+	})
+
+	cases := map[string]DetailLevel{
+		"//pkg:lib":      DetailLevelDrop,
+		"//pkg:test":     DetailLevelDrop,
+		"//pkg/sub:lib":  DetailLevelVerbose, // sub-package — not matched by :*
+		"//pkgabc:lib":   DetailLevelVerbose, // prefix collision guarded by ':' anchor
+		"//otherpkg:lib": DetailLevelVerbose,
+	}
+	for label, want := range cases {
+		if got := f.LevelForTarget(label); got != want {
+			t.Errorf("LevelForTarget(%q) = %q, want %q", label, got, want)
+		}
+	}
+}
+
+func TestFilter_SubtreePatternMatching(t *testing.T) {
+	// //pkg/... matches //pkg:target AND any //pkg/sub[/...]:target, but not
+	// packages that merely share a prefix (//pkgabc:...).
+	f := NewFilter(FilterConfig{
+		DefaultLevel: DetailLevelVerbose,
+		Rules: []FilterRule{
+			{Pattern: "//pkg/...", DetailLevel: DetailLevelDrop},
+		},
+	})
+
+	cases := map[string]DetailLevel{
+		"//pkg:target":          DetailLevelDrop,
+		"//pkg/sub:target":      DetailLevelDrop,
+		"//pkg/sub/more:target": DetailLevelDrop,
+		"//pkgabc:target":       DetailLevelVerbose, // prefix-only collision
+		"//pkgabc/sub:target":   DetailLevelVerbose,
+		"//other:target":        DetailLevelVerbose,
+	}
+	for label, want := range cases {
+		if got := f.LevelForTarget(label); got != want {
+			t.Errorf("LevelForTarget(%q) = %q, want %q", label, got, want)
+		}
+	}
+}
+
+func TestFilter_FirstMatchWins(t *testing.T) {
+	// Rule order matters: the //pkg:lib exact match comes before the
+	// //pkg:* package sweep, so //pkg:lib gets verbose while its neighbours
+	// get dropped.
+	f := NewFilter(FilterConfig{
+		DefaultLevel: DetailLevelDrop,
+		Rules: []FilterRule{
+			{Pattern: "//pkg:lib", DetailLevel: DetailLevelVerbose},
+			{Pattern: "//pkg:*", DetailLevel: DetailLevelDrop},
+		},
+	})
+
+	if got := f.LevelForTarget("//pkg:lib"); got != DetailLevelVerbose {
+		t.Errorf("//pkg:lib should win first rule: got %q, want verbose", got)
+	}
+	if got := f.LevelForTarget("//pkg:other"); got != DetailLevelDrop {
+		t.Errorf("//pkg:other should fall through to second rule: got %q, want drop", got)
+	}
+	if got := f.LevelForTarget("//outside:x"); got != DetailLevelDrop {
+		t.Errorf("//outside:x falls through to default: got %q, want drop", got)
+	}
+}
+
+func TestFilter_FirstMatchWins_ReversedOrder(t *testing.T) {
+	// Swap the order: now //pkg:* claims every target first, so the more
+	// specific //pkg:lib rule is unreachable — a lint a human author would
+	// flag, but Filter itself must honour the declared order.
+	f := NewFilter(FilterConfig{
+		DefaultLevel: DetailLevelDrop,
+		Rules: []FilterRule{
+			{Pattern: "//pkg:*", DetailLevel: DetailLevelDrop},
+			{Pattern: "//pkg:lib", DetailLevel: DetailLevelVerbose},
+		},
+	})
+	if got := f.LevelForTarget("//pkg:lib"); got != DetailLevelDrop {
+		t.Errorf("first-match-wins: //pkg:lib should hit :* rule, got %q", got)
+	}
+}
+
+func TestFilter_EmptyLabelUsesDefault(t *testing.T) {
+	f := NewFilter(FilterConfig{
+		DefaultLevel: DetailLevelTargets,
+		Rules: []FilterRule{
+			{Pattern: "//pkg/...", DetailLevel: DetailLevelDrop},
+		},
+	})
+	if got := f.LevelForTarget(""); got != DetailLevelTargets {
+		t.Errorf("empty label should fall through to default, got %q", got)
+	}
+}
+
+func TestFilterConfigValidate_AcceptsEmpty(t *testing.T) {
+	// No filter block: empty config validates.
+	fc := FilterConfig{}
+	if err := fc.Validate(); err != nil {
+		t.Errorf("empty FilterConfig should validate, got: %v", err)
+	}
+}
+
+func TestFilterConfigValidate_AcceptsAllKnownLevels(t *testing.T) {
+	for _, level := range []DetailLevel{DetailLevelDrop, DetailLevelBuildOnly, DetailLevelTargets, DetailLevelVerbose} {
+		fc := FilterConfig{
+			DefaultLevel: level,
+			Rules: []FilterRule{
+				{Pattern: "//pkg:*", DetailLevel: level},
+			},
+		}
+		if err := fc.Validate(); err != nil {
+			t.Errorf("level %q should validate, got: %v", level, err)
+		}
+	}
+}
+
+func TestFilterConfigValidate_RejectsUnknownDefaultLevel(t *testing.T) {
+	fc := FilterConfig{DefaultLevel: "summary"}
+	err := fc.Validate()
+	if err == nil {
+		t.Fatal("expected error for unknown default_level")
+	}
+	if !strings.Contains(err.Error(), "default_level") {
+		t.Errorf("error should mention default_level, got: %v", err)
+	}
+}
+
+func TestFilterConfigValidate_RejectsUnknownRuleLevel(t *testing.T) {
+	fc := FilterConfig{
+		Rules: []FilterRule{
+			{Pattern: "//pkg:*", DetailLevel: "loud"},
+		},
+	}
+	err := fc.Validate()
+	if err == nil {
+		t.Fatal("expected error for unknown rule detail_level")
+	}
+	if !strings.Contains(err.Error(), "rules[0]") {
+		t.Errorf("error should mention the failing rule index, got: %v", err)
+	}
+}
+
+func TestFilterConfigValidate_RejectsEmptyPattern(t *testing.T) {
+	fc := FilterConfig{
+		Rules: []FilterRule{
+			{Pattern: "", DetailLevel: DetailLevelDrop},
+		},
+	}
+	if err := fc.Validate(); err == nil {
+		t.Fatal("expected error for empty pattern")
+	}
+}
+
+func TestFilterConfigValidate_RejectsMalformedPatterns(t *testing.T) {
+	cases := []string{
+		"pkg:target",   // missing //
+		"@repo//pkg:t", // external repos not supported
+		"//:target",    // empty package
+		"//pkg",        // no : and no /...
+		"///...",       // empty subtree prefix
+	}
+	for _, pattern := range cases {
+		fc := FilterConfig{
+			Rules: []FilterRule{
+				{Pattern: pattern, DetailLevel: DetailLevelDrop},
+			},
+		}
+		if err := fc.Validate(); err == nil {
+			t.Errorf("pattern %q should have failed validation", pattern)
+		}
+	}
+}
+
+func TestDetailLevel_AllowFlags(t *testing.T) {
+	cases := map[DetailLevel]struct {
+		target bool
+		action bool
+	}{
+		DetailLevelDrop:      {target: false, action: false},
+		DetailLevelBuildOnly: {target: false, action: false},
+		DetailLevelTargets:   {target: true, action: false},
+		DetailLevelVerbose:   {target: true, action: true},
+	}
+	for level, want := range cases {
+		if got := level.allowTarget(); got != want.target {
+			t.Errorf("%q.allowTarget() = %v, want %v", level, got, want.target)
+		}
+		if got := level.allowAction(); got != want.action {
+			t.Errorf("%q.allowAction() = %v, want %v", level, got, want.action)
+		}
+	}
+}

--- a/receiver/besreceiver/filter_tracebuilder_test.go
+++ b/receiver/besreceiver/filter_tracebuilder_test.go
@@ -1,0 +1,242 @@
+package besreceiver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.uber.org/zap"
+	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
+
+	bep "github.com/chagui/besreceiver/internal/bep/buildeventstream"
+)
+
+// collectSpanKinds returns a map from span "kind" to count across all
+// trace batches in the sink. "Kind" collapses name variants like
+// "bazel.action Javac" to "bazel.action" and "bazel.build build" to
+// "bazel.build" so tests can focus on which span types were emitted.
+func collectSpanKinds(sink *consumertest.TracesSink) map[string]int {
+	counts := make(map[string]int)
+	for _, td := range sink.AllTraces() {
+		rs := td.ResourceSpans()
+		for i := range rs.Len() {
+			sss := rs.At(i).ScopeSpans()
+			for j := range sss.Len() {
+				spans := sss.At(j).Spans()
+				for k := range spans.Len() {
+					counts[spanKind(spans.At(k).Name())]++
+				}
+			}
+		}
+	}
+	return counts
+}
+
+// spanKind strips the trailing descriptor from a span name so tests can
+// compare by kind. "bazel.action Javac" → "bazel.action". Unknown names
+// pass through unchanged.
+func spanKind(name string) string {
+	if i := strings.IndexByte(name, ' '); i > 0 {
+		return name[:i]
+	}
+	return name
+}
+
+// driveFilteredInvocation feeds a minimal but representative BEP stream
+// through a TraceBuilder configured with the given FilterConfig. The
+// stream covers every per-target span type (target, action, test) plus
+// the always-on root and metrics spans, so a single invocation exercises
+// every filter decision point.
+func driveFilteredInvocation(t *testing.T, filter FilterConfig, targets ...string) *consumertest.TracesSink {
+	t.Helper()
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{Filter: filter})
+	tb.Start()
+	t.Cleanup(tb.Stop)
+	ctx := context.Background()
+
+	const invID = "inv-filter"
+	var seq int64 = 1
+	send := func(obe *pb.OrderedBuildEvent) {
+		t.Helper()
+		if err := tb.ProcessOrderedBuildEvent(ctx, obe); err != nil {
+			t.Fatalf("process event seq=%d: %v", obe.GetSequenceNumber(), err)
+		}
+	}
+
+	send(makeBuildStartedOBE(t, invID, "uuid-filter", "build", seq))
+	seq++
+	for _, label := range targets {
+		send(makeTargetConfiguredOBE(t, invID, label, seq))
+		seq++
+		send(makeActionOBE(t, invID, label, "Javac", seq, true))
+		seq++
+		send(makeTestResultOBE(t, invID, label, seq, bep.TestStatus_PASSED))
+		seq++
+	}
+	send(makeBuildFinishedOBE(t, invID, seq, 0, "SUCCESS"))
+	seq++
+	send(makeBuildMetricsOBE(t, invID, seq, 1000, 500))
+
+	return sink
+}
+
+func TestFilter_NoBlock_PreservesVerboseBehavior(t *testing.T) {
+	// FilterConfig zero value (== omitted YAML block) must not drop any span.
+	sink := driveFilteredInvocation(t, FilterConfig{}, "//pkg:lib")
+
+	got := collectSpanKinds(sink)
+	for _, want := range []string{"bazel.build", "bazel.target", "bazel.action", "bazel.test", "bazel.metrics"} {
+		if got[want] == 0 {
+			t.Errorf("expected at least one %s span, got counts=%v", want, got)
+		}
+	}
+}
+
+func TestFilter_DefaultLevelDrop_EmitsOnlyRootAndMetrics(t *testing.T) {
+	sink := driveFilteredInvocation(t, FilterConfig{DefaultLevel: DetailLevelDrop}, "//pkg:lib")
+	got := collectSpanKinds(sink)
+
+	if got["bazel.build"] != 1 {
+		t.Errorf("expected 1 bazel.build, got %d (all=%v)", got["bazel.build"], got)
+	}
+	if got["bazel.metrics"] != 1 {
+		t.Errorf("expected 1 bazel.metrics, got %d (all=%v)", got["bazel.metrics"], got)
+	}
+	for _, unwanted := range []string{"bazel.target", "bazel.action", "bazel.test"} {
+		if got[unwanted] != 0 {
+			t.Errorf("%s should be dropped at drop level, got %d", unwanted, got[unwanted])
+		}
+	}
+}
+
+func TestFilter_DefaultLevelBuildOnly_MatchesDrop(t *testing.T) {
+	// build_only is a UX-level rename of drop for the whole invocation; the
+	// per-target spans it suppresses are identical.
+	sink := driveFilteredInvocation(t, FilterConfig{DefaultLevel: DetailLevelBuildOnly}, "//pkg:lib")
+	got := collectSpanKinds(sink)
+
+	if got["bazel.build"] != 1 || got["bazel.metrics"] != 1 {
+		t.Errorf("build_only: expected root + metrics only, got %v", got)
+	}
+	if got["bazel.target"] != 0 || got["bazel.action"] != 0 || got["bazel.test"] != 0 {
+		t.Errorf("build_only: expected zero per-target spans, got %v", got)
+	}
+}
+
+func TestFilter_DefaultLevelTargets_SuppressesActionsAndTests(t *testing.T) {
+	sink := driveFilteredInvocation(t, FilterConfig{DefaultLevel: DetailLevelTargets}, "//pkg:lib")
+	got := collectSpanKinds(sink)
+
+	if got["bazel.target"] != 1 {
+		t.Errorf("expected 1 bazel.target, got %d (all=%v)", got["bazel.target"], got)
+	}
+	if got["bazel.action"] != 0 {
+		t.Errorf("expected 0 bazel.action at targets level, got %d", got["bazel.action"])
+	}
+	if got["bazel.test"] != 0 {
+		t.Errorf("expected 0 bazel.test at targets level, got %d", got["bazel.test"])
+	}
+	if got["bazel.build"] != 1 || got["bazel.metrics"] != 1 {
+		t.Errorf("targets level must still emit root + metrics, got %v", got)
+	}
+}
+
+func TestFilter_DefaultLevelVerbose_EmitsEverySpan(t *testing.T) {
+	sink := driveFilteredInvocation(t, FilterConfig{DefaultLevel: DetailLevelVerbose}, "//pkg:lib")
+	got := collectSpanKinds(sink)
+	for _, want := range []string{"bazel.build", "bazel.target", "bazel.action", "bazel.test", "bazel.metrics"} {
+		if got[want] == 0 {
+			t.Errorf("verbose: expected %s span, got counts=%v", want, got)
+		}
+	}
+}
+
+func TestFilter_PerTargetRules_ApplyIndependently(t *testing.T) {
+	// Three targets, one per detail level. Verify each gets exactly the
+	// span set its rule permits.
+	sink := driveFilteredInvocation(t, FilterConfig{
+		DefaultLevel: DetailLevelVerbose,
+		Rules: []FilterRule{
+			{Pattern: "//drop:target", DetailLevel: DetailLevelDrop},
+			{Pattern: "//targets:target", DetailLevel: DetailLevelTargets},
+			// //verbose:target falls through to default=verbose.
+		},
+	}, "//drop:target", "//targets:target", "//verbose:target")
+
+	// Gather attribute-tagged target labels to assert which targets survived.
+	seen := make(map[string]map[string]bool) // kind -> set of labels
+	for _, td := range sink.AllTraces() {
+		rs := td.ResourceSpans()
+		for i := range rs.Len() {
+			sss := rs.At(i).ScopeSpans()
+			for j := range sss.Len() {
+				spans := sss.At(j).Spans()
+				for k := range spans.Len() {
+					sp := spans.At(k)
+					kind := spanKind(sp.Name())
+					lbl, ok := sp.Attributes().Get("bazel.target.label")
+					if !ok {
+						continue
+					}
+					if seen[kind] == nil {
+						seen[kind] = make(map[string]bool)
+					}
+					seen[kind][lbl.Str()] = true
+				}
+			}
+		}
+	}
+
+	// //drop:target — no spans should reference it.
+	for kind, labels := range seen {
+		if labels["//drop:target"] {
+			t.Errorf("dropped target should produce no %s span, but saw one", kind)
+		}
+	}
+	// //targets:target — target span yes, action/test no.
+	if !seen["bazel.target"]["//targets:target"] {
+		t.Error("//targets:target should emit its bazel.target span")
+	}
+	if seen["bazel.action"]["//targets:target"] {
+		t.Error("//targets:target should NOT emit action spans at targets level")
+	}
+	if seen["bazel.test"]["//targets:target"] {
+		t.Error("//targets:target should NOT emit test spans at targets level")
+	}
+	// //verbose:target — everything.
+	for _, kind := range []string{"bazel.target", "bazel.action", "bazel.test"} {
+		if !seen[kind]["//verbose:target"] {
+			t.Errorf("//verbose:target should emit %s span, got seen=%v", kind, seen[kind])
+		}
+	}
+}
+
+func TestFilter_SubtreePatternInStream(t *testing.T) {
+	// //third_party/... → drop; default verbose. The //third_party target is
+	// silenced while //src gets every span.
+	sink := driveFilteredInvocation(t, FilterConfig{
+		DefaultLevel: DetailLevelVerbose,
+		Rules: []FilterRule{
+			{Pattern: "//third_party/...", DetailLevel: DetailLevelDrop},
+		},
+	}, "//third_party/dep:lib", "//src/main:app")
+
+	got := collectSpanKinds(sink)
+	// 1 target for //src/main:app only.
+	if got["bazel.target"] != 1 {
+		t.Errorf("expected exactly 1 bazel.target (only //src/main:app), got %d", got["bazel.target"])
+	}
+	if got["bazel.action"] != 1 {
+		t.Errorf("expected exactly 1 bazel.action (only //src/main:app), got %d", got["bazel.action"])
+	}
+}
+
+func TestFilter_InvalidDetailLevel_FailsConfigValidate(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Filter.DefaultLevel = "loud"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Config.Validate should reject invalid filter.default_level")
+	}
+}

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -106,10 +106,18 @@ type invocationState struct {
 	// caps bounds the size of Slice[Map] attributes emitted on the
 	// bazel.metrics span for high-cardinality BuildMetrics sub-messages.
 	caps HighCardinalityCaps
+
+	// filter gates per-target span emission. Never nil — the TraceBuilder
+	// installs a pass-through filter when the operator has not configured
+	// one, so callers can dereference without a guard.
+	filter *Filter
 }
 
-func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time, pii PIIConfig, caps HighCardinalityCaps) *invocationState {
+func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time, pii PIIConfig, caps HighCardinalityCaps, filter *Filter) *invocationState {
 	traces, ss := newTracesPayload()
+	if filter == nil {
+		filter = NewFilter(FilterConfig{})
+	}
 	return &invocationState{
 		traceID:       traceID,
 		rootSpanID:    rootSpanID,
@@ -121,6 +129,7 @@ func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, star
 		scopeSpans:    ss,
 		pii:           pii,
 		caps:          caps,
+		filter:        filter,
 	}
 }
 
@@ -141,6 +150,13 @@ func newTracesPayload() (ptrace.Traces, ptrace.ScopeSpans) {
 // reparenting counter metric.
 func (s *invocationState) addTarget(label, ruleKind, configID string) int {
 	if s.flushed {
+		return 0
+	}
+	// Filter runs at event-processing time, not emission time: skipping here
+	// avoids any allocation for targets the operator has dropped. The root
+	// bazel.build and bazel.metrics spans bypass the filter entirely and
+	// are emitted elsewhere.
+	if !s.filter.LevelForTarget(label).allowTarget() {
 		return 0
 	}
 
@@ -178,8 +194,20 @@ func (s *invocationState) populateTargetSpan(span ptrace.Span, label, ruleKind, 
 	return spanID
 }
 
+// addAction appends a bazel.action span for the given ActionExecuted event.
+// Conditionals (PII gate, filter gate, orphan reparent, mnemonic name,
+// optional timestamps) live inline; splitting them into helpers would
+// fragment the per-span build across several stateful methods without any
+// real readability gain.
 func (s *invocationState) addAction(label, configID, primaryOutput string, action *bep.ActionExecuted) {
 	if s.flushed {
+		return
+	}
+	// Action-label filtering uses the owning target's label — actions are
+	// structural children. When label is empty the filter falls through to
+	// DefaultLevel, which is the only correct default (the action can't be
+	// attributed to any rule).
+	if !s.filter.LevelForTarget(label).allowAction() {
 		return
 	}
 
@@ -247,6 +275,12 @@ func (s *invocationState) populateActionSpan(span ptrace.Span, parentSpanID pcom
 
 func (s *invocationState) addTestResult(label, configID string, tr *bep.BuildEventId_TestResultId, result *bep.TestResult) {
 	if s.flushed {
+		return
+	}
+	// Tests share the action gate: allowAction()==true only at verbose.
+	// If the operator wants per-target summary without per-shard detail,
+	// DetailLevelTargets suppresses both.
+	if !s.filter.LevelForTarget(label).allowAction() {
 		return
 	}
 

--- a/receiver/besreceiver/receiver.go
+++ b/receiver/besreceiver/receiver.go
@@ -46,6 +46,7 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 			PII:                  r.config.PII,
 			Caps:                 r.config.HighCardinalityCaps,
 			MaxActionDataEntries: r.config.MaxActionDataEntries,
+			Filter:               r.config.Filter,
 		})
 		r.traceBuilder.Start()
 

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -60,6 +60,8 @@ type TraceBuilderConfig struct {
 	// bazel.metrics span and as per-mnemonic gauges. Zero selects the default
 	// (defaultMaxActionDataEntries).
 	MaxActionDataEntries int
+	// Filter configures per-target detail level filtering. Empty value = pass-through.
+	Filter FilterConfig
 }
 
 // TraceBuilder converts BEP events into OTel traces, logs, and metrics.
@@ -89,6 +91,10 @@ type TraceBuilder struct {
 	// TraceBuilderConfig.MaxActionDataEntries with defaultMaxActionDataEntries
 	// as the zero-value fallback.
 	maxActionDataEntries int
+
+	// filter gates per-target span emission. Compiled once at NewTraceBuilder
+	// time and shared across invocations (immutable after construction).
+	filter *Filter
 
 	// Cumulative counters for cross-invocation metrics.
 	counters *cumulativeCounters
@@ -145,6 +151,7 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		pii:                  cfg.PII,
 		caps:                 cfg.Caps.withDefaults(),
 		maxActionDataEntries: cfg.MaxActionDataEntries,
+		filter:               NewFilter(cfg.Filter),
 		counters:             newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
 		activeInvocations:    activeInvocations,
 		eventsProcessed:      eventsProcessed,
@@ -351,7 +358,7 @@ func eventTypeName(event *bep.BuildEvent) string {
 func (tb *TraceBuilder) handleBuildStarted(ctx context.Context, invocations map[string]*invocationState, invocationID string, started *bep.BuildStarted) error {
 	traceID := traceIDFromUUID(started.GetUuid())
 	rootSpanID := spanIDFromIdentity(started.GetUuid(), "root")
-	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now(), tb.pii, tb.caps)
+	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now(), tb.pii, tb.caps, tb.filter)
 	tb.activeInvocations.Add(ctx, 1)
 
 	tb.logger.Debug("Build started",

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -590,6 +590,7 @@ func TestReapStale(t *testing.T) {
 		time.Now().Add(-time.Hour),
 		PIIConfig{},
 		HighCardinalityCaps{},
+		nil,
 	)
 	span := state.appendSpan()
 	span.SetSpanID(spanIDFromIdentity("uuid-stale", "action", "//pkg:lib", "Javac", ""))
@@ -1587,6 +1588,7 @@ func TestTraceBuilder_Aborted_WithoutBuildFinished(t *testing.T) {
 		time.Now().Add(-time.Hour),
 		PIIConfig{},
 		HighCardinalityCaps{},
+		nil,
 	)
 	state.recordAbort(&bep.Aborted{Reason: bep.Aborted_TIME_OUT, Description: "deadline"})
 


### PR DESCRIPTION
Adds configurable per-target span filtering. A monorepo build can produce tens of thousands of spans, and most operators only want flamegraph-level detail on their own code while keeping build/metrics aggregates for everything else. The new `filter` block exposes four detail levels (`drop`, `build_only`, `targets`, `verbose`) and a rule list keyed by Bazel label patterns (`//pkg:target`, `//pkg:*`, `//pkg/...`). First matching rule wins; the `default_level` applies otherwise. `drop` keeps only the root `bazel.build` + `bazel.metrics` spans; `targets` also keeps per-target spans; `verbose` preserves current behaviour (and remains the default, so configs without a `filter` block are unchanged).

Filtering runs at event-processing time, not emission — an unwanted target never allocates a span. A new `filter.go` exposes `Filter`, `NewFilter`, `LevelForTarget` and validates patterns at config-load time (malformed prefix, external `@repo` labels, and unknown level strings all surface as clear errors). `FilterConfig` is validated inside `Config.Validate`. `TraceBuilderConfig` carries the config through to a single `*Filter` compiled at startup and shared across invocations. `invocationState` dereferences it in `addTarget/addAction/addTestResult` before building anything, with a nil-safe pass-through when tests construct states directly.

Closes #13.