### PR TITLE
feat(besreceiver): aggregate build summary counters on root span

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -54,6 +54,13 @@ receivers:
     #       detail_level: build_only
     #     - pattern: "//src/main/..."
     #       detail_level: verbose
+    # Summary counters stamped on the root bazel.build span
+    # (bazel.summary.total_targets, .total_actions, .failed_actions,
+    # .success_actions, .total_tests, .passed_tests, .failed_tests,
+    # .flaky_tests). Counts reflect the full build — a target dropped by
+    # the filter above still contributes to the totals. Default: enabled.
+    # summary:
+    #   enabled: true
 
 processors:
   memory_limiter:

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -148,6 +148,30 @@ action-summary aggregates for the whole build.
 | `bazel.metrics.actions_created`          | int  | `ActionSummary.actions_created`           |
 | `bazel.metrics.actions_executed`         | int  | `ActionSummary.actions_executed`          |
 
+## Summary counters
+
+Aggregate per-invocation counters stamped on the root `bazel.build` span. Counts
+reflect the full build — targets dropped by [detail-level filtering](filter.md)
+still contribute to the totals so dashboards and alerts see a stable view of
+build health regardless of trace verbosity. Enabled by default; set
+`summary.enabled: false` to suppress the entire block.
+
+| Attribute                         | Type | Source                                         |
+|-----------------------------------|------|------------------------------------------------|
+| `bazel.summary.total_targets`     | int  | count of `TargetConfigured` events             |
+| `bazel.summary.total_actions`     | int  | count of `ActionExecuted` events               |
+| `bazel.summary.success_actions`   | int  | `ActionExecuted` with `success=true`           |
+| `bazel.summary.failed_actions`    | int  | `ActionExecuted` with `success=false`          |
+| `bazel.summary.total_tests`       | int  | count of `TestSummary` events (one per target) |
+| `bazel.summary.passed_tests`      | int  | `TestSummary.overall_status = PASSED`          |
+| `bazel.summary.failed_tests`      | int  | `TestSummary.overall_status = FAILED/TIMEOUT/...` |
+| `bazel.summary.flaky_tests`       | int  | `TestSummary.overall_status = FLAKY`           |
+
+Test tallies come from `TestSummary` (post-retry verdict, emitted once per test
+target) rather than `TestResult` (one per attempt), so flaky retries don't
+double-count. Zero-valued counters are still emitted when the feature is
+enabled so downstream queries can rely on attribute presence.
+
 ## PII controls
 
 Attributes marked **PII** above are gated by the `pii:` config block on the

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	// empty, the receiver emits every span (pre-filter behaviour). See
 	// FilterConfig.
 	Filter FilterConfig `mapstructure:"filter"`
+
+	// Summary controls aggregate build counters stamped on the root span.
+	// See SummaryConfig.
+	Summary SummaryConfig `mapstructure:"summary"`
 }
 
 // HighCardinalityCaps configures per-attribute limits on the Slice[Map]
@@ -97,6 +101,19 @@ func (c HighCardinalityCaps) withDefaults() HighCardinalityCaps {
 		c.GraphValues = d.GraphValues
 	}
 	return c
+}
+
+// SummaryConfig controls whether per-invocation aggregate counters are emitted
+// as bazel.summary.* attributes on the root bazel.build span. Default enabled.
+//
+// Summary counts reflect the full build — they are recorded before any
+// detail-level filter would drop the underlying target/action/test span,
+// so a dropped span still contributes to the totals.
+type SummaryConfig struct {
+	// Enabled toggles emission of all bazel.summary.* attributes. When true
+	// (default), every counter is emitted as Int64 including zero values so
+	// downstream queries can rely on attribute presence.
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // PIIConfig controls which potentially-sensitive fields from BEP events are

--- a/receiver/besreceiver/factory.go
+++ b/receiver/besreceiver/factory.go
@@ -48,6 +48,7 @@ func createDefaultConfig() component.Config {
 			// unless the operator opts into a stricter level or adds rules.
 			DefaultLevel: DetailLevelVerbose,
 		},
+		Summary: SummaryConfig{Enabled: true},
 	}
 }
 

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -111,9 +111,36 @@ type invocationState struct {
 	// installs a pass-through filter when the operator has not configured
 	// one, so callers can dereference without a guard.
 	filter *Filter
+
+	// summary toggles the bazel.summary.* block on the root span. Counters in
+	// `summaryCounts` are populated unconditionally so enabling the feature
+	// mid-build (unsupported today) would still produce consistent totals.
+	summary SummaryConfig
+	// summaryCounts accumulates aggregate counters for emission on the root
+	// span during finalize. Recording happens in the event mutators
+	// (addTarget / addAction / addTestResult / summarizeTarget) before any
+	// filtering or span emission, so totals reflect the full build even when
+	// detail-level filtering (see #13) suppresses the matching span.
+	summaryCounts BuildSummary
 }
 
-func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time, pii PIIConfig, caps HighCardinalityCaps, filter *Filter) *invocationState {
+// BuildSummary holds per-invocation aggregate counters emitted as
+// bazel.summary.* attributes on the root bazel.build span. Fields match the
+// issue #15 spec; CachedLocally is populated from TestResult.cached_locally
+// but not stamped on the span today (reserved for a future attribute).
+type BuildSummary struct {
+	TotalTargets   int64
+	TotalActions   int64
+	FailedActions  int64
+	SuccessActions int64
+	CachedLocally  int64
+	TotalTests     int64
+	PassedTests    int64
+	FailedTests    int64
+	FlakyTests     int64
+}
+
+func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, started *bep.BuildStarted, now time.Time, pii PIIConfig, caps HighCardinalityCaps, filter *Filter, summary SummaryConfig) *invocationState {
 	traces, ss := newTracesPayload()
 	if filter == nil {
 		filter = NewFilter(FilterConfig{})
@@ -130,6 +157,7 @@ func newInvocationState(traceID pcommon.TraceID, rootSpanID pcommon.SpanID, star
 		pii:           pii,
 		caps:          caps,
 		filter:        filter,
+		summary:       summary,
 	}
 }
 
@@ -152,6 +180,10 @@ func (s *invocationState) addTarget(label, ruleKind, configID string) int {
 	if s.flushed {
 		return 0
 	}
+	// Summary records before any filtering — the count reflects the full
+	// build, not only the targets whose spans are ultimately emitted.
+	s.summaryCounts.TotalTargets++
+
 	// Filter runs at event-processing time, not emission time: skipping here
 	// avoids any allocation for targets the operator has dropped. The root
 	// bazel.build and bazel.metrics spans bypass the filter entirely and
@@ -203,6 +235,10 @@ func (s *invocationState) addAction(label, configID, primaryOutput string, actio
 	if s.flushed {
 		return
 	}
+	// Summary records before any filtering — the counts reflect the full
+	// build, not only the actions whose spans are ultimately emitted.
+	s.recordActionSummary(action)
+
 	// Action-label filtering uses the owning target's label — actions are
 	// structural children. When label is empty the filter falls through to
 	// DefaultLevel, which is the only correct default (the action can't be
@@ -277,6 +313,13 @@ func (s *invocationState) addTestResult(label, configID string, tr *bep.BuildEve
 	if s.flushed {
 		return
 	}
+	// Summary records CachedLocally per-attempt before filtering; the per-test
+	// pass/fail/flaky tallies come from TestSummary (one per target) in
+	// summarizeTarget so retries don't double-count.
+	if result.GetCachedLocally() {
+		s.summaryCounts.CachedLocally++
+	}
+
 	// Tests share the action gate: allowAction()==true only at verbose.
 	// If the operator wants per-target summary without per-shard detail,
 	// DetailLevelTargets suppresses both.
@@ -470,6 +513,8 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 
 	s.applyContextAttributes(span)
 
+	s.applySummaryAttributes(span)
+
 	if finished != nil {
 		exitCode := finished.GetExitCode()
 		span.Attributes().PutStr("bazel.exit_code.name", exitCode.GetName())
@@ -660,9 +705,28 @@ func (s *invocationState) completeTarget(label string, tc *bep.TargetComplete) {
 // summarizeTarget applies TestSummary attributes to the target span. No-op
 // when the target span is missing (non-test target or out-of-order) or when
 // the state is already flushed.
+//
+// Summary counts are driven by TestSummary.overall_status (one per test
+// target, post-retry verdict) rather than individual TestResult events, so
+// the totals reflect unique tests rather than attempts. The counter update
+// runs unconditionally — including the missing-span case — so a test target
+// whose span was dropped by detail-level filtering still contributes.
 func (s *invocationState) summarizeTarget(label string, ts *bep.TestSummary) {
 	if s.flushed {
 		return
+	}
+	s.summaryCounts.TotalTests++
+	switch ts.GetOverallStatus() {
+	case bep.TestStatus_PASSED:
+		s.summaryCounts.PassedTests++
+	case bep.TestStatus_FLAKY:
+		s.summaryCounts.FlakyTests++
+	case bep.TestStatus_FAILED, bep.TestStatus_TIMEOUT, bep.TestStatus_INCOMPLETE,
+		bep.TestStatus_REMOTE_FAILURE, bep.TestStatus_FAILED_TO_BUILD,
+		bep.TestStatus_TOOL_HALTED_BEFORE_TESTING:
+		s.summaryCounts.FailedTests++
+	case bep.TestStatus_NO_STATUS:
+		// Unreported status — include in the total but don't tag a verdict.
 	}
 	span, ok := s.targets[targetKey(label, "")]
 	if !ok {
@@ -724,6 +788,37 @@ func (s *invocationState) applyContextAttributes(span ptrace.Span) {
 			span.Attributes().PutStr("bazel.metadata."+k, s.buildMetadata[k])
 		}
 	}
+}
+
+// recordActionSummary increments per-invocation action counters for a single
+// ActionExecuted event. Extracted to keep addAction below the cognitive
+// complexity budget.
+func (s *invocationState) recordActionSummary(action *bep.ActionExecuted) {
+	s.summaryCounts.TotalActions++
+	if action.GetSuccess() {
+		s.summaryCounts.SuccessActions++
+		return
+	}
+	s.summaryCounts.FailedActions++
+}
+
+// applySummaryAttributes writes bazel.summary.* aggregate counters on the
+// root span. No-op when Summary.Enabled is false. Zero-valued counters are
+// emitted so downstream queries can rely on attribute presence rather than
+// guarding against absent keys.
+func (s *invocationState) applySummaryAttributes(span ptrace.Span) {
+	if !s.summary.Enabled {
+		return
+	}
+	attrs := span.Attributes()
+	attrs.PutInt("bazel.summary.total_targets", s.summaryCounts.TotalTargets)
+	attrs.PutInt("bazel.summary.total_actions", s.summaryCounts.TotalActions)
+	attrs.PutInt("bazel.summary.success_actions", s.summaryCounts.SuccessActions)
+	attrs.PutInt("bazel.summary.failed_actions", s.summaryCounts.FailedActions)
+	attrs.PutInt("bazel.summary.total_tests", s.summaryCounts.TotalTests)
+	attrs.PutInt("bazel.summary.passed_tests", s.summaryCounts.PassedTests)
+	attrs.PutInt("bazel.summary.failed_tests", s.summaryCounts.FailedTests)
+	attrs.PutInt("bazel.summary.flaky_tests", s.summaryCounts.FlakyTests)
 }
 
 // nullConfigID is Bazel's sentinel for the null configuration — a TargetCompletedId

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -62,6 +62,8 @@ type TraceBuilderConfig struct {
 	MaxActionDataEntries int
 	// Filter configures per-target detail level filtering. Empty value = pass-through.
 	Filter FilterConfig
+	// Summary gates bazel.summary.* aggregate attributes on the root span.
+	Summary SummaryConfig
 }
 
 // TraceBuilder converts BEP events into OTel traces, logs, and metrics.
@@ -95,6 +97,11 @@ type TraceBuilder struct {
 	// filter gates per-target span emission. Compiled once at NewTraceBuilder
 	// time and shared across invocations (immutable after construction).
 	filter *Filter
+
+	// summary gates bazel.summary.* aggregate attributes on the root span.
+	// Threaded into invocationState so the recording calls in addTarget /
+	// addAction / addTestResult / summarizeTarget stay self-contained.
+	summary SummaryConfig
 
 	// Cumulative counters for cross-invocation metrics.
 	counters *cumulativeCounters
@@ -152,6 +159,7 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		caps:                 cfg.Caps.withDefaults(),
 		maxActionDataEntries: cfg.MaxActionDataEntries,
 		filter:               NewFilter(cfg.Filter),
+		summary:              cfg.Summary,
 		counters:             newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
 		activeInvocations:    activeInvocations,
 		eventsProcessed:      eventsProcessed,
@@ -358,7 +366,7 @@ func eventTypeName(event *bep.BuildEvent) string {
 func (tb *TraceBuilder) handleBuildStarted(ctx context.Context, invocations map[string]*invocationState, invocationID string, started *bep.BuildStarted) error {
 	traceID := traceIDFromUUID(started.GetUuid())
 	rootSpanID := spanIDFromIdentity(started.GetUuid(), "root")
-	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now(), tb.pii, tb.caps, tb.filter)
+	invocations[invocationID] = newInvocationState(traceID, rootSpanID, started, time.Now(), tb.pii, tb.caps, tb.filter, tb.summary)
 	tb.activeInvocations.Add(ctx, 1)
 
 	tb.logger.Debug("Build started",

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -591,6 +591,7 @@ func TestReapStale(t *testing.T) {
 		PIIConfig{},
 		HighCardinalityCaps{},
 		nil,
+		SummaryConfig{},
 	)
 	span := state.appendSpan()
 	span.SetSpanID(spanIDFromIdentity("uuid-stale", "action", "//pkg:lib", "Javac", ""))
@@ -1589,6 +1590,7 @@ func TestTraceBuilder_Aborted_WithoutBuildFinished(t *testing.T) {
 		PIIConfig{},
 		HighCardinalityCaps{},
 		nil,
+		SummaryConfig{},
 	)
 	state.recordAbort(&bep.Aborted{Reason: bep.Aborted_TIME_OUT, Description: "deadline"})
 
@@ -2718,4 +2720,121 @@ func TestTraceBuilder_StructuredCommandLine_Truncated(t *testing.T) {
 	// <= commandLineMaxBytes + ellipsis rune (3 bytes).
 	assert.LessOrEqual(t, len(cmd.Str()), commandLineMaxBytes+3)
 	assert.True(t, strings.HasSuffix(cmd.Str(), "…"), "expected truncation marker")
+}
+
+// summaryAttrInt fetches a bazel.summary.* Int64 attribute from the root span.
+// Asserts presence and returns the value so callers can compare against
+// per-test expectations inline.
+func summaryAttrInt(t *testing.T, span ptrace.Span, key string) int64 {
+	t.Helper()
+	v, ok := span.Attributes().Get(key)
+	require.Truef(t, ok, "expected attribute %s on root span", key)
+	require.Equalf(t, pcommon.ValueTypeInt, v.Type(), "expected %s to be Int64", key)
+	return v.Int()
+}
+
+// TestTraceBuilder_Summary_AccurateCounts feeds a representative event stream
+// (2 targets, 3 actions with a 2/1 success/fail split, 3 tests covering the
+// passed/flaky/failed verdicts) and asserts every bazel.summary.* value.
+func TestTraceBuilder_Summary_AccurateCounts(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		Summary: SummaryConfig{Enabled: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-sum", "uuid-sum", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-sum", "//pkg:lib", 2),
+		makeTargetConfiguredOBE(t, "inv-sum", "//pkg:test", 3),
+		makeActionOBE(t, "inv-sum", "//pkg:lib", "Javac", 4, true),
+		makeActionOBE(t, "inv-sum", "//pkg:lib", "Turbine", 5, true),
+		makeActionOBE(t, "inv-sum", "//pkg:lib", "Javac", 6, false),
+		makeTestSummaryOBE(t, "inv-sum", "//pkg:test/pass", 7, bep.TestStatus_PASSED, 1, 1, 0, 0),
+		makeTestSummaryOBE(t, "inv-sum", "//pkg:test/flake", 8, bep.TestStatus_FLAKY, 1, 1, 0, 0),
+		makeTestSummaryOBE(t, "inv-sum", "//pkg:test/fail", 9, bep.TestStatus_FAILED, 1, 1, 0, 0),
+		makeBuildFinishedOBE(t, "inv-sum", 10, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	assert.Equal(t, int64(2), summaryAttrInt(t, root, "bazel.summary.total_targets"))
+	assert.Equal(t, int64(3), summaryAttrInt(t, root, "bazel.summary.total_actions"))
+	assert.Equal(t, int64(2), summaryAttrInt(t, root, "bazel.summary.success_actions"))
+	assert.Equal(t, int64(1), summaryAttrInt(t, root, "bazel.summary.failed_actions"))
+	assert.Equal(t, int64(3), summaryAttrInt(t, root, "bazel.summary.total_tests"))
+	assert.Equal(t, int64(1), summaryAttrInt(t, root, "bazel.summary.passed_tests"))
+	assert.Equal(t, int64(1), summaryAttrInt(t, root, "bazel.summary.failed_tests"))
+	assert.Equal(t, int64(1), summaryAttrInt(t, root, "bazel.summary.flaky_tests"))
+}
+
+// TestTraceBuilder_Summary_ZeroCountersEmittedWhenEnabled verifies that a
+// build without any targets / actions / tests still produces zero-valued
+// Int64 attributes — the spec requires attribute presence regardless of
+// event count so downstream queries can rely on the keys existing.
+func TestTraceBuilder_Summary_ZeroCountersEmittedWhenEnabled(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		Summary: SummaryConfig{Enabled: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-zero", "uuid-zero", "build", 1),
+		makeBuildFinishedOBE(t, "inv-zero", 2, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	for _, key := range []string{
+		"bazel.summary.total_targets",
+		"bazel.summary.total_actions",
+		"bazel.summary.success_actions",
+		"bazel.summary.failed_actions",
+		"bazel.summary.total_tests",
+		"bazel.summary.passed_tests",
+		"bazel.summary.failed_tests",
+		"bazel.summary.flaky_tests",
+	} {
+		assert.Equal(t, int64(0), summaryAttrInt(t, root, key), "%s should be 0", key)
+	}
+}
+
+// TestTraceBuilder_Summary_DisabledOmitsAllAttributes asserts the enabled=false
+// path omits every bazel.summary.* attribute — not just zeros, but the keys
+// themselves. Mirrors the feature-gate contract in the issue acceptance
+// criteria.
+func TestTraceBuilder_Summary_DisabledOmitsAllAttributes(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		Summary: SummaryConfig{Enabled: false},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-off", "uuid-off", "build", 1),
+		makeTargetConfiguredOBE(t, "inv-off", "//pkg:lib", 2),
+		makeActionOBE(t, "inv-off", "//pkg:lib", "Javac", 3, true),
+		makeTestSummaryOBE(t, "inv-off", "//pkg:test", 4, bep.TestStatus_PASSED, 1, 1, 0, 0),
+		makeBuildFinishedOBE(t, "inv-off", 5, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	root.Attributes().Range(func(k string, _ pcommon.Value) bool {
+		assert.Falsef(t, strings.HasPrefix(k, "bazel.summary."),
+			"no bazel.summary.* attribute should be emitted when disabled, found %s", k)
+		return true
+	})
+}
+
+// TestTraceBuilder_Summary_DefaultFactoryEnablesEmission guards the default
+// config path — createDefaultConfig() must set Summary.Enabled=true so users
+// who never set the block still see the aggregate counters.
+func TestTraceBuilder_Summary_DefaultFactoryEnablesEmission(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	assert.True(t, cfg.Summary.Enabled, "summary.enabled must default to true")
 }


### PR DESCRIPTION
Surfaces an at-a-glance summary of the build on the root `bazel.build` span so dashboards and alerts can query invocation-level health (how many actions failed, how many tests were flaky, etc.) without traversing child spans. Counters accumulate on `invocationState.summaryCounts` as BEP events arrive and are stamped as `bazel.summary.*` Int64 attributes during `writeRootSpan`. Eight counters are emitted today: `total_targets`, `total_actions`, `success_actions`, `failed_actions`, `total_tests`, `passed_tests`, `failed_tests`, `flaky_tests`.

Test tallies come from `TestSummary.overall_status` (post-retry verdict, one per test target) rather than `TestResult` (one per attempt) so flaky retries don't inflate the counts. `summary.enabled` defaults to `true`; when flipped off the entire `bazel.summary.*` block is omitted. Zero-valued counters are still emitted under the enabled path so downstream queries can assert attribute presence without a null case.

Recording happens at the top of each event mutator — before the #13 filter gate. That's intentional: a target dropped by `detail_level: drop` still contributes to `total_targets`, an action suppressed at `build_only` still bumps `total_actions`/`success_actions`/`failed_actions`. This keeps the summary a faithful view of the build rather than a view of what happened to be emitted.

Docs: new "Summary counters" section in `docs/attributes.md` (sibling to the PII section) with the full attribute table and a note about the pre-filter recording contract. `collector-config.yaml` gains a commented `summary:` block alongside the existing `pii:` and `filter:` examples.

Closes #15.