### PR TITLE
feat(besreceiver): route Progress events to logs pipeline

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -61,6 +61,16 @@ receivers:
     # the filter above still contributes to the totals. Default: enabled.
     # summary:
     #   enabled: true
+    # Route Bazel Progress events (streaming stdout/stderr) to the logs
+    # pipeline. Opt-in: Progress payloads can be large and may contain
+    # anything Bazel prints — command lines, file paths, env vars, secrets
+    # echoed by actions. Each non-empty stream produces one log record:
+    # stdout -> INFO, stderr -> ERROR. Chunks larger than max_chunk_size are
+    # truncated with bazel.progress.truncated=true and
+    # bazel.progress.original_bytes=N. max_chunk_size: 0 disables the cap.
+    # progress:
+    #   enabled: false
+    #   max_chunk_size: 65536
 
 processors:
   memory_limiter:

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -278,6 +278,59 @@ is `Info` for successful events, `Error` for failures and aborts. Log
 records carry the invocation's TraceID so they correlate with the trace
 emitted for the same invocation.
 
+## Progress logs
+
+Bazel's `Progress` BEP events carry streaming stdout/stderr chunks. They
+are opt-in because payloads can be large and may contain anything Bazel
+prints — command lines, file paths, env vars, or secrets echoed by
+actions. Enable routing to the logs pipeline with:
+
+```yaml
+receivers:
+  bes:
+    progress:
+      enabled: true          # default: false
+      max_chunk_size: 65536  # bytes per record; 0 = unlimited
+```
+
+When enabled, each non-empty stream on a `Progress` event emits one log
+record with `event.name=bazel.progress`. Empty streams are skipped. A
+`Progress` with empty stdout AND empty stderr emits nothing.
+
+| Attribute                        | Type   | Source                                          |
+|----------------------------------|--------|-------------------------------------------------|
+| `bazel.invocation_id`            | string | BES stream invocation id                        |
+| `bazel.progress.stream`          | string | `stdout` or `stderr`                            |
+| `bazel.progress.bytes`           | int    | Original byte length of the stream chunk        |
+| `bazel.progress.truncated`       | bool   | `true` when `bytes > max_chunk_size`            |
+| `bazel.progress.opaque_count`    | int    | `BuildEventId.Progress.opaque_count` — same on the stderr and stdout records of one event so consumers can pair them |
+
+Both `bazel.progress.bytes` and `bazel.progress.truncated` are stamped on
+every record so downstream queries can rely on attribute presence rather
+than guarding against absent keys.
+
+Severity is `INFO` on both streams — Bazel routes normal-build chatter
+(`Loading:`, `Analyzing:`, `Build completed successfully`) through stderr,
+so mapping stderr to `ERROR` would page on every green build. Operators
+who need elevation can stack a `transformprocessor`. When both streams
+carry data on the same `Progress` event, the receiver emits stderr first
+to match the BEP spec ordering (`build_event_stream.proto:303-304`).
+
+The record body is the (possibly truncated) stream content. Truncation
+clips at a UTF-8 rune boundary so consumers never see invalid encoding.
+Records carry the invocation's TraceID, matching the correlation scheme
+used for other log records.
+
+Memory note: this feature truncates the *log record body*, not the
+inbound gRPC payload. The full Progress message must still be unmarshalled
+by the receiver before truncation runs. See `docs/adr/0002-large-payload-handling.md`
+for the heap-bounding story (issues #64/#65/#66).
+
+Since stream contents can contain PII, the feature defaults off. When
+enabled, stack a `redactionprocessor` (or similar) downstream to scrub
+sensitive substrings before export — per-key PII controls do not apply
+to free-form output.
+
 ## Metrics
 
 Per-invocation gauges (`bazel.invocation.*`) and cross-invocation

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -48,7 +48,42 @@ type Config struct {
 	// Summary controls aggregate build counters stamped on the root span.
 	// See SummaryConfig.
 	Summary SummaryConfig `mapstructure:"summary"`
+
+	// Progress gates routing of Bazel Progress BEP events (streaming
+	// stdout/stderr chunks) through the OTel logs pipeline. Defaults to
+	// disabled to preserve pre-feature behaviour — Progress payloads can be
+	// large and contain anything Bazel prints, so operators must opt in. See
+	// ProgressConfig.
+	Progress ProgressConfig `mapstructure:"progress"`
 }
+
+// ProgressConfig controls emission of Progress BEP events as log records.
+// When Enabled is false (default), Progress events are silently dropped; when
+// true, each non-empty stream (stdout/stderr) on a Progress event produces
+// one log record with severity INFO (stdout) or ERROR (stderr).
+//
+// MaxChunkSize caps the body size per record: chunks exceeding it are
+// truncated and stamped with bazel.progress.truncated=true plus
+// bazel.progress.original_bytes=N. A value of 0 disables the cap.
+type ProgressConfig struct {
+	// Enabled is the master switch. Defaults to false — Progress payloads
+	// may contain command lines, file paths, env vars, or secrets echoed by
+	// actions, and they are the largest events on the wire in practice.
+	Enabled bool `mapstructure:"enabled"`
+	// MaxChunkSize is the maximum body size (bytes) per emitted log record.
+	// Chunks larger than this are truncated at the byte boundary and
+	// annotated with bazel.progress.truncated=true. Zero means unlimited.
+	// Negative values are rejected at Validate.
+	MaxChunkSize int `mapstructure:"max_chunk_size"`
+}
+
+// defaultProgressMaxChunkSize bounds Progress log bodies to 64 KiB by default.
+// A single Bazel Progress payload can span hundreds of MiB on large builds;
+// routing the full content untrimmed into the logs pipeline would blow the
+// default OTLP batch size and inflate backend storage cost. 64 KiB keeps a
+// useful amount of context (~1000 lines of typical build output) while leaving
+// the operator room to raise or lower the cap explicitly.
+const defaultProgressMaxChunkSize = 64 * 1024
 
 // HighCardinalityCaps configures per-attribute limits on the Slice[Map]
 // attributes emitted on the bazel.metrics span for high-cardinality
@@ -187,6 +222,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.MaxActionDataEntries < 0 {
 		return fmt.Errorf("max_action_data_entries must not be negative, got %d", cfg.MaxActionDataEntries)
+	}
+	if cfg.Progress.MaxChunkSize < 0 {
+		return fmt.Errorf("progress.max_chunk_size must not be negative, got %d", cfg.Progress.MaxChunkSize)
 	}
 	if err := cfg.Filter.Validate(); err != nil {
 		return err

--- a/receiver/besreceiver/config_test.go
+++ b/receiver/besreceiver/config_test.go
@@ -139,3 +139,33 @@ func TestConfigValidate_NegativeMaxActionDataEntries(t *testing.T) {
 		t.Error("expected error for negative max_action_data_entries")
 	}
 }
+
+func TestConfigDefaults_Progress(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	// Progress emission defaults to off — operators opt in explicitly.
+	if cfg.Progress.Enabled {
+		t.Error("Progress.Enabled must default to false")
+	}
+	if cfg.Progress.MaxChunkSize != defaultProgressMaxChunkSize {
+		t.Errorf("expected default progress.max_chunk_size %d, got %d",
+			defaultProgressMaxChunkSize, cfg.Progress.MaxChunkSize)
+	}
+}
+
+func TestConfigValidate_NegativeProgressMaxChunkSize(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Progress.MaxChunkSize = -1
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for negative progress.max_chunk_size")
+	}
+}
+
+func TestConfigValidate_ZeroProgressMaxChunkSize(t *testing.T) {
+	// 0 is valid — it disables the cap (unlimited per-record size).
+	cfg := createDefaultConfig().(*Config)
+	cfg.Progress.Enabled = true
+	cfg.Progress.MaxChunkSize = 0
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected zero max_chunk_size to validate (means unlimited), got %v", err)
+	}
+}

--- a/receiver/besreceiver/factory.go
+++ b/receiver/besreceiver/factory.go
@@ -49,6 +49,13 @@ func createDefaultConfig() component.Config {
 			DefaultLevel: DetailLevelVerbose,
 		},
 		Summary: SummaryConfig{Enabled: true},
+		Progress: ProgressConfig{
+			// Disabled by default — Progress payloads are large and may
+			// contain sensitive content echoed by actions. Operators opt in
+			// explicitly to route stdout/stderr into the logs pipeline.
+			Enabled:      false,
+			MaxChunkSize: defaultProgressMaxChunkSize,
+		},
 	}
 }
 

--- a/receiver/besreceiver/receiver.go
+++ b/receiver/besreceiver/receiver.go
@@ -47,6 +47,7 @@ func (r *besReceiver) Start(ctx context.Context, host component.Host) error {
 			Caps:                 r.config.HighCardinalityCaps,
 			MaxActionDataEntries: r.config.MaxActionDataEntries,
 			Filter:               r.config.Filter,
+			Progress:             r.config.Progress,
 		})
 		r.traceBuilder.Start()
 

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -388,6 +388,20 @@ func makeTestSummaryOBE(t testing.TB, invID, label string, seqNum int64, status 
 	})
 }
 
+func makeProgressOBE(t testing.TB, invID string, seqNum int64, stdout, stderr string) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_Progress{
+				Progress: &bep.BuildEventId_ProgressId{OpaqueCount: int32(seqNum)},
+			},
+		},
+		Payload: &bep.BuildEvent_Progress{
+			Progress: &bep.Progress{Stdout: stdout, Stderr: stderr},
+		},
+	})
+}
+
 func makeBuildMetricsOBE(t testing.TB, invID string, seqNum, wallMs, cpuMs int64) *pb.OrderedBuildEvent {
 	t.Helper()
 	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -64,6 +64,9 @@ type TraceBuilderConfig struct {
 	Filter FilterConfig
 	// Summary gates bazel.summary.* aggregate attributes on the root span.
 	Summary SummaryConfig
+	// Progress configures Progress BEP event routing to the logs pipeline.
+	// Zero value = disabled, no Progress-derived log records emitted.
+	Progress ProgressConfig
 }
 
 // TraceBuilder converts BEP events into OTel traces, logs, and metrics.
@@ -102,6 +105,11 @@ type TraceBuilder struct {
 	// Threaded into invocationState so the recording calls in addTarget /
 	// addAction / addTestResult / summarizeTarget stay self-contained.
 	summary SummaryConfig
+
+	// progress gates Progress BEP event routing to the logs pipeline. Copied
+	// from TraceBuilderConfig.Progress at construction and consulted per
+	// event in handleProgress.
+	progress ProgressConfig
 
 	// Cumulative counters for cross-invocation metrics.
 	counters *cumulativeCounters
@@ -160,6 +168,7 @@ func NewTraceBuilder(tracesConsumer consumer.Traces, logsConsumer consumer.Logs,
 		maxActionDataEntries: cfg.MaxActionDataEntries,
 		filter:               NewFilter(cfg.Filter),
 		summary:              cfg.Summary,
+		progress:             cfg.Progress,
 		counters:             newCumulativeCounters(pcommon.NewTimestampFromTime(time.Now())),
 		activeInvocations:    activeInvocations,
 		eventsProcessed:      eventsProcessed,
@@ -323,11 +332,18 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 			return nil
 		}
 		return tb.handleTestSummary(ctx, invocations, invocationID, event.GetId(), p.TestSummary)
+	case *bep.BuildEvent_Progress:
+		if p.Progress == nil {
+			return nil
+		}
+		return tb.handleProgress(ctx, invocations, invocationID, event.GetId(), p.Progress)
 	}
 	return nil
 }
 
 // eventTypeName returns a short name for the BEP event type, used as a metric attribute.
+//
+//nolint:gocyclo // Flat payload dispatch mirrors processEvent; grows with handled types.
 func eventTypeName(event *bep.BuildEvent) string {
 	switch event.GetPayload().(type) {
 	case *bep.BuildEvent_Started:
@@ -352,6 +368,8 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "target_complete"
 	case *bep.BuildEvent_TestSummary:
 		return "test_summary"
+	case *bep.BuildEvent_Progress:
+		return "progress"
 	case *bep.BuildEvent_Configuration:
 		return "configuration"
 	case *bep.BuildEvent_OptionsParsed:
@@ -715,15 +733,25 @@ func reconstructCommandLine(cl *commandline.CommandLine) string {
 		}
 	}
 	joined := strings.Join(parts, " ")
-	if len(joined) <= commandLineMaxBytes {
-		return joined
+	clipped, truncated := truncateUTF8(joined, commandLineMaxBytes)
+	if !truncated {
+		return clipped
 	}
-	// Back off to rune boundary so we never emit invalid UTF-8.
-	end := commandLineMaxBytes
-	for end > 0 && !utf8.RuneStart(joined[end]) {
+	return clipped + "…"
+}
+
+// truncateUTF8 returns s clipped to at most maxBytes, backed off to a rune
+// boundary so the result is valid UTF-8. maxBytes <= 0 disables the cap.
+// The boolean reports whether truncation occurred.
+func truncateUTF8(s string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return s, false
+	}
+	end := maxBytes
+	for end > 0 && !utf8.RuneStart(s[end]) {
 		end--
 	}
-	return joined[:end] + "…"
+	return s[:end], true
 }
 
 // handleTargetComplete enriches an existing bazel.target span with outcome
@@ -779,6 +807,93 @@ func (tb *TraceBuilder) handleTestSummary(ctx context.Context, invocations map[s
 		},
 	)
 	return nil
+}
+
+// handleProgress routes Bazel Progress BEP events (streaming stdout/stderr
+// chunks) through the logs pipeline. The feature is gated behind
+// TraceBuilder.progress.Enabled — when disabled, Progress events are silently
+// dropped. Each non-empty stream produces one log record at INFO severity.
+// Chunks exceeding progress.MaxChunkSize are clipped at a UTF-8 rune boundary
+// and stamped with bazel.progress.truncated=true plus bazel.progress.bytes=N
+// (original byte length). MaxChunkSize == 0 disables the cap.
+//
+// stderr is emitted before stdout to match the BEP spec ordering contract
+// (build_event_stream.proto: "stderr has been emitted before stdout if both
+// are present"). The opaque_count from BuildEventId is stamped on each record
+// so consumers can re-establish chunk order across streams.
+//
+// Silently dropped when the invocation has no state (Progress arriving before
+// BuildStarted, or after the invocation is reaped) or once the trace batch
+// has been flushed — matches the gate used by every other handler.
+func (tb *TraceBuilder) handleProgress(ctx context.Context, invocations map[string]*invocationState, invocationID string, eventID *bep.BuildEventId, progress *bep.Progress) error {
+	if !tb.progress.Enabled {
+		return nil
+	}
+	state := invocations[invocationID]
+	if state == nil || state.flushed {
+		return nil
+	}
+	// Progress has no timestamp field; use invocation-scoped now so records
+	// are orderable even when handled out of wall-clock order by consumers.
+	ts := time.Now()
+	opaqueCount := eventID.GetProgress().GetOpaqueCount()
+	if stderr := progress.GetStderr(); stderr != "" {
+		tb.emitProgressLog(ctx, state, invocationID, "stderr", stderr, opaqueCount, ts)
+	}
+	if stdout := progress.GetStdout(); stdout != "" {
+		tb.emitProgressLog(ctx, state, invocationID, "stdout", stdout, opaqueCount, ts)
+	}
+	return nil
+}
+
+// emitProgressLog builds and emits a single log record for a Progress stream
+// chunk. Severity is INFO regardless of stream — Bazel routes normal-build
+// chatter ("Loading:", "Analyzing:", "Build completed successfully") through
+// stderr, so mapping stderr to ERROR would page on every green build.
+// Operators who need elevation can stack a transformprocessor downstream.
+func (tb *TraceBuilder) emitProgressLog(ctx context.Context, state *invocationState, invocationID, stream, body string, opaqueCount int32, ts time.Time) {
+	if tb.logsConsumer == nil {
+		return
+	}
+
+	originalBytes := len(body)
+	body, truncated := truncateUTF8(body, tb.progress.MaxChunkSize)
+
+	logs, lr := newLogPayload()
+	lr.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	lr.SetSeverityNumber(plog.SeverityNumberInfo)
+	lr.SetSeverityText(plog.SeverityNumberInfo.String())
+	lr.Body().SetStr(body)
+
+	attrs := lr.Attributes()
+	attrs.PutStr("event.name", "bazel.progress")
+	attrs.PutStr("bazel.invocation_id", invocationID)
+	attrs.PutStr("bazel.progress.stream", stream)
+	attrs.PutInt("bazel.progress.bytes", int64(originalBytes))
+	attrs.PutBool("bazel.progress.truncated", truncated)
+	attrs.PutInt("bazel.progress.opaque_count", int64(opaqueCount))
+
+	lr.SetTraceID(state.traceID)
+
+	if err := tb.logsConsumer.ConsumeLogs(ctx, logs); err != nil {
+		tb.logger.Warn("Failed to emit Progress log record",
+			zap.String("invocation_id", invocationID),
+			zap.String("stream", stream),
+			zap.Error(err),
+		)
+	}
+}
+
+// newLogPayload returns an empty plog.Logs pre-populated with the standard
+// resource (service.name=bazel) and scope (besreceiver), plus the empty log
+// record to be populated by the caller.
+func newLogPayload() (plog.Logs, plog.LogRecord) {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "bazel")
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.Scope().SetName("besreceiver")
+	return logs, sl.LogRecords().AppendEmpty()
 }
 
 func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[string]*invocationState, invocationID string, metrics *bep.BuildMetrics) error {
@@ -869,13 +984,7 @@ func (tb *TraceBuilder) emitLog(ctx context.Context, state *invocationState, inv
 		return
 	}
 
-	logs := plog.NewLogs()
-	rl := logs.ResourceLogs().AppendEmpty()
-	rl.Resource().Attributes().PutStr("service.name", "bazel")
-	sl := rl.ScopeLogs().AppendEmpty()
-	sl.Scope().SetName("besreceiver")
-
-	lr := sl.LogRecords().AppendEmpty()
+	logs, lr := newLogPayload()
 	if !ts.IsZero() {
 		lr.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 	}

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2837,4 +2838,261 @@ func TestTraceBuilder_Summary_DisabledOmitsAllAttributes(t *testing.T) {
 func TestTraceBuilder_Summary_DefaultFactoryEnablesEmission(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.True(t, cfg.Summary.Enabled, "summary.enabled must default to true")
+}
+
+// --- Progress → logs tests ---
+
+// newProgressTB builds a TraceBuilder with Progress enabled at the given cap.
+// Returns the builder and a logs sink for assertion.
+func newProgressTB(t *testing.T, maxChunkSize int) (*TraceBuilder, *consumertest.LogsSink) {
+	t.Helper()
+	logsSink := new(consumertest.LogsSink)
+	tb := NewTraceBuilder(nil, logsSink, nil, zap.NewNop(), TraceBuilderConfig{
+		Progress: ProgressConfig{Enabled: true, MaxChunkSize: maxChunkSize},
+	})
+	tb.Start()
+	t.Cleanup(tb.Stop)
+	return tb, logsSink
+}
+
+// firstProgressRecord returns the single log record at index i, failing if
+// the shape is unexpected.
+func firstProgressRecord(t *testing.T, sink *consumertest.LogsSink, i int) plog.LogRecord {
+	t.Helper()
+	logs := sink.AllLogs()
+	require.Greater(t, len(logs), i, "missing log record at index %d", i)
+	rl := logs[i].ResourceLogs()
+	require.Equal(t, 1, rl.Len())
+	sl := rl.At(0).ScopeLogs()
+	require.Equal(t, 1, sl.Len())
+	lrs := sl.At(0).LogRecords()
+	require.Equal(t, 1, lrs.Len())
+	return lrs.At(0)
+}
+
+func TestProgress_DisabledByDefault(t *testing.T) {
+	logsSink := new(consumertest.LogsSink)
+	// Zero-value TraceBuilderConfig.Progress → Enabled=false.
+	tb := NewTraceBuilder(nil, logsSink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-dis", "uuid-dis", "build", 1),
+		makeProgressOBE(t, "inv-dis", 2, "stdout chunk\n", "stderr chunk\n"),
+	)
+
+	// Only the BuildStarted log record; Progress must be suppressed entirely.
+	require.Equal(t, 1, logsSink.LogRecordCount())
+	lr := firstProgressRecord(t, logsSink, 0)
+	evt, _ := lr.Attributes().Get("event.name")
+	assert.Equal(t, "bazel.build.started", evt.Str())
+}
+
+func TestProgress_Enabled_StdoutOnly(t *testing.T) {
+	tb, logsSink := newProgressTB(t, 1024)
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-so", "uuid-so", "build", 1),
+		makeProgressOBE(t, "inv-so", 2, "compiling //pkg:lib\n", ""),
+	)
+
+	// 1 BuildStarted + 1 stdout record = 2.
+	require.Equal(t, 2, logsSink.LogRecordCount())
+	lr := firstProgressRecord(t, logsSink, 1)
+	assert.Equal(t, plog.SeverityNumberInfo, lr.SeverityNumber())
+	assert.Equal(t, "compiling //pkg:lib\n", lr.Body().Str())
+
+	evt, _ := lr.Attributes().Get("event.name")
+	assert.Equal(t, "bazel.progress", evt.Str())
+	stream, _ := lr.Attributes().Get("bazel.progress.stream")
+	assert.Equal(t, "stdout", stream.Str())
+	invID, _ := lr.Attributes().Get("bazel.invocation_id")
+	assert.Equal(t, "inv-so", invID.Str())
+
+	// bytes + truncated are always stamped so consumers can rely on presence.
+	bytes, ok := lr.Attributes().Get("bazel.progress.bytes")
+	require.True(t, ok, "bazel.progress.bytes must always be stamped")
+	assert.Equal(t, int64(len("compiling //pkg:lib\n")), bytes.Int())
+
+	trunc, ok := lr.Attributes().Get("bazel.progress.truncated")
+	require.True(t, ok, "bazel.progress.truncated must always be stamped")
+	assert.False(t, trunc.Bool())
+
+	// opaque_count is propagated from BuildEventId so consumers can re-establish
+	// chunk order across stdout/stderr.
+	op, ok := lr.Attributes().Get("bazel.progress.opaque_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(2), op.Int())
+
+	// TraceID ties the record back to the invocation.
+	assert.Equal(t, traceIDFromUUID("uuid-so"), lr.TraceID())
+}
+
+func TestProgress_Enabled_StderrOnly(t *testing.T) {
+	tb, logsSink := newProgressTB(t, 1024)
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-se", "uuid-se", "build", 1),
+		makeProgressOBE(t, "inv-se", 2, "", "WARNING: dangling reference\n"),
+	)
+
+	require.Equal(t, 2, logsSink.LogRecordCount())
+	lr := firstProgressRecord(t, logsSink, 1)
+	// stderr maps to INFO — Bazel routes normal-build chatter through stderr.
+	assert.Equal(t, plog.SeverityNumberInfo, lr.SeverityNumber())
+	assert.Equal(t, "WARNING: dangling reference\n", lr.Body().Str())
+	stream, _ := lr.Attributes().Get("bazel.progress.stream")
+	assert.Equal(t, "stderr", stream.Str())
+}
+
+func TestProgress_Enabled_BothStreams_StderrFirst(t *testing.T) {
+	tb, logsSink := newProgressTB(t, 1024)
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-both", "uuid-both", "build", 1),
+		makeProgressOBE(t, "inv-both", 2, "out-chunk\n", "err-chunk\n"),
+	)
+
+	// 1 BuildStarted + 2 Progress (stderr first per BEP spec, then stdout).
+	require.Equal(t, 3, logsSink.LogRecordCount())
+
+	stderrLR := firstProgressRecord(t, logsSink, 1)
+	stream1, _ := stderrLR.Attributes().Get("bazel.progress.stream")
+	assert.Equal(t, "stderr", stream1.Str(), "stderr must be emitted first per BEP spec")
+	assert.Equal(t, plog.SeverityNumberInfo, stderrLR.SeverityNumber())
+	assert.Equal(t, "err-chunk\n", stderrLR.Body().Str())
+
+	stdoutLR := firstProgressRecord(t, logsSink, 2)
+	stream2, _ := stdoutLR.Attributes().Get("bazel.progress.stream")
+	assert.Equal(t, "stdout", stream2.Str())
+	assert.Equal(t, plog.SeverityNumberInfo, stdoutLR.SeverityNumber())
+	assert.Equal(t, "out-chunk\n", stdoutLR.Body().Str())
+
+	// Both records share the same opaque_count so consumers can pair them.
+	op1, _ := stderrLR.Attributes().Get("bazel.progress.opaque_count")
+	op2, _ := stdoutLR.Attributes().Get("bazel.progress.opaque_count")
+	assert.Equal(t, op1.Int(), op2.Int())
+}
+
+func TestProgress_Enabled_EmptyStreamsSuppressed(t *testing.T) {
+	tb, logsSink := newProgressTB(t, 1024)
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-empty", "uuid-empty", "build", 1),
+		// Both streams empty — no Progress record must be emitted.
+		makeProgressOBE(t, "inv-empty", 2, "", ""),
+	)
+
+	require.Equal(t, 1, logsSink.LogRecordCount(), "empty Progress must emit nothing")
+}
+
+func TestProgress_Truncation_SingleStream(t *testing.T) {
+	const maxChunkSize = 16
+	tb, logsSink := newProgressTB(t, maxChunkSize)
+	ctx := context.Background()
+
+	// 100 bytes of stdout; must be truncated to 16 and stamped.
+	stdout := strings.Repeat("x", 100)
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-trunc", "uuid-trunc", "build", 1),
+		makeProgressOBE(t, "inv-trunc", 2, stdout, ""),
+	)
+
+	require.Equal(t, 2, logsSink.LogRecordCount())
+	lr := firstProgressRecord(t, logsSink, 1)
+	assert.Equal(t, maxChunkSize, len(lr.Body().Str()), "body must be truncated to MaxChunkSize")
+	assert.Equal(t, strings.Repeat("x", maxChunkSize), lr.Body().Str())
+
+	trunc, ok := lr.Attributes().Get("bazel.progress.truncated")
+	require.True(t, ok)
+	assert.True(t, trunc.Bool())
+
+	bytes, ok := lr.Attributes().Get("bazel.progress.bytes")
+	require.True(t, ok)
+	assert.Equal(t, int64(100), bytes.Int(), "bytes reflects original length, not clipped length")
+}
+
+func TestProgress_Truncation_RuneSafe(t *testing.T) {
+	// Cap that lands mid-rune for the test fixture — verify the body is
+	// clipped at a rune boundary rather than producing invalid UTF-8.
+	const maxChunkSize = 5
+	tb, logsSink := newProgressTB(t, maxChunkSize)
+	ctx := context.Background()
+
+	// "héllo" — h(1) + é(2) + l(1) + l(1) + o(1) = 6 bytes; cap of 5 lands
+	// inside é, so truncation must back off to either 1 byte ("h") or 3 bytes
+	// ("hé"). Either way the result must be valid UTF-8.
+	stdout := "héllo"
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-rune", "uuid-rune", "build", 1),
+		makeProgressOBE(t, "inv-rune", 2, stdout, ""),
+	)
+
+	lr := firstProgressRecord(t, logsSink, 1)
+	body := lr.Body().Str()
+	assert.True(t, utf8.ValidString(body), "truncated body must be valid UTF-8, got %q", body)
+	assert.LessOrEqual(t, len(body), maxChunkSize)
+}
+
+func TestProgress_CapDisabled_ZeroMeansUnlimited(t *testing.T) {
+	// MaxChunkSize == 0 disables the cap — even very large bodies pass
+	// through verbatim. truncated is stamped as false; bytes carries the
+	// original length.
+	tb, logsSink := newProgressTB(t, 0)
+	ctx := context.Background()
+
+	stdout := strings.Repeat("y", 1<<20) // 1 MiB
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-unl", "uuid-unl", "build", 1),
+		makeProgressOBE(t, "inv-unl", 2, stdout, ""),
+	)
+
+	require.Equal(t, 2, logsSink.LogRecordCount())
+	lr := firstProgressRecord(t, logsSink, 1)
+	assert.Equal(t, len(stdout), len(lr.Body().Str()), "body must pass through unmodified when cap is 0")
+	trunc, _ := lr.Attributes().Get("bazel.progress.truncated")
+	assert.False(t, trunc.Bool())
+	bytes, _ := lr.Attributes().Get("bazel.progress.bytes")
+	assert.Equal(t, int64(len(stdout)), bytes.Int())
+}
+
+func TestProgress_PostFlushDropped(t *testing.T) {
+	// Progress arriving after BuildFinished (which flushes the trace batch)
+	// must be silently dropped — matches the gate every other handler uses.
+	tb, logsSink := newProgressTB(t, 1024)
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-postf", "uuid-postf", "build", 1),
+		makeBuildFinishedOBE(t, "inv-postf", 2, 0, "SUCCESS"),
+		// Late Progress — the batch is already flushed.
+		makeProgressOBE(t, "inv-postf", 3, "late stdout\n", "late stderr\n"),
+	)
+
+	for i := range logsSink.LogRecordCount() {
+		lr := firstProgressRecord(t, logsSink, i)
+		evt, _ := lr.Attributes().Get("event.name")
+		assert.NotEqual(t, "bazel.progress", evt.Str(),
+			"post-flush Progress must not emit a log record")
+	}
+}
+
+func TestProgress_UnknownInvocationDropped(t *testing.T) {
+	// Progress arrives before BuildStarted — no invocation state yet, so the
+	// record must be silently dropped (matches the pattern used by other
+	// handlers).
+	tb, logsSink := newProgressTB(t, 1024)
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeProgressOBE(t, "inv-orphan", 1, "out\n", "err\n"),
+	)
+
+	require.Equal(t, 0, logsSink.LogRecordCount())
 }


### PR DESCRIPTION
Adds opt-in consumption of Bazel `Progress` BEP events as OTel log records. Each non-empty stream produces one record at `INFO` severity, stamped with `bazel.progress.{stream,bytes,truncated,opaque_count}`. When the body exceeds `progress.max_chunk_size` the receiver clips at a UTF-8 rune boundary (never producing invalid encoding) and `bazel.progress.truncated=true`. `max_chunk_size: 0` disables the cap; config validation rejects negative values.

Default is `progress.enabled: false` to avoid surprise log volume — Bazel builds with `--build_event_publish_all_actions` produce a lot of Progress. Operators opt in explicitly, and the bundled 64 KiB chunk size keeps the worst-case per-record payload bounded once they do.

## Review-driven design choices

- **Severity is `INFO` on both streams.** Bazel routes normal-build chatter (`Loading:`, `Analyzing:`, `Build completed successfully`) through stderr — mapping stderr to `ERROR` would page on every green build. Operators who need elevation can stack a `transformprocessor` downstream.
- **Emission order is stderr-first**, matching the BEP spec (`build_event_stream.proto:303-304`: "stderr has been emitted before stdout if both are present"). Both records on a single Progress event share the same `opaque_count` so consumers can pair them and reconstruct chunk order.
- **Rune-safe truncation.** The body clip backs off to a UTF-8 rune boundary using a new shared `truncateUTF8` helper (also adopted by `reconstructCommandLine` to dedup the existing manual loop).
- **Always-on `bytes` and `truncated` attributes.** Both are stamped on every record so downstream queries can rely on attribute presence rather than guarding for absent keys. The previous `original_bytes`-only-on-truncation contract is gone — replaced by `bytes` (always = original byte length).
- **Post-flush gate.** `handleProgress` checks `state.flushed`, matching the gate every other event handler uses; late Progress arriving after `BuildFinished` is dropped silently rather than appearing in a separate consumer batch.
- **`emitLog` / `emitProgressLog` deduplication.** Both now share a `newLogPayload` helper for the resource/scope boilerplate, eliminating the duplicated `service.name="bazel"` literal and the duplicated record-construction logic.

## Memory bounding — explicit non-goal

This PR truncates the *log record body*, not the inbound gRPC payload. The full Progress message is still allocated by `proto.Unmarshal` before the handler runs. See `docs/adr/0002-large-payload-handling.md` and the concrete follow-ups #64/#65/#66 for the heap-bounding story.

## ACK back-pressure — known trade-off, follow-up filed

Routing Progress through the existing synchronous `ConsumeLogs` path widens an existing back-pressure surface: a stalled logs pipeline now holds BES ACKs on the highest-volume BEP event class. The pattern pre-exists for every other handler, so fixing it correctly is project-wide. Filed as #72 (async/bounded logs path).

## Deferred to follow-ups

- #72 — async logs path so logs-pipeline back-pressure doesn't gate BES ACKs
- #73 — per-stream `progress.stdout` / `progress.stderr` toggles

Closes #60.