### PR TITLE
feat(besreceiver): stamp bazel.run attrs from ExecRequestConstructed

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -48,6 +48,19 @@ without `BuildFinished`, from the reaper path.
 | `bazel.options.startup_count`| int    | `len(OptionsParsed.explicit_startup_options)`                    |
 | `bazel.options.command_count`| int    | `len(OptionsParsed.explicit_cmd_line)`                           |
 | `bazel.command_line`         | string | Reconstructed `StructuredCommandLine` — **PII**, requires `include_command_line` |
+| `bazel.run.argv`                       | Slice[string]      | `ExecRequestConstructed.argv` (only on `bazel run`) — **PII**, requires `include_command_args` |
+| `bazel.run.working_directory`          | string             | `ExecRequestConstructed.working_directory` (only on `bazel run`) — **PII**, requires `include_working_dir` |
+| `bazel.run.environment_variable_count` | int                | `len(ExecRequestConstructed.environment_variable)` (only on `bazel run`) |
+| `bazel.run.environment`                | Slice[Map]         | `ExecRequestConstructed.environment_variable` (only on `bazel run`) — `{name, value}` entries; **PII**, requires `include_command_args` |
+| `bazel.run.should_exec`                | bool               | `ExecRequestConstructed.should_exec` (only on `bazel run`) |
+
+The `bazel.run.*` group is populated only for `bazel run` invocations, where
+Bazel emits `ExecRequestConstructed` after the build succeeds and before the
+target is exec'd. `bazel build` / `bazel test` invocations carry none of
+these attributes. `bazel.run.environment_variable_count` and
+`bazel.run.should_exec` are always emitted when the event arrives (counts
+and bools carry no PII); argv, environment, and working_directory are
+PII-gated per the table above.
 
 Key sanitization for `bazel.workspace.*` and `bazel.metadata.*`: lowercase,
 collapse whitespace to `_`, strip characters outside `[a-z0-9_.]`, trim
@@ -186,8 +199,8 @@ receivers:
       include_hostname: false              # bazel.host + host-like workspace/metadata keys
       include_username: false              # bazel.user + user-like workspace/metadata keys
       include_workspace_dir: false         # bazel.workspace_directory + matching workspace/metadata keys
-      include_working_dir: false           # bazel.working_directory + matching workspace/metadata keys
-      include_command_args: false          # bazel.action.command_line
+      include_working_dir: false           # bazel.working_directory + bazel.run.working_directory + matching workspace/metadata keys
+      include_command_args: false          # bazel.action.command_line + bazel.run.argv + bazel.run.environment
       include_action_output_paths: false   # bazel.action.primary_output
       include_workspace_status: false      # bazel.workspace.* pathway (per-key filtered)
       include_build_metadata: false        # bazel.metadata.* pathway (per-key filtered)

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -100,6 +100,13 @@ type invocationState struct {
 	commandCount int64
 	commandLine  string
 
+	// execRequest buffers the ExecRequestConstructed payload for emission as
+	// bazel.run.* attrs on the root span. Only one ExecRequestConstructed
+	// event fires per invocation (on successful `bazel run`); later arrivals
+	// would overwrite, but the pattern matches WorkspaceStatus /
+	// StructuredCommandLine buffering where final-value-wins is acceptable.
+	execRequest *bep.ExecRequestConstructed
+
 	// pii opts specific BEP fields into span emission; see PIIConfig.
 	pii PIIConfig
 
@@ -511,6 +518,8 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 		span.Attributes().PutStr("bazel.command_line", s.commandLine)
 	}
 
+	s.applyExecRequestAttrs(span)
+
 	s.applyContextAttributes(span)
 
 	s.applySummaryAttributes(span)
@@ -559,6 +568,67 @@ func (s *invocationState) applyStartedAttributes(span ptrace.Span) {
 			span.Attributes().PutStr("bazel.user", user)
 		}
 	}
+}
+
+// applyExecRequestAttrs stamps bazel.run.* attributes from a buffered
+// ExecRequestConstructed. No-op when the event was never buffered (the
+// common case for `bazel build` / `bazel test` invocations, which never
+// emit ExecRequestConstructed).
+//
+// Gating matrix:
+//   - bazel.run.argv:                     PII.IncludeCommandArgs
+//   - bazel.run.environment:              PII.IncludeCommandArgs (env often
+//     carries argv-adjacent secrets, so it reuses the same gate)
+//   - bazel.run.working_directory:        PII.IncludeWorkingDir
+//   - bazel.run.environment_variable_count: always emitted (count only, safe)
+//   - bazel.run.should_exec:              always emitted (bool, safe)
+//
+// The BEP proto types argv / working_directory / env name+value as bytes,
+// not string — they are filesystem paths and OS environment values that
+// may contain arbitrary bytes. We cast to string for attribute emission
+// (matching the convention used for other byte-typed BEP fields).
+func (s *invocationState) applyExecRequestAttrs(span ptrace.Span) {
+	er := s.execRequest
+	if er == nil {
+		return
+	}
+
+	// Always-on attrs first: count and should_exec are safe to emit even
+	// when details are redacted, giving operators an "event arrived" signal.
+	span.Attributes().PutInt("bazel.run.environment_variable_count", int64(len(er.GetEnvironmentVariable())))
+	span.Attributes().PutBool("bazel.run.should_exec", er.GetShouldExec())
+
+	if s.pii.IncludeWorkingDir {
+		if wd := er.GetWorkingDirectory(); len(wd) > 0 {
+			span.Attributes().PutStr("bazel.run.working_directory", string(wd))
+		}
+	}
+
+	if s.pii.IncludeCommandArgs {
+		if argv := er.GetArgv(); len(argv) > 0 {
+			slice := span.Attributes().PutEmptySlice("bazel.run.argv")
+			for _, a := range argv {
+				slice.AppendEmpty().SetStr(string(a))
+			}
+		}
+		if env := er.GetEnvironmentVariable(); len(env) > 0 {
+			slice := span.Attributes().PutEmptySlice("bazel.run.environment")
+			for _, v := range env {
+				m := slice.AppendEmpty().SetEmptyMap()
+				m.PutStr("name", string(v.GetName()))
+				m.PutStr("value", string(v.GetValue()))
+			}
+		}
+	}
+}
+
+// setExecRequest buffers an ExecRequestConstructed payload for emission on
+// the root span. No-op after the invocation has been flushed.
+func (s *invocationState) setExecRequest(er *bep.ExecRequestConstructed) {
+	if s.flushed || er == nil {
+		return
+	}
+	s.execRequest = er
 }
 
 // recordAbort stores the first abort reason and description on the invocation

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -423,6 +423,49 @@ func makeBuildMetricsOBE(t testing.TB, invID string, seqNum, wallMs, cpuMs int64
 	})
 }
 
+// makeExecRequestConstructedOBE builds an ExecRequestConstructed event for
+// `bazel run` tests. argv and envVars are emitted as-is (argv as a list of
+// strings, env as a list of name=value pairs). workingDir and shouldExec are
+// set directly on the payload. The BEP proto types these fields as bytes, so
+// we cast through []byte to match the generated Go shape.
+func makeExecRequestConstructedOBE(t testing.TB, invID string, seqNum int64, argv []string, workingDir string, env map[string]string, shouldExec bool) *pb.OrderedBuildEvent {
+	t.Helper()
+	argvBytes := make([][]byte, 0, len(argv))
+	for _, a := range argv {
+		argvBytes = append(argvBytes, []byte(a))
+	}
+	// Sort env by key for deterministic emission — BEP map iteration order is
+	// non-deterministic and assertions on the environment slice compare by
+	// index.
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	envVars := make([]*bep.EnvironmentVariable, 0, len(env))
+	for _, k := range keys {
+		envVars = append(envVars, &bep.EnvironmentVariable{
+			Name:  []byte(k),
+			Value: []byte(env[k]),
+		})
+	}
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_ExecRequest{
+				ExecRequest: &bep.BuildEventId_ExecRequestId{},
+			},
+		},
+		Payload: &bep.BuildEvent_ExecRequest{
+			ExecRequest: &bep.ExecRequestConstructed{
+				Argv:                argvBytes,
+				WorkingDirectory:    []byte(workingDir),
+				EnvironmentVariable: envVars,
+				ShouldExec:          shouldExec,
+			},
+		},
+	})
+}
+
 // sendAndACK sends a request on the stream, receives the ACK, and asserts the sequence number matches.
 func sendAndACK(t testing.TB, stream pb.PublishBuildEvent_PublishBuildToolEventStreamClient, req *pb.PublishBuildToolEventStreamRequest, expectedSeq int64) {
 	t.Helper()

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -337,6 +337,11 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 			return nil
 		}
 		return tb.handleProgress(ctx, invocations, invocationID, event.GetId(), p.Progress)
+	case *bep.BuildEvent_ExecRequest:
+		if p.ExecRequest == nil {
+			return nil
+		}
+		return tb.handleExecRequestConstructed(ctx, invocations, invocationID, p.ExecRequest)
 	}
 	return nil
 }
@@ -376,6 +381,8 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "options_parsed"
 	case *bep.BuildEvent_StructuredCommandLine:
 		return "structured_command_line"
+	case *bep.BuildEvent_ExecRequest:
+		return "exec_request"
 	default:
 		return "other"
 	}
@@ -752,6 +759,26 @@ func truncateUTF8(s string, maxBytes int) (string, bool) {
 		end--
 	}
 	return s[:end], true
+}
+
+// handleExecRequestConstructed buffers the ExecRequestConstructed payload on
+// the invocation state for emission as bazel.run.* attributes on the root
+// span. Emitted by Bazel only for `bazel run`, after the build succeeds and
+// just before the run target is exec'd. One event per invocation; post-flush
+// arrivals are dropped (the root span is already out).
+func (tb *TraceBuilder) handleExecRequestConstructed(_ context.Context, invocations map[string]*invocationState, invocationID string, er *bep.ExecRequestConstructed) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	state.setExecRequest(er)
+	tb.logger.Debug("ExecRequestConstructed received",
+		zap.String("invocation_id", invocationID),
+		zap.Int("argv_len", len(er.GetArgv())),
+		zap.Int("env_count", len(er.GetEnvironmentVariable())),
+		zap.Bool("should_exec", er.GetShouldExec()),
+	)
+	return nil
 }
 
 // handleTargetComplete enriches an existing bazel.target span with outcome

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -3096,3 +3096,213 @@ func TestProgress_UnknownInvocationDropped(t *testing.T) {
 
 	require.Equal(t, 0, logsSink.LogRecordCount())
 }
+
+// --- ExecRequestConstructed / bazel.run.* (issue #63) ---
+
+// runExecRequestStream runs a `bazel run` style event sequence (BuildStarted →
+// ExecRequestConstructed → BuildFinished) through the TraceBuilder with the
+// given PII config and returns the captured traces sink.
+func runExecRequestStream(t *testing.T, pii PIIConfig) *consumertest.TracesSink {
+	t.Helper()
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{PII: pii})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-run", "uuid-run", "run", 1),
+		makeExecRequestConstructedOBE(t, "inv-run", 2,
+			[]string{"/bin/bazel-out/.../bin/tool", "--flag", "value"},
+			"/home/user/workspace",
+			map[string]string{"FOO": "bar", "PATH": "/usr/bin"},
+			true,
+		),
+		makeBuildFinishedOBE(t, "inv-run", 3, 0, "SUCCESS"),
+	)
+	return sink
+}
+
+// TestExecRequest_AllPIIOn verifies every bazel.run.* attribute is stamped
+// when the necessary PII gates are open.
+func TestExecRequest_AllPIIOn(t *testing.T) {
+	sink := runExecRequestStream(t, PIIConfig{
+		IncludeCommandArgs: true,
+		IncludeWorkingDir:  true,
+	})
+	root := findRootSpan(t, sink)
+
+	// Always-on: count + should_exec.
+	count, ok := root.Attributes().Get("bazel.run.environment_variable_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(2), count.Int())
+
+	se, ok := root.Attributes().Get("bazel.run.should_exec")
+	require.True(t, ok)
+	assert.True(t, se.Bool())
+
+	// Working directory (gated by IncludeWorkingDir).
+	wd, ok := root.Attributes().Get("bazel.run.working_directory")
+	require.True(t, ok)
+	assert.Equal(t, "/home/user/workspace", wd.Str())
+
+	// argv (gated by IncludeCommandArgs) as Slice[string].
+	argv, ok := root.Attributes().Get("bazel.run.argv")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeSlice, argv.Type())
+	require.Equal(t, 3, argv.Slice().Len())
+	assert.Equal(t, "/bin/bazel-out/.../bin/tool", argv.Slice().At(0).Str())
+	assert.Equal(t, "--flag", argv.Slice().At(1).Str())
+	assert.Equal(t, "value", argv.Slice().At(2).Str())
+
+	// environment (gated by IncludeCommandArgs) as Slice[Map{name,value}],
+	// sorted by key thanks to the test helper.
+	env, ok := root.Attributes().Get("bazel.run.environment")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeSlice, env.Type())
+	require.Equal(t, 2, env.Slice().Len())
+
+	first := env.Slice().At(0).Map()
+	name, ok := first.Get("name")
+	require.True(t, ok)
+	assert.Equal(t, "FOO", name.Str())
+	value, ok := first.Get("value")
+	require.True(t, ok)
+	assert.Equal(t, "bar", value.Str())
+
+	second := env.Slice().At(1).Map()
+	name2, ok := second.Get("name")
+	require.True(t, ok)
+	assert.Equal(t, "PATH", name2.Str())
+	value2, ok := second.Get("value")
+	require.True(t, ok)
+	assert.Equal(t, "/usr/bin", value2.Str())
+}
+
+// TestExecRequest_PIIOff_CountAndShouldExecStillEmitted asserts the default
+// (redacted) path still emits the safe count/should_exec attrs when the
+// ExecRequestConstructed event arrives, so operators retain a "run
+// invocation" signal.
+func TestExecRequest_PIIOff_CountAndShouldExecStillEmitted(t *testing.T) {
+	sink := runExecRequestStream(t, PIIConfig{})
+	root := findRootSpan(t, sink)
+
+	// Always-on attrs present.
+	count, ok := root.Attributes().Get("bazel.run.environment_variable_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(2), count.Int())
+
+	se, ok := root.Attributes().Get("bazel.run.should_exec")
+	require.True(t, ok)
+	assert.True(t, se.Bool())
+
+	// Gated attrs redacted.
+	for _, key := range []string{
+		"bazel.run.argv",
+		"bazel.run.working_directory",
+		"bazel.run.environment",
+	} {
+		_, has := root.Attributes().Get(key)
+		assert.False(t, has, "expected %s to be redacted with PII off", key)
+	}
+}
+
+// TestExecRequest_WorkingDirGate_OnlyDir asserts IncludeWorkingDir alone
+// surfaces only working_directory; argv and environment stay redacted.
+func TestExecRequest_WorkingDirGate_OnlyDir(t *testing.T) {
+	sink := runExecRequestStream(t, PIIConfig{IncludeWorkingDir: true})
+	root := findRootSpan(t, sink)
+
+	wd, ok := root.Attributes().Get("bazel.run.working_directory")
+	require.True(t, ok)
+	assert.Equal(t, "/home/user/workspace", wd.Str())
+
+	_, hasArgv := root.Attributes().Get("bazel.run.argv")
+	assert.False(t, hasArgv, "argv must stay redacted without IncludeCommandArgs")
+	_, hasEnv := root.Attributes().Get("bazel.run.environment")
+	assert.False(t, hasEnv, "environment must stay redacted without IncludeCommandArgs")
+}
+
+// TestExecRequest_CommandArgsGate_ArgvAndEnv asserts IncludeCommandArgs
+// surfaces both argv and environment (shared gate per issue #63) while
+// keeping working_directory redacted.
+func TestExecRequest_CommandArgsGate_ArgvAndEnv(t *testing.T) {
+	sink := runExecRequestStream(t, PIIConfig{IncludeCommandArgs: true})
+	root := findRootSpan(t, sink)
+
+	argv, ok := root.Attributes().Get("bazel.run.argv")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeSlice, argv.Type())
+	assert.Equal(t, 3, argv.Slice().Len())
+
+	env, ok := root.Attributes().Get("bazel.run.environment")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeSlice, env.Type())
+	assert.Equal(t, 2, env.Slice().Len())
+
+	_, hasWD := root.Attributes().Get("bazel.run.working_directory")
+	assert.False(t, hasWD, "working_directory must stay redacted without IncludeWorkingDir")
+}
+
+// TestExecRequest_NoWorkingDirectory asserts that an ExecRequestConstructed
+// event with an empty working_directory does not emit a blank attribute even
+// when IncludeWorkingDir is true.
+func TestExecRequest_NoWorkingDirectory(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeWorkingDir: true, IncludeCommandArgs: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-run-nowd", "uuid-run-nowd", "run", 1),
+		makeExecRequestConstructedOBE(t, "inv-run-nowd", 2,
+			[]string{"tool"},
+			"", // empty working directory
+			map[string]string{"HOME": "/root"},
+			false,
+		),
+		makeBuildFinishedOBE(t, "inv-run-nowd", 3, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	_, has := root.Attributes().Get("bazel.run.working_directory")
+	assert.False(t, has, "empty working_directory must not emit the attribute")
+
+	se, ok := root.Attributes().Get("bazel.run.should_exec")
+	require.True(t, ok)
+	assert.False(t, se.Bool())
+}
+
+// TestExecRequest_BazelBuild_NoAttrsEmitted asserts that a regular `bazel
+// build` invocation (which does not emit ExecRequestConstructed) carries
+// none of the bazel.run.* attributes. Regression guard for the "only stamp
+// when the event arrived" contract.
+func TestExecRequest_BazelBuild_NoAttrsEmitted(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeWorkingDir: true, IncludeCommandArgs: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-build", "uuid-build", "build", 1),
+		makeBuildFinishedOBE(t, "inv-build", 2, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	for _, key := range []string{
+		"bazel.run.argv",
+		"bazel.run.working_directory",
+		"bazel.run.environment_variable_count",
+		"bazel.run.environment",
+		"bazel.run.should_exec",
+	} {
+		_, has := root.Attributes().Get(key)
+		assert.False(t, has, "bazel build must not emit %s (no ExecRequestConstructed event)", key)
+	}
+}


### PR DESCRIPTION
On `bazel run` invocations Bazel emits `ExecRequestConstructed` carrying the final argv, working directory, environment, env-vars-to-unset, and whether the process will actually exec. The PR exposes those on five always-on counts/booleans plus four PII-gated detail attributes so `bazel run` traces are self-describing without operators having to correlate by command name. `bazel build` / `bazel test` invocations emit nothing here.

## Review-driven design choices

- **Late post-flush path is the production path, not defense-in-depth.** Bazel's BEP proto explicitly places `ExecRequestConstructed` "after a successful build and before trying to execute" — i.e. it can arrive *after* `BuildFinished` on the wire. The receiver handles both orderings: pre-flush, attrs land on the root `bazel.build` span (current design); post-flush, the receiver emits a standalone `bazel.run` child span (parented to the root via traceID/spanID) carrying the same attrs through a new `lateRunSpan` helper. Without this, every `bazel run` invocation would silently emit empty `bazel.run.*` attrs.
- **Split `IncludeRunEnvironment` from `IncludeCommandArgs`.** Run environments routinely carry credentials, tokens, and host-derived secrets that command-line arguments do not. The original PR re-used `IncludeCommandArgs` for both axes; the gates are now independent so operators can show argv without exposing env, and vice versa. Docstrings and `docs/attributes.md` are updated accordingly.
- **`environment_variable_to_clear` (proto field 4) emitted.** Previously dropped silently — operators saw the env-set list, ran a repro with those vars, and got different behavior because exec also unset others. Now exposed as both a slice and an always-on count.
- **UTF-8 validated on every bytes→string cast.** pdata accepts arbitrary strings but OTLP/JSON exporters reject invalid UTF-8 and that failure cascades the *entire* span batch, not just one attribute. Non-UTF-8 entries are silently skipped (one `utf8.ValidString` guard per cast site).
- **Bounded argv/env.** argv capped at 200 entries, env at 50, env-to-clear at 50; each value clipped at 256 bytes via the existing `truncateAttrValue` helper. The always-on count attributes report the full payload size, not the capped slice, so operators see the truth even when emission is clipped.
- **Server-side env sort.** Bazel emits env in process-environ iteration order, which is not stable across OSes or runs. Sorting by name in the receiver makes downstream queries and diffs deterministic. Also fixed: the test helper no longer sorts on the input side, so any future receiver-side regression surfaces.

## Deferred to follow-up
- OTel semconv alignment for argv/env (`process.command_args` / `process.runtime.environment`) — separate task, requires schema discussion.
- `nolint:gocyclo` replacement on `eventTypeName` with a `map[reflect.Type]string` — applies project-wide to every dispatch site, scoped out of this PR.

Closes #63.