### PR TITLE
feat(besreceiver): emit bazel.fetch span per Fetch BEP event

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -39,6 +39,7 @@ receivers:
     #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
     #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)
     #   include_command_line: false        # bazel.command_line (coarse only)
+    #   include_fetch_query_string: false  # preserve query string on bazel.fetch.url (default off — strips pre-signed S3/GCS creds)
     # Per-target detail level filtering. default_level applies when no rule
     # matches; rules are evaluated in order and first match wins. Levels:
     #   drop       emits only the root bazel.build and bazel.metrics spans

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -20,6 +20,7 @@ bazel.build (root)
 ├── bazel.target
 │   ├── bazel.test
 │   └── bazel.test
+├── bazel.fetch
 └── bazel.metrics
 ```
 
@@ -147,6 +148,54 @@ start plus `test_attempt_duration` when set.
 Status is `ERROR` with the enum name as the message when the status is
 anything other than `PASSED`.
 
+## `bazel.fetch`
+
+One span per external-resource `Fetch` BEP event, parented directly to
+the root `bazel.build` span. Emitted only when Bazel actually fetched
+the resource — cached hits produce no event and therefore no span. Name
+is `bazel.fetch`, span kind is `Client`.
+
+Timing is **zero-width** at the event's processing instant. The Fetch
+proto carries no per-event timestamps, and inferring duration from
+invocation start would paint every fetch as a build-stream-spanning
+bar, dwarfing every other span on the flamegraph. A zero-width span
+correctly says "this fetch happened" without fabricating duration.
+When richer timing matters, future work could thread
+`OrderedBuildEvent.Event.EventTime` through to anchor the span on the
+BES envelope timestamp.
+
+| Attribute                  | Type   | Source                                                           |
+|----------------------------|--------|------------------------------------------------------------------|
+| `bazel.fetch.url`          | string | `FetchId.url`, redacted (see below)                              |
+| `bazel.fetch.success`      | bool   | `Fetch.success`                                                  |
+| `bazel.fetch.downloader`   | string | `FetchId.Downloader` enum (`HTTP`, `GRPC`, `UNKNOWN`)            |
+
+**URL redaction.** The receiver strips userinfo (`user:token@host`)
+unconditionally — fetch URLs frequently carry credentials inline, and
+forwarding the raw form into traces or logs is a silent PII leak. The
+query string is also stripped by default because pre-signed S3/GCS URLs
+put credentials in `X-Amz-*` parameters; operators who explicitly want
+the query string (debugging a custom mirror, tracking version params)
+can opt in via `pii.include_fetch_query_string: true`. Non-RFC-3986
+references like `oci://repo/image@sha256:…` and `file://` mirror paths
+are passed through unmodified rather than dropped — better to emit the
+original than nothing.
+
+**SpanID disambiguation.** SpanIDs mix the URL, the downloader enum,
+and a per-invocation sequence counter so retries (transient HTTP
+failures, `repository_cache` evictions, multi-arch toolchain pulls)
+produce distinct SpanIDs that downstream backends do not collapse.
+
+A fetch with an empty URL or one that arrives before `BuildStarted` is
+silently dropped. Status is set to `ERROR` with message
+`"fetch failed: <redacted-url>"` when `Fetch.success` is false;
+otherwise `Unset`. Fetch spans are per-invocation detail — the `filter`
+block suppresses them at `default_level: drop` and
+`default_level: build_only`. Per-rule patterns (`//pkg:target`,
+`//pkg/...`) do **not** apply to fetches: a fetch has no owning target,
+so the filter is queried with an empty label which falls through to the
+configured `default_level`.
+
 ## `bazel.metrics`
 
 One span per invocation, emitted from `BuildMetrics`. Carries timing and
@@ -201,6 +250,7 @@ receivers:
       include_workspace_dir: false         # bazel.workspace_directory + matching workspace/metadata keys
       include_working_dir: false           # bazel.working_directory + bazel.run.working_directory + matching workspace/metadata keys
       include_command_args: false          # bazel.action.command_line + bazel.run.argv + bazel.run.environment
+      include_fetch_query_string: false    # preserve query string on bazel.fetch.url (default off — strips pre-signed S3/GCS creds)
       include_action_output_paths: false   # bazel.action.primary_output
       include_workspace_status: false      # bazel.workspace.* pathway (per-key filtered)
       include_build_metadata: false        # bazel.metadata.* pathway (per-key filtered)

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -195,6 +195,13 @@ type PIIConfig struct {
 	// string is free-form so per-field filtering is not attempted —
 	// operators needing finer control should layer a redactionprocessor.
 	IncludeCommandLine bool `mapstructure:"include_command_line"`
+	// IncludeFetchQueryString controls whether `bazel.fetch.url` (and the
+	// matching log body) preserves the URL query string. Default false:
+	// fetch URLs frequently carry pre-signed credentials in query params
+	// (S3, GCS) so the receiver strips them. Operators who deliberately
+	// want the full URL — e.g. to debug a custom mirror — opt in here.
+	// Userinfo (`user:pass@host`) is always stripped regardless.
+	IncludeFetchQueryString bool `mapstructure:"include_fetch_query_string"`
 }
 
 // Validate checks that the receiver configuration is valid.

--- a/receiver/besreceiver/filter.go
+++ b/receiver/besreceiver/filter.go
@@ -59,6 +59,23 @@ func (d DetailLevel) allowAction() bool {
 	return d == DetailLevelVerbose
 }
 
+// allowFetch returns true if the level permits emission of bazel.fetch
+// spans. Fetch spans are per-invocation detail with no owning target, so
+// drop / build_only suppress them; targets and verbose keep them. The
+// split from allowAction matters because an operator may want per-target
+// spans suppressed (DetailLevelTargets or below for the action gate) yet
+// still see fetch activity, which is frequently the dominant cost on
+// clean builds.
+func (d DetailLevel) allowFetch() bool {
+	switch d {
+	case DetailLevelTargets, DetailLevelVerbose:
+		return true
+	case DetailLevelDrop, DetailLevelBuildOnly:
+		return false
+	}
+	return false
+}
+
 // FilterConfig configures per-target detail level filtering. When the
 // surrounding receiver config omits this block entirely, DefaultLevel is
 // empty and Rules is nil; NewFilter treats that as verbose (current

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -2,6 +2,7 @@ package besreceiver
 
 import (
 	"math"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -129,6 +130,12 @@ type invocationState struct {
 	// filtering or span emission, so totals reflect the full build even when
 	// detail-level filtering (see #13) suppresses the matching span.
 	summaryCounts BuildSummary
+
+	// fetchSeq disambiguates SpanIDs for repeated fetches of the same URL
+	// within one invocation (transient retries, multi-arch toolchain pulls,
+	// repository_cache evictions). Combined with FetchId.Downloader the
+	// resulting SpanID is unique per fetch event in the stream.
+	fetchSeq int64
 }
 
 // BuildSummary holds per-invocation aggregate counters emitted as
@@ -943,6 +950,110 @@ func (s *invocationState) lateActionSpan(label, configID, primaryOutput string, 
 	parentSpanID, _ := s.resolveTargetSpan(label, configID)
 	s.populateActionSpan(span, parentSpanID, label, primaryOutput, action)
 	return traces
+}
+
+// fetchSpanInput carries everything populateFetchSpan needs. The handler
+// captures these once so pre-flush and post-flush paths share the same
+// redacted URL, downloader name, and zero-width timestamp.
+type fetchSpanInput struct {
+	displayURL string                              // already redacted; used for span attr + log body
+	downloader bep.BuildEventId_FetchId_Downloader // proto enum; emitted as bazel.fetch.downloader
+	seq        int64                               // per-invocation counter — disambiguates SpanIDs
+	success    bool
+	at         time.Time // event-processing time; zero-width span anchors here
+}
+
+// addFetch appends a bazel.fetch span for a Fetch BEP event.
+//
+// Filter gate (allowFetch): suppressed at drop / build_only. The fetch
+// has no owning target so the filter is queried with an empty label,
+// which falls through to default_level — per-rule patterns are
+// unreachable for fetches (documented in docs/attributes.md).
+func (s *invocationState) addFetch(in fetchSpanInput) {
+	if s.flushed {
+		return
+	}
+	if in.displayURL == "" {
+		return
+	}
+	if !s.filter.LevelForTarget("").allowFetch() {
+		return
+	}
+	span := s.appendSpan()
+	s.populateFetchSpan(span, in)
+}
+
+// populateFetchSpan stamps identity, parenting, timing, attributes, and
+// status on a pre-appended fetch span. Shared by the pre-flush addFetch
+// path and the post-flush lateFetchSpan path.
+//
+// Timing is zero-width at in.at — the Fetch proto carries no per-event
+// timestamps and inferring duration from invocation createdAt produced
+// 5-minute-wide bars on the flamegraph. A zero-width span at the
+// event-processing instant correctly indicates "this fetch happened"
+// without fabricating a duration.
+//
+// SpanID disambiguation mixes downloader + per-invocation sequence
+// counter into the identity hash so retries, multi-arch toolchain pulls,
+// and repository_cache evictions don't collapse onto the same SpanID.
+func (s *invocationState) populateFetchSpan(span ptrace.Span, in fetchSpanInput) {
+	downloader := in.downloader.String()
+	span.SetSpanID(spanIDFromIdentity(s.uuid, "fetch", in.displayURL, downloader, strconv.FormatInt(in.seq, 10)))
+	span.SetParentSpanID(s.rootSpanID)
+	span.SetName("bazel.fetch")
+	span.SetKind(ptrace.SpanKindClient)
+
+	ts := pcommon.NewTimestampFromTime(in.at)
+	span.SetStartTimestamp(ts)
+	span.SetEndTimestamp(ts)
+
+	span.Attributes().PutStr("bazel.fetch.url", in.displayURL)
+	span.Attributes().PutBool("bazel.fetch.success", in.success)
+	if downloader != "" {
+		span.Attributes().PutStr("bazel.fetch.downloader", downloader)
+	}
+
+	if !in.success {
+		span.Status().SetCode(ptrace.StatusCodeError)
+		span.Status().SetMessage("fetch failed: " + in.displayURL)
+	}
+}
+
+// lateFetchSpan emits a standalone bazel.fetch span for a Fetch event
+// that arrived after the main batch was flushed. Same pattern as
+// lateActionSpan / lateTestResultSpan.
+func (s *invocationState) lateFetchSpan(in fetchSpanInput) ptrace.Traces {
+	traces, ss := newTracesPayload()
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(s.traceID)
+	s.populateFetchSpan(span, in)
+	return traces
+}
+
+// redactFetchURL strips userinfo (and optionally the query string) from
+// fetch URLs before emission. URLs Bazel sees can carry credentials
+// inline (`https://user:token@host/...`) and pre-signed S3/GCS query
+// params; both are silent PII leaks if forwarded verbatim into traces or
+// logs. Userinfo is always stripped; the query string is gated by
+// PII.IncludeFetchQueryString (default false).
+//
+// Falls back to the original string when url.Parse fails — Bazel's BEP
+// also carries non-RFC-3986 references like `oci://repo/image@sha256:…`
+// and bare paths for `file://` mirrors. Returning those untouched is
+// safer than returning empty (which would suppress the span).
+func redactFetchURL(s string, includeQuery bool) string {
+	if s == "" {
+		return s
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Scheme == "" {
+		return s
+	}
+	u.User = nil
+	if !includeQuery {
+		u.RawQuery = ""
+	}
+	return u.Redacted()
 }
 
 // lateTestResultSpan emits a standalone bazel.test span for a TestResult

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -402,6 +402,31 @@ func makeProgressOBE(t testing.TB, invID string, seqNum int64, stdout, stderr st
 	})
 }
 
+// makeFetchOBE builds a BuildEvent_Fetch ordered build event with the url
+// carried on the BuildEventId (where Bazel actually puts it) and success
+// on the payload. Defaults the downloader enum to UNKNOWN; use
+// makeFetchOBEWithDownloader to exercise the HTTP / GRPC variants.
+func makeFetchOBE(t testing.TB, invID, url string, seqNum int64, success bool) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeFetchOBEWithDownloader(t, invID, url, seqNum, success, bep.BuildEventId_FetchId_UNKNOWN)
+}
+
+// makeFetchOBEWithDownloader is the full-arity helper exposing
+// FetchId.Downloader.
+func makeFetchOBEWithDownloader(t testing.TB, invID, url string, seqNum int64, success bool, downloader bep.BuildEventId_FetchId_Downloader) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_Fetch{
+				Fetch: &bep.BuildEventId_FetchId{Url: url, Downloader: downloader},
+			},
+		},
+		Payload: &bep.BuildEvent_Fetch{
+			Fetch: &bep.Fetch{Success: success},
+		},
+	})
+}
+
 func makeBuildMetricsOBE(t testing.TB, invID string, seqNum, wallMs, cpuMs int64) *pb.OrderedBuildEvent {
 	t.Helper()
 	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -342,6 +342,11 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 			return nil
 		}
 		return tb.handleExecRequestConstructed(ctx, invocations, invocationID, p.ExecRequest)
+	case *bep.BuildEvent_Fetch:
+		if p.Fetch == nil {
+			return nil
+		}
+		return tb.handleFetch(ctx, invocations, invocationID, event.GetId(), p.Fetch)
 	}
 	return nil
 }
@@ -383,6 +388,8 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "structured_command_line"
 	case *bep.BuildEvent_ExecRequest:
 		return "exec_request"
+	case *bep.BuildEvent_Fetch:
+		return "fetch"
 	default:
 		return "other"
 	}
@@ -921,6 +928,70 @@ func newLogPayload() (plog.Logs, plog.LogRecord) {
 	sl := rl.ScopeLogs().AppendEmpty()
 	sl.Scope().SetName("besreceiver")
 	return logs, sl.LogRecords().AppendEmpty()
+}
+
+// handleFetch emits a bazel.fetch span for a Fetch BEP event, parented
+// under the root bazel.build span. A Fetch before BuildStarted (unknown
+// invocation) or with an empty URL is silently dropped. Filter gate is
+// enforced once at the top of the handler so log emission and span
+// emission share the same suppression contract — without the early
+// gate, drop/build_only would still leak the redacted URL into the
+// logs pipeline.
+//
+// Timing is zero-width at event-processing time; the Fetch proto carries
+// no per-event timestamps and inferring duration from invocation
+// createdAt produced flamegraph-spanning bars (see review of #70).
+func (tb *TraceBuilder) handleFetch(ctx context.Context, invocations map[string]*invocationState, invocationID string, eventID *bep.BuildEventId, fetch *bep.Fetch) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+
+	rawURL := eventID.GetFetch().GetUrl()
+	if rawURL == "" {
+		return nil
+	}
+
+	// Hoist the filter gate above log emission so drop/build_only
+	// suppress the URL on every pathway, not just the span.
+	if !state.filter.LevelForTarget("").allowFetch() {
+		return nil
+	}
+
+	displayURL := redactFetchURL(rawURL, state.pii.IncludeFetchQueryString)
+	success := fetch.GetSuccess()
+	state.fetchSeq++
+	in := fetchSpanInput{
+		displayURL: displayURL,
+		downloader: eventID.GetFetch().GetDownloader(),
+		seq:        state.fetchSeq,
+		success:    success,
+		at:         time.Now(),
+	}
+
+	severity := plog.SeverityNumberInfo
+	body := fmt.Sprintf("Fetch succeeded: %s", displayURL)
+	if !success {
+		severity = plog.SeverityNumberError
+		body = fmt.Sprintf("Fetch failed: %s", displayURL)
+	}
+	tb.emitLog(ctx, state, invocationID, "bazel.fetch",
+		body, severity, in.at,
+		map[string]string{
+			"bazel.fetch.url":        displayURL,
+			"bazel.fetch.success":    strconv.FormatBool(success),
+			"bazel.fetch.downloader": in.downloader.String(),
+		},
+	)
+
+	// Post-flush arrivals ride the same traceID in a standalone payload.
+	if state.flushed {
+		traces := state.lateFetchSpan(in)
+		return tb.consumeAndRecord(ctx, traces)
+	}
+
+	state.addFetch(in)
+	return nil
 }
 
 func (tb *TraceBuilder) handleBuildMetrics(ctx context.Context, invocations map[string]*invocationState, invocationID string, metrics *bep.BuildMetrics) error {

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -3306,3 +3306,410 @@ func TestExecRequest_BazelBuild_NoAttrsEmitted(t *testing.T) {
 		assert.False(t, has, "bazel build must not emit %s (no ExecRequestConstructed event)", key)
 	}
 }
+
+// findFetchSpans returns every bazel.fetch span across all trace batches
+// in the sink.
+func findFetchSpans(t *testing.T, sink *consumertest.TracesSink) []ptrace.Span {
+	t.Helper()
+	var out []ptrace.Span
+	for _, tr := range sink.AllTraces() {
+		for i := range tr.ResourceSpans().Len() {
+			rs := tr.ResourceSpans().At(i)
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					s := ss.Spans().At(k)
+					if s.Name() == "bazel.fetch" {
+						out = append(out, s)
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// logRecordsByEventName returns every log record across the sink whose
+// `event.name` attribute matches the given value. Tests should not unroll
+// the four-level pdata iteration manually.
+func logRecordsByEventName(t *testing.T, sink *consumertest.LogsSink, eventName string) []plog.LogRecord {
+	t.Helper()
+	var out []plog.LogRecord
+	for _, lg := range sink.AllLogs() {
+		for i := range lg.ResourceLogs().Len() {
+			rl := lg.ResourceLogs().At(i)
+			for j := range rl.ScopeLogs().Len() {
+				sl := rl.ScopeLogs().At(j)
+				for k := range sl.LogRecords().Len() {
+					lr := sl.LogRecords().At(k)
+					if evt, ok := lr.Attributes().Get("event.name"); ok && evt.Str() == eventName {
+						out = append(out, lr)
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func TestTraceBuilder_Fetch_Success(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-fetch-ok", "uuid-fetch-ok", "build", 1),
+		makeFetchOBE(t, "inv-fetch-ok", "https://example.com/lib.tar.gz", 2, true),
+		makeBuildFinishedOBE(t, "inv-fetch-ok", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1, "expected exactly one bazel.fetch span")
+
+	span := spans[0]
+	url, ok := span.Attributes().Get("bazel.fetch.url")
+	require.True(t, ok, "missing bazel.fetch.url")
+	assert.Equal(t, "https://example.com/lib.tar.gz", url.Str())
+
+	success, ok := span.Attributes().Get("bazel.fetch.success")
+	require.True(t, ok, "missing bazel.fetch.success")
+	assert.True(t, success.Bool())
+
+	assert.Equal(t, ptrace.StatusCodeUnset, span.Status().Code(),
+		"successful fetch should not set Error status")
+
+	// Parented to root.
+	root := findRootSpan(t, sink)
+	assert.Equal(t, root.SpanID(), span.ParentSpanID(), "fetch span must be parented to bazel.build root")
+	assert.Equal(t, root.TraceID(), span.TraceID(), "fetch span must share traceID with root")
+}
+
+func TestTraceBuilder_Fetch_Failure(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-fetch-fail", "uuid-fetch-fail", "build", 1),
+		makeFetchOBE(t, "inv-fetch-fail", "https://example.com/broken.tar.gz", 2, false),
+		makeBuildFinishedOBE(t, "inv-fetch-fail", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	success, ok := span.Attributes().Get("bazel.fetch.success")
+	require.True(t, ok)
+	assert.False(t, success.Bool())
+
+	assert.Equal(t, ptrace.StatusCodeError, span.Status().Code(),
+		"failed fetch must set Error status")
+	assert.Equal(t, "fetch failed: https://example.com/broken.tar.gz", span.Status().Message())
+}
+
+func TestTraceBuilder_Fetch_SuppressedByFilter_BuildOnly(t *testing.T) {
+	// Acceptance criterion: drop / build_only filter levels suppress the
+	// per-fetch span. Fetches are per-invocation detail, so they're gated
+	// the same way targets are.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		Filter: FilterConfig{DefaultLevel: DetailLevelBuildOnly},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-fetch-bo", "uuid-fetch-bo", "build", 1),
+		makeFetchOBE(t, "inv-fetch-bo", "https://example.com/lib.tar.gz", 2, true),
+		makeBuildFinishedOBE(t, "inv-fetch-bo", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	assert.Empty(t, spans, "build_only default_level must suppress bazel.fetch spans")
+}
+
+func TestTraceBuilder_Fetch_SuppressedByFilter_Drop(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		Filter: FilterConfig{DefaultLevel: DetailLevelDrop},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-fetch-drop", "uuid-fetch-drop", "build", 1),
+		makeFetchOBE(t, "inv-fetch-drop", "https://example.com/lib.tar.gz", 2, true),
+		makeBuildFinishedOBE(t, "inv-fetch-drop", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	assert.Empty(t, spans, "drop default_level must suppress bazel.fetch spans")
+}
+
+func TestTraceBuilder_Fetch_BeforeBuildStarted_Dropped(t *testing.T) {
+	// Fetch before BuildStarted arrives with no invocation state. The event
+	// must be silently dropped without emitting any span or erroring.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Send Fetch first; no BuildStarted has set up state yet.
+	require.NoError(t, tb.ProcessOrderedBuildEvent(ctx,
+		makeFetchOBE(t, "inv-fetch-early", "https://example.com/early.tar.gz", 1, true)))
+
+	assert.Empty(t, findFetchSpans(t, sink),
+		"fetch before BuildStarted must emit no span")
+	assert.Equal(t, 0, sink.SpanCount(), "no spans of any kind should be emitted")
+}
+
+func TestTraceBuilder_Fetch_MissingURL_NoSpan(t *testing.T) {
+	// A Fetch event without a URL is dropped per spec.
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-fetch-no-url", "uuid-fetch-no-url", "build", 1),
+		makeFetchOBE(t, "inv-fetch-no-url", "", 2, true),
+		makeBuildFinishedOBE(t, "inv-fetch-no-url", 3, 0, "SUCCESS"),
+	)
+
+	assert.Empty(t, findFetchSpans(t, sink),
+		"fetch with empty URL must emit no span")
+}
+
+// TestTraceBuilder_Fetch_RedactsUserinfo — URLs with embedded credentials
+// (`user:token@host`) are redacted by default. Both the span attribute
+// and the log record body must carry the cleaned URL; never the raw
+// secret-bearing form.
+func TestTraceBuilder_Fetch_RedactsUserinfo(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	logsSink := new(consumertest.LogsSink)
+	tb := NewTraceBuilder(sink, logsSink, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-redact", "uuid-redact", "build", 1),
+		makeFetchOBE(t, "inv-redact", "https://alice:s3cret@mirror.example.com/lib.tar.gz", 2, true),
+		makeBuildFinishedOBE(t, "inv-redact", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1)
+	url, _ := spans[0].Attributes().Get("bazel.fetch.url")
+	assert.NotContains(t, url.Str(), "alice", "userinfo username must be stripped")
+	assert.NotContains(t, url.Str(), "s3cret", "userinfo password must be stripped")
+	assert.Contains(t, url.Str(), "mirror.example.com", "host must survive redaction")
+
+	// And the log body should also be redacted.
+	for _, lr := range logRecordsByEventName(t, logsSink, "bazel.fetch") {
+		assert.NotContains(t, lr.Body().Str(), "s3cret",
+			"log body must redact userinfo password")
+	}
+}
+
+// TestTraceBuilder_Fetch_RedactsQueryStringByDefault — pre-signed S3/GCS
+// URLs put credentials in query params. The default-off
+// IncludeFetchQueryString config strips them.
+func TestTraceBuilder_Fetch_RedactsQueryStringByDefault(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-q", "uuid-q", "build", 1),
+		makeFetchOBE(t, "inv-q",
+			"https://s3.example.com/bucket/key.tar.gz?X-Amz-Signature=abc123&X-Amz-Date=20260101",
+			2, true),
+		makeBuildFinishedOBE(t, "inv-q", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1)
+	url, _ := spans[0].Attributes().Get("bazel.fetch.url")
+	assert.NotContains(t, url.Str(), "X-Amz-Signature")
+	assert.NotContains(t, url.Str(), "abc123")
+	assert.Contains(t, url.Str(), "/bucket/key.tar.gz")
+}
+
+// TestTraceBuilder_Fetch_QueryStringOptIn — operators investigating a
+// custom mirror can opt into preserving the query string.
+func TestTraceBuilder_Fetch_QueryStringOptIn(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeFetchQueryString: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-qopt", "uuid-qopt", "build", 1),
+		makeFetchOBE(t, "inv-qopt",
+			"https://mirror.example.com/lib.tar.gz?version=1.2.3", 2, true),
+		makeBuildFinishedOBE(t, "inv-qopt", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1)
+	url, _ := spans[0].Attributes().Get("bazel.fetch.url")
+	assert.Contains(t, url.Str(), "version=1.2.3")
+}
+
+// TestTraceBuilder_Fetch_NonStandardURLPassThrough — Bazel's BEP also
+// carries non-RFC-3986 URLs (oci:// references with @sha256, file://
+// mirror paths). The receiver must pass them through unmodified rather
+// than dropping the span.
+func TestTraceBuilder_Fetch_NonStandardURLPassThrough(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	const ociURL = "oci://repo.example.com/image@sha256:deadbeef"
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-oci", "uuid-oci", "build", 1),
+		makeFetchOBE(t, "inv-oci", ociURL, 2, true),
+		makeBuildFinishedOBE(t, "inv-oci", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1)
+	url, _ := spans[0].Attributes().Get("bazel.fetch.url")
+	assert.Equal(t, ociURL, url.Str())
+}
+
+// TestTraceBuilder_Fetch_DownloaderAttribute — bazel.fetch.downloader
+// surfaces the FetchId.Downloader enum so retries via different
+// transports (HTTP vs gRPC, often during fallback) can be told apart.
+func TestTraceBuilder_Fetch_DownloaderAttribute(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-dl", "uuid-dl", "build", 1),
+		makeFetchOBEWithDownloader(t, "inv-dl",
+			"https://example.com/lib.tar.gz", 2, true,
+			bep.BuildEventId_FetchId_HTTP),
+		makeBuildFinishedOBE(t, "inv-dl", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1)
+	dl, ok := spans[0].Attributes().Get("bazel.fetch.downloader")
+	require.True(t, ok)
+	assert.Equal(t, "HTTP", dl.Str())
+}
+
+// TestTraceBuilder_Fetch_SameURLDistinctSpanIDs — repeated fetches of
+// the same URL within one invocation (transient retry, multi-arch
+// toolchain pull) must produce distinct SpanIDs so backends do not
+// collapse them.
+func TestTraceBuilder_Fetch_SameURLDistinctSpanIDs(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-dup", "uuid-dup", "build", 1),
+		makeFetchOBE(t, "inv-dup", "https://example.com/lib.tar.gz", 2, false),
+		makeFetchOBE(t, "inv-dup", "https://example.com/lib.tar.gz", 3, true),
+		makeBuildFinishedOBE(t, "inv-dup", 4, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 2, "two fetch events must produce two spans")
+	assert.NotEqual(t, spans[0].SpanID(), spans[1].SpanID(),
+		"repeated fetches of the same URL must have distinct SpanIDs")
+}
+
+// TestTraceBuilder_Fetch_InstantSpanTiming — the span is zero-width at
+// event-processing time, not a 5-minute bar from invocation createdAt.
+func TestTraceBuilder_Fetch_InstantSpanTiming(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-instant", "uuid-instant", "build", 1),
+		makeFetchOBE(t, "inv-instant", "https://example.com/lib.tar.gz", 2, true),
+		makeBuildFinishedOBE(t, "inv-instant", 3, 0, "SUCCESS"),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1)
+	assert.Equal(t, spans[0].StartTimestamp(), spans[0].EndTimestamp(),
+		"fetch span must be zero-width (start == end)")
+}
+
+// TestTraceBuilder_Fetch_LatePostFlush — Fetch arriving between
+// BuildFinished and BuildMetrics goes through lateFetchSpan and emits
+// in a standalone Traces payload tied to the same TraceID.
+func TestTraceBuilder_Fetch_LatePostFlush(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-late", "uuid-late", "build", 1),
+		// BuildFinished flushes the pending traces batch.
+		makeBuildFinishedOBE(t, "inv-late", 2, 0, "SUCCESS"),
+		// Late fetch must still produce a span.
+		makeFetchOBE(t, "inv-late", "https://example.com/late.tar.gz", 3, true),
+	)
+
+	spans := findFetchSpans(t, sink)
+	require.Len(t, spans, 1, "post-flush Fetch must still produce a span")
+	assert.Equal(t, traceIDFromUUID("uuid-late"), spans[0].TraceID(),
+		"late fetch span must share the invocation traceID")
+}
+
+// TestTraceBuilder_Fetch_FilterSuppressesLogToo — the log emission must
+// also respect the filter gate. Drop / build_only operators must not
+// see fetch URLs leak into the logs pipeline even though they suppressed
+// the spans.
+func TestTraceBuilder_Fetch_FilterSuppressesLogToo(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	logsSink := new(consumertest.LogsSink)
+	tb := NewTraceBuilder(sink, logsSink, nil, zap.NewNop(), TraceBuilderConfig{
+		Filter: FilterConfig{DefaultLevel: DetailLevelBuildOnly},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-flog", "uuid-flog", "build", 1),
+		makeFetchOBE(t, "inv-flog", "https://alice:s3cret@host/x", 2, true),
+		makeBuildFinishedOBE(t, "inv-flog", 3, 0, "SUCCESS"),
+	)
+
+	assert.Empty(t, findFetchSpans(t, sink), "filter must suppress the span")
+	assert.Empty(t, logRecordsByEventName(t, logsSink, "bazel.fetch"),
+		"filter must suppress bazel.fetch log records too")
+}


### PR DESCRIPTION
Makes external dependency downloads (http_archive, http_file, module resolution, OCI, file:// mirrors) visible in the trace flamegraph as `bazel.fetch` spans parented to the root `bazel.build`. For repos with heavy external surface area, fetch latency is often the dominant cost of clean builds and was previously invisible.

## Review-driven design choices

- **URL redaction by default.** Userinfo (`user:token@host`) is unconditionally stripped — fetch URLs frequently carry credentials inline. The query string is also stripped by default because pre-signed S3/GCS URLs put credentials in `X-Amz-*` parameters; operators who need them (debugging custom mirrors, version-pin tracking) opt in via `pii.include_fetch_query_string: true`. Redaction lives in a new `redactFetchURL` helper and is applied to both the span attribute and the log body. Non-RFC-3986 references (`oci://repo/image@sha256:…`, `file://` mirrors) pass through unmodified rather than being dropped.
- **Filter check hoisted above log emission.** `handleFetch` now runs `state.filter.LevelForTarget("").allowFetch()` once, at the top of the handler, before any log or span work. Drop / build_only operators no longer leak the URL into logs while suppressing the span. Per-rule patterns don't apply to fetches (no owning target, so the filter falls through to `default_level`); this is documented explicitly in `docs/attributes.md`.
- **Zero-width span timing.** The Fetch proto carries no timestamps; the original implementation used `start = invocation createdAt, end = time.Now()`, which painted every fetch as a build-stream-spanning bar. The span is now zero-width at event-processing time — correctly indicating "this fetch happened" without fabricating duration. Threading `OrderedBuildEvent.Event.EventTime` for richer timing is a follow-up if real per-event timestamps become useful.
- **SpanID disambiguation.** SpanIDs now mix the URL, the `FetchId.Downloader` enum, and a per-invocation sequence counter (`state.fetchSeq`). Repeated fetches of the same URL — transient retries, multi-arch toolchain pulls, `repository_cache` evictions — produce distinct SpanIDs that downstream backends do not collapse.
- **`bazel.fetch.downloader` attribute.** Surfaces the `FetchId.Downloader` enum (`HTTP`, `GRPC`, `UNKNOWN`) so retries via different transports are visible in queries.
- **`fetch failed: <url>` status message.** The redacted URL is included in the failure status so the trace identifies which fetch broke without forcing operators to cross-reference span attrs.

## Tests added

7 new on top of the existing 6: userinfo redaction (span + log), query-string default-strip, query-string opt-in, non-standard URL pass-through, downloader attribute, same-URL distinct SpanIDs, instant span timing, late post-flush emission, filter-suppresses-log-too.

## Deferred to follow-up
- OTel semconv `url.full` alignment (dual-emit vs rename) — needs schema discussion.
- Threading `OrderedBuildEvent.Event.EventTime` through `eventMsg` for a real per-event timestamp.
- Replacing `nolint:gocyclo` on `eventTypeName` with a `map[reflect.Type]string` dispatch — applies to every dispatch site, scoped out of this PR.

Closes #61.