### PR TITLE
feat(besreceiver): stamp bazel.patterns on root span from PatternExpanded

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -54,6 +54,7 @@ without `BuildFinished`, from the reaper path.
 | `bazel.run.environment_variable_count` | int                | `len(ExecRequestConstructed.environment_variable)` (only on `bazel run`) |
 | `bazel.run.environment`                | Slice[Map]         | `ExecRequestConstructed.environment_variable` (only on `bazel run`) — `{name, value}` entries; **PII**, requires `include_command_args` |
 | `bazel.run.should_exec`                | bool               | `ExecRequestConstructed.should_exec` (only on `bazel run`) |
+| `bazel.patterns`                       | Slice[Map]         | `PatternExpanded` — one entry per requested pattern: `{pattern, target_count}`. Aggregated across events; capped by `high_cardinality_caps.patterns` (default 50). |
 
 The `bazel.run.*` group is populated only for `bazel run` invocations, where
 Bazel emits `ExecRequestConstructed` after the build succeeds and before the
@@ -62,6 +63,16 @@ these attributes. `bazel.run.environment_variable_count` and
 `bazel.run.should_exec` are always emitted when the event arrives (counts
 and bools carry no PII); argv, environment, and working_directory are
 PII-gated per the table above.
+
+`bazel.patterns` captures what the user asked for: e.g. a `bazel test //...`
+invocation that fans out to 1,400 tests emits a single entry
+`{pattern: "//...", target_count: 1400}`. Patterns are aggregated by
+pattern string across multiple `PatternExpanded` events (unlikely in
+practice, but preserved for correctness). Empty pattern strings and
+zero-target expansions are skipped; when no `PatternExpanded` event
+arrives the attribute is absent entirely. Exceeding
+`high_cardinality_caps.patterns` truncates in sorted pattern order and
+emits a Warn log with the invocation id, original count, and kept count.
 
 Key sanitization for `bazel.workspace.*` and `bazel.metadata.*`: lowercase,
 collapse whitespace to `_`, strip characters outside `[a-z0-9_.]`, trim

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -87,9 +87,10 @@ const defaultProgressMaxChunkSize = 64 * 1024
 
 // HighCardinalityCaps configures per-attribute limits on the Slice[Map]
 // attributes emitted on the bazel.metrics span for high-cardinality
-// BuildMetrics sub-messages. Emission is span-attribute-only (no standalone
-// metrics) to avoid series explosion in metrics backends. A value of 0 is
-// treated as "use default".
+// BuildMetrics sub-messages, plus the bazel.patterns Slice[Map] stamped on
+// the root span. Emission is span-attribute-only (no standalone metrics) to
+// avoid series explosion in metrics backends. A value of 0 is treated as
+// "use default".
 type HighCardinalityCaps struct {
 	// Garbage caps the number of entries in bazel.metrics.garbage derived from
 	// MemoryMetrics.garbage_metrics. Default: 20.
@@ -101,6 +102,9 @@ type HighCardinalityCaps struct {
 	// bazel.metrics.graph.{dirtied,changed,built,cleaned,evaluated}_values
 	// attributes derived from BuildGraphMetrics. Default: 50.
 	GraphValues int `mapstructure:"graph_values"`
+	// Patterns caps the number of entries in bazel.patterns on the root span,
+	// derived from PatternExpanded events. Default: 50.
+	Patterns int `mapstructure:"patterns"`
 }
 
 // Default caps chosen for typical Bazel invocations; see HighCardinalityCaps
@@ -109,6 +113,7 @@ const (
 	defaultCapGarbage     = 20
 	defaultCapPackageLoad = 100
 	defaultCapGraphValues = 50
+	defaultCapPatterns    = 50
 )
 
 // defaultHighCardinalityCaps returns the documented default caps. Mirrored on
@@ -119,6 +124,7 @@ func defaultHighCardinalityCaps() HighCardinalityCaps {
 		Garbage:     defaultCapGarbage,
 		PackageLoad: defaultCapPackageLoad,
 		GraphValues: defaultCapGraphValues,
+		Patterns:    defaultCapPatterns,
 	}
 }
 
@@ -134,6 +140,9 @@ func (c HighCardinalityCaps) withDefaults() HighCardinalityCaps {
 	}
 	if c.GraphValues <= 0 {
 		c.GraphValues = d.GraphValues
+	}
+	if c.Patterns <= 0 {
+		c.Patterns = d.Patterns
 	}
 	return c
 }
@@ -226,6 +235,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.HighCardinalityCaps.GraphValues < 0 {
 		return fmt.Errorf("high_cardinality_caps.graph_values must not be negative, got %d", cfg.HighCardinalityCaps.GraphValues)
+	}
+	if cfg.HighCardinalityCaps.Patterns < 0 {
+		return fmt.Errorf("high_cardinality_caps.patterns must not be negative, got %d", cfg.HighCardinalityCaps.Patterns)
 	}
 	if cfg.MaxActionDataEntries < 0 {
 		return fmt.Errorf("max_action_data_entries must not be negative, got %d", cfg.MaxActionDataEntries)

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -86,6 +86,11 @@ type invocationState struct {
 	// buildMetadata buffers sanitized --build_metadata entries until the root
 	// span is emitted. Keys are pre-sanitized; values are pre-truncated.
 	buildMetadata map[string]string
+	// patterns buffers PatternExpanded aggregates keyed by pattern string;
+	// value is the summed target_count across events for the same pattern.
+	// Emitted as the bazel.patterns Slice[Map] on the root span during
+	// writeRootSpan. Capped at caps.Patterns entries with a warning log.
+	patterns map[string]int64
 
 	// configurations maps config id → Configuration payload. Populated by
 	// handleConfiguration so handleTargetConfigured can stamp config attrs
@@ -465,32 +470,37 @@ func applyResourceUsage(span ptrace.Span, usage []*bep.TestResult_ExecutionInfo_
 }
 
 // finalize appends the root span with start/end timestamps and exit code,
-// marks the invocation as flushed, and returns the accumulated traces batch.
-func (s *invocationState) finalize(finished *bep.BuildFinished) (ptrace.Traces, bool) {
+// marks the invocation as flushed, and returns the accumulated traces batch
+// together with any truncation records produced by root-span attrs (e.g.
+// bazel.patterns exceeding its cap). The caller is expected to log one
+// warning per record with invocation context.
+func (s *invocationState) finalize(finished *bep.BuildFinished) (ptrace.Traces, []truncationRecord, bool) {
 	if s.flushed {
-		return ptrace.Traces{}, false
+		return ptrace.Traces{}, nil, false
 	}
 
-	s.writeRootSpan(finished)
+	truncs := s.writeRootSpan(finished)
 
 	s.flushed = true
 	// Any entries left in pendingReparent represent actions/tests whose
 	// TargetConfigured never arrived. Their spans stay parented to root
 	// (explicit orphan), matching prior behavior.
 	s.pendingReparent = nil
-	return s.pendingTraces, true
+	return s.pendingTraces, truncs, true
 }
 
 // writeRootSpan appends the root bazel.build span to the pending traces batch.
 // finished may be nil when the root span is emitted without BuildFinished
 // (e.g. the reaper flushing an aborted build that never sent BuildFinished).
+// Returns any truncation records produced by capped root-span attrs
+// (bazel.patterns); caller logs one warning per record.
 //
 // When abortRecorded is true, abort attributes are written alongside any
 // existing exit-code attributes and the status message is set to
 // "aborted: <reason>: <description>". Abort is the root cause, so its
 // status takes precedence; the exit code is the consequence and its
 // attributes remain for observability.
-func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
+func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) []truncationRecord {
 	span := s.appendSpan()
 	span.SetSpanID(s.rootSpanID)
 	// command is a free-form string in the proto, but in practice bounded to
@@ -548,6 +558,10 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) {
 		span.Status().SetCode(ptrace.StatusCodeError)
 		span.Status().SetMessage("aborted: " + s.abortReason + ": " + s.abortDescription)
 	}
+
+	var truncs []truncationRecord
+	truncs = s.applyPatternAttrs(span, truncs)
+	return truncs
 }
 
 // applyStartedAttributes writes root-span attributes derived from the
@@ -710,6 +724,33 @@ func (s *invocationState) addBuildMetadata(md map[string]string) {
 		}
 		s.buildMetadata[key] = truncateAttrValue(md[rawKey])
 		kept = len(s.buildMetadata)
+	}
+}
+
+// addPatternExpanded aggregates a PatternExpanded event onto the invocation
+// state for emission as bazel.patterns on the root span. patterns is the
+// list of pattern strings from BuildEventId_PatternExpandedId (a single BEP
+// event may carry multiple patterns); targetCount is the number of targets
+// the expansion resolved to (len of the event's children). Empty patterns
+// and zero-target expansions are skipped. Aggregation sums target_count for
+// duplicate pattern keys. The cap is enforced at emission time in
+// applyPatternAttrs, not here, so late-arriving low-cardinality aggregates
+// aren't silently dropped.
+func (s *invocationState) addPatternExpanded(patterns []string, targetCount int64) {
+	if s.flushed {
+		return
+	}
+	if targetCount <= 0 {
+		return
+	}
+	if s.patterns == nil {
+		s.patterns = make(map[string]int64)
+	}
+	for _, p := range patterns {
+		if p == "" {
+			continue
+		}
+		s.patterns[p] += targetCount
 	}
 }
 
@@ -896,6 +937,49 @@ func (s *invocationState) applySummaryAttributes(span ptrace.Span) {
 	attrs.PutInt("bazel.summary.passed_tests", s.summaryCounts.PassedTests)
 	attrs.PutInt("bazel.summary.failed_tests", s.summaryCounts.FailedTests)
 	attrs.PutInt("bazel.summary.flaky_tests", s.summaryCounts.FlakyTests)
+}
+
+// applyPatternAttrs emits bazel.patterns as a Slice[Map] on the root span
+// from buffered PatternExpanded aggregates. Each entry is {pattern,
+// target_count}. Entries are sorted by pattern string so truncation is
+// deterministic across reruns with the same inputs. When the aggregate
+// count exceeds caps.Patterns the tail is dropped and one truncationRecord
+// is appended; caller logs the warning.
+//
+// No attribute is emitted when s.patterns is empty — absent vs present-
+// but-empty is a meaningful distinction downstream.
+func (s *invocationState) applyPatternAttrs(span ptrace.Span, truncs []truncationRecord) []truncationRecord {
+	if len(s.patterns) == 0 {
+		return truncs
+	}
+	keys := make([]string, 0, len(s.patterns))
+	for k := range s.patterns {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	limit := s.caps.withDefaults().Patterns
+	original := len(keys)
+	kept := original
+	if limit > 0 && original > limit {
+		keys = keys[:limit]
+		kept = limit
+	}
+
+	slice := span.Attributes().PutEmptySlice("bazel.patterns")
+	for _, k := range keys {
+		m := slice.AppendEmpty().SetEmptyMap()
+		m.PutStr("pattern", k)
+		m.PutInt("target_count", s.patterns[k])
+	}
+	if kept < original {
+		truncs = append(truncs, truncationRecord{
+			attribute: "bazel.patterns",
+			original:  original,
+			kept:      kept,
+		})
+	}
+	return truncs
 }
 
 // nullConfigID is Bazel's sentinel for the null configuration — a TargetCompletedId
@@ -1534,25 +1618,28 @@ func durationToMs(d *durationpb.Duration) int64 {
 	return d.AsDuration().Milliseconds()
 }
 
-// flushOrphaned returns pending traces for invocations that were never finished.
-// Used by the reaper to flush spans before deleting stale state.
+// flushOrphaned returns pending traces for invocations that were never finished,
+// together with any truncation records produced when the root span is emitted
+// on the abort path. Used by the reaper to flush spans before deleting stale
+// state.
 //
 // When an abort was recorded but BuildFinished never arrived, also emit the
 // root span (stamped with abort attrs via writeRootSpan) so the abort signal
 // is preserved. Otherwise the existing pending spans are flushed as-is,
 // matching prior behavior for timed-out but non-aborted invocations.
-func (s *invocationState) flushOrphaned() (ptrace.Traces, bool) {
+func (s *invocationState) flushOrphaned() (ptrace.Traces, []truncationRecord, bool) {
 	if s.flushed {
-		return ptrace.Traces{}, false
+		return ptrace.Traces{}, nil, false
 	}
 	if !s.abortRecorded && s.pendingTraces.SpanCount() == 0 {
-		return ptrace.Traces{}, false
+		return ptrace.Traces{}, nil, false
 	}
+	var truncs []truncationRecord
 	if s.abortRecorded {
-		s.writeRootSpan(nil)
+		truncs = s.writeRootSpan(nil)
 	}
 	s.flushed = true
-	return s.pendingTraces, true
+	return s.pendingTraces, truncs, true
 }
 
 // resolveTargetSpan looks up the parent span for an action or test result.

--- a/receiver/besreceiver/patterns_test.go
+++ b/receiver/besreceiver/patterns_test.go
@@ -1,0 +1,203 @@
+package besreceiver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	buildpb "google.golang.org/genproto/googleapis/devtools/build/v1"
+)
+
+// patternEntries extracts the bazel.patterns Slice[Map] attribute from a
+// span into a stable map keyed by pattern. Fails the test if the attribute
+// is present but shaped wrong.
+func patternEntries(t *testing.T, span ptrace.Span) (map[string]int64, bool) {
+	t.Helper()
+	attr, ok := span.Attributes().Get("bazel.patterns")
+	if !ok {
+		return nil, false
+	}
+	require.Equal(t, pcommon.ValueTypeSlice, attr.Type(), "bazel.patterns must be a slice")
+	out := make(map[string]int64, attr.Slice().Len())
+	for i := range attr.Slice().Len() {
+		e := attr.Slice().At(i)
+		require.Equal(t, pcommon.ValueTypeMap, e.Type(), "entry %d must be a map", i)
+		m := e.Map()
+		pv, pok := m.Get("pattern")
+		require.True(t, pok, "entry %d missing pattern", i)
+		require.Equal(t, pcommon.ValueTypeStr, pv.Type(), "entry %d pattern must be string", i)
+		tv, tok := m.Get("target_count")
+		require.True(t, tok, "entry %d missing target_count", i)
+		require.Equal(t, pcommon.ValueTypeInt, tv.Type(), "entry %d target_count must be int", i)
+		out[pv.Str()] = tv.Int()
+	}
+	return out, true
+}
+
+func TestPatternExpanded_SingleEvent_ProducesOneEntry(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-1", "uuid-pat-1", "test", 1),
+		makePatternExpandedOBE(t, "inv-pat-1", 2, []string{"//foo/..."}, 3),
+		makeBuildFinishedOBE(t, "inv-pat-1", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok, "expected bazel.patterns attribute")
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(3), entries["//foo/..."])
+}
+
+func TestPatternExpanded_MultiplePatterns_EmitsEntryPerPattern(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-multi", "uuid-pat-multi", "build", 1),
+		// One event carrying two patterns — each gets target_count=2.
+		makePatternExpandedOBE(t, "inv-pat-multi", 2, []string{"//a/...", "//b/..."}, 2),
+		makePatternExpandedOBE(t, "inv-pat-multi", 3, []string{"//c:tgt"}, 1),
+		makeBuildFinishedOBE(t, "inv-pat-multi", 4, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok)
+	assert.Equal(t, map[string]int64{
+		"//a/...": 2,
+		"//b/...": 2,
+		"//c:tgt": 1,
+	}, entries)
+}
+
+func TestPatternExpanded_RepeatedPattern_AggregatesTargetCount(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-agg", "uuid-pat-agg", "test", 1),
+		makePatternExpandedOBE(t, "inv-pat-agg", 2, []string{"//same/..."}, 4),
+		makePatternExpandedOBE(t, "inv-pat-agg", 3, []string{"//same/..."}, 7),
+		makeBuildFinishedOBE(t, "inv-pat-agg", 4, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(11), entries["//same/..."])
+}
+
+func TestPatternExpanded_EmptyPatternAndZeroTargets_Skipped(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-skip", "uuid-pat-skip", "build", 1),
+		// Empty pattern string — skipped.
+		makePatternExpandedOBE(t, "inv-pat-skip", 2, []string{""}, 3),
+		// Zero-target expansion — whole event skipped.
+		makePatternExpandedOBE(t, "inv-pat-skip", 3, []string{"//never"}, 0),
+		// Real pattern to verify the attr is still emitted.
+		makePatternExpandedOBE(t, "inv-pat-skip", 4, []string{"//real"}, 2),
+		makeBuildFinishedOBE(t, "inv-pat-skip", 5, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok)
+	assert.Equal(t, map[string]int64{"//real": 2}, entries)
+}
+
+func TestPatternExpanded_NoEvents_NoAttribute(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-none", "uuid-pat-none", "build", 1),
+		makeBuildFinishedOBE(t, "inv-pat-none", 2, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	_, ok := span.Attributes().Get("bazel.patterns")
+	assert.False(t, ok, "bazel.patterns must be absent when no PatternExpanded events arrived")
+}
+
+func TestPatternExpanded_OverCap_TruncatedWithWarning(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, logger, TraceBuilderConfig{
+		Caps: HighCardinalityCaps{Patterns: 3},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	seq := int64(1)
+	events := []*buildpb.OrderedBuildEvent{
+		makeBuildStartedOBE(t, "inv-pat-trunc", "uuid-pat-trunc", "build", seq),
+	}
+	// Emit 5 distinct patterns; cap is 3. Keys sort lexicographically so
+	// the surviving set is deterministic: "//p00", "//p01", "//p02".
+	for i := range 5 {
+		seq++
+		events = append(events, makePatternExpandedOBE(t, "inv-pat-trunc", seq, []string{fmt.Sprintf("//p%02d", i)}, 1))
+	}
+	seq++
+	events = append(events, makeBuildFinishedOBE(t, "inv-pat-trunc", seq, 0, "SUCCESS"))
+
+	processEvents(ctx, t, tb, events...)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok)
+	assert.Len(t, entries, 3, "cap should have truncated to 3 entries")
+	assert.Contains(t, entries, "//p00")
+	assert.Contains(t, entries, "//p01")
+	assert.Contains(t, entries, "//p02")
+
+	warnings := logs.FilterMessage("Truncated high-cardinality root-span attribute").All()
+	require.NotEmpty(t, warnings, "expected a truncation warning log")
+	fields := warnings[0].ContextMap()
+	assert.Equal(t, "inv-pat-trunc", fields["invocation_id"])
+	assert.Equal(t, "bazel.patterns", fields["attribute"])
+	assert.Equal(t, int64(5), fields["original_count"])
+	assert.Equal(t, int64(3), fields["kept"])
+}
+
+func TestPatternExpanded_DefaultCapIs50(t *testing.T) {
+	caps := defaultHighCardinalityCaps()
+	assert.Equal(t, 50, caps.Patterns)
+}
+
+func TestPatternExpanded_ConfigDefault_IncludesPatternsCap(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	assert.Equal(t, 50, cfg.HighCardinalityCaps.Patterns)
+}

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -156,6 +156,37 @@ func makeBuildMetadataOBE(t testing.TB, invID string, seqNum int64, entries map[
 	})
 }
 
+// makePatternExpandedOBE builds an OrderedBuildEvent for a PatternExpanded
+// payload. patterns are the expanded pattern strings carried on the event
+// id (BuildEventId.pattern.pattern); targetCount is the number of synthetic
+// TargetConfigured children used to represent how many targets the
+// expansion resolved to. Child labels are irrelevant — the receiver only
+// counts them.
+func makePatternExpandedOBE(t testing.TB, invID string, seqNum int64, patterns []string, targetCount int) *pb.OrderedBuildEvent {
+	t.Helper()
+	children := make([]*bep.BuildEventId, 0, targetCount)
+	for i := range targetCount {
+		children = append(children, &bep.BuildEventId{
+			Id: &bep.BuildEventId_TargetConfigured{
+				TargetConfigured: &bep.BuildEventId_TargetConfiguredId{
+					Label: fmt.Sprintf("//pattern_child:t%d", i),
+				},
+			},
+		})
+	}
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_Pattern{
+				Pattern: &bep.BuildEventId_PatternExpandedId{Pattern: patterns},
+			},
+		},
+		Children: children,
+		Payload: &bep.BuildEvent_Expanded{
+			Expanded: &bep.PatternExpanded{},
+		},
+	})
+}
+
 // makeAbortedOBE builds an OrderedBuildEvent for an Aborted payload. Aborted
 // events can ride on any BuildEventId; this helper uses BuildFinished by
 // default to exercise the "aborts replace another event ID" path. Pass a

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -327,6 +327,11 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 			return nil
 		}
 		return tb.handleTargetComplete(ctx, invocations, invocationID, event.GetId(), p.Completed)
+	case *bep.BuildEvent_Expanded:
+		if p.Expanded == nil {
+			return nil
+		}
+		return tb.handlePatternExpanded(ctx, invocations, invocationID, event)
 	case *bep.BuildEvent_TestSummary:
 		if p.TestSummary == nil {
 			return nil
@@ -390,6 +395,8 @@ func eventTypeName(event *bep.BuildEvent) string {
 		return "exec_request"
 	case *bep.BuildEvent_Fetch:
 		return "fetch"
+	case *bep.BuildEvent_Expanded:
+		return "pattern_expanded"
 	default:
 		return "other"
 	}
@@ -575,9 +582,17 @@ func (tb *TraceBuilder) handleBuildFinished(ctx context.Context, invocations map
 		return nil
 	}
 
-	traces, ok := state.finalize(finished)
+	traces, truncs, ok := state.finalize(finished)
 	if !ok {
 		return nil
+	}
+	for _, tr := range truncs {
+		tb.logger.Warn("Truncated high-cardinality root-span attribute",
+			zap.String("invocation_id", invocationID),
+			zap.String("attribute", tr.attribute),
+			zap.Int("original_count", tr.original),
+			zap.Int("kept", tr.kept),
+		)
 	}
 
 	tb.logger.Debug("Build finished",
@@ -661,6 +676,29 @@ func (tb *TraceBuilder) handleWorkspaceStatus(_ context.Context, invocations map
 	tb.logger.Debug("Workspace status received",
 		zap.String("invocation_id", invocationID),
 		zap.Int("items", len(ws.GetItem())),
+	)
+	return nil
+}
+
+// handlePatternExpanded aggregates a PatternExpanded event onto the
+// invocation state for later emission as bazel.patterns on the root span.
+// Pattern strings come from BuildEventId.pattern.pattern (repeated); the
+// target count is the number of children on the event — each child is a
+// target/pattern the expansion resolved to. Empty pattern lists and zero-
+// target expansions are dropped. Post-flush arrivals are ignored (matches
+// the buffering semantics of workspace_status / build_metadata).
+func (tb *TraceBuilder) handlePatternExpanded(_ context.Context, invocations map[string]*invocationState, invocationID string, event *bep.BuildEvent) error {
+	state := invocations[invocationID]
+	if state == nil {
+		return nil
+	}
+	patterns := event.GetId().GetPattern().GetPattern()
+	targetCount := int64(len(event.GetChildren()))
+	state.addPatternExpanded(patterns, targetCount)
+	tb.logger.Debug("Pattern expanded",
+		zap.String("invocation_id", invocationID),
+		zap.Int("patterns", len(patterns)),
+		zap.Int64("target_count", targetCount),
 	)
 	return nil
 }
@@ -1117,7 +1155,15 @@ func (tb *TraceBuilder) reapStale(invocations map[string]*invocationState, now t
 		if now.Sub(state.createdAt) <= tb.invocationTimeout {
 			continue
 		}
-		if traces, ok := state.flushOrphaned(); ok && tb.tracesConsumer != nil {
+		if traces, truncs, ok := state.flushOrphaned(); ok && tb.tracesConsumer != nil {
+			for _, tr := range truncs {
+				tb.logger.Warn("Truncated high-cardinality root-span attribute",
+					zap.String("invocation_id", invID),
+					zap.String("attribute", tr.attribute),
+					zap.Int("original_count", tr.original),
+					zap.Int("kept", tr.kept),
+				)
+			}
 			if err := tb.tracesConsumer.ConsumeTraces(context.Background(), traces); err != nil {
 				tb.logger.Error("Failed to flush orphaned spans",
 					zap.String("invocation_id", invID),


### PR DESCRIPTION
Surfaces `PatternExpanded` events as a Slice[Map] attribute `bazel.patterns` on the root `bazel.build` span. Each entry is `{pattern, target_count}` aggregated by pattern across the invocation. Test-heavy repos that invoke `bazel test //...` get a self-describing trace — the difference between "asked for one thing" and "ran 1,400 tests" is now visible without correlating against external logs. Empty patterns and zero-target expansions are skipped.

Capped under `high_cardinality_caps.patterns` (default 50) following the #29 pattern. Truncation surfaces a warning log via the new `[]truncationRecord` return from `writeRootSpan` — same shape as the BuildMetrics truncation pipeline. Aggregation is done over a `map[string]int64` buffered on `invocationState` and stamped during `writeRootSpan`, identical to the workspace_items / build_metadata buffering. Empty buffer → no attribute, so absent vs present-but-empty stays a meaningful distinction.

One proto-shape note worth flagging: the pattern strings live on `BuildEventId.pattern.pattern` (repeated on the id), not on the `PatternExpanded` payload itself. The payload only carries `test_suite_expansions`. `target_count` is derived from `len(event.children)` — each child id is a target (or nested pattern) the expansion resolved to.

Required signature changes for the truncation plumbing: `writeRootSpan` now returns `[]truncationRecord`, which threads through `finalize` and `flushOrphaned`. Both existing callers in `tracebuilder.go` updated to consume and warn-log the records. Distinct log message (`"Truncated high-cardinality root-span attribute"`) so operators can filter from the BuildMetrics-side warning by namespace.

Closes #62.