### PR TITLE
feat(besreceiver): apply review-fix follow-ups for ExecRequestConstructed (#69)

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -34,7 +34,8 @@ receivers:
     #   include_username: false            # bazel.user + user-like workspace/metadata keys
     #   include_workspace_dir: false       # bazel.workspace_directory
     #   include_working_dir: false         # bazel.working_directory
-    #   include_command_args: false        # bazel.action.command_line (slice)
+    #   include_command_args: false        # bazel.action.command_line + bazel.run.argv
+    #   include_run_environment: false     # bazel.run.environment + bazel.run.environment_variable_to_clear
     #   include_action_output_paths: false # bazel.action.primary_output
     #   include_workspace_status: false    # bazel.workspace.* pathway (per-key filtered)
     #   include_build_metadata: false      # bazel.metadata.* pathway (per-key filtered)

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -49,20 +49,44 @@ without `BuildFinished`, from the reaper path.
 | `bazel.options.startup_count`| int    | `len(OptionsParsed.explicit_startup_options)`                    |
 | `bazel.options.command_count`| int    | `len(OptionsParsed.explicit_cmd_line)`                           |
 | `bazel.command_line`         | string | Reconstructed `StructuredCommandLine` — **PII**, requires `include_command_line` |
-| `bazel.run.argv`                       | Slice[string]      | `ExecRequestConstructed.argv` (only on `bazel run`) — **PII**, requires `include_command_args` |
-| `bazel.run.working_directory`          | string             | `ExecRequestConstructed.working_directory` (only on `bazel run`) — **PII**, requires `include_working_dir` |
-| `bazel.run.environment_variable_count` | int                | `len(ExecRequestConstructed.environment_variable)` (only on `bazel run`) |
-| `bazel.run.environment`                | Slice[Map]         | `ExecRequestConstructed.environment_variable` (only on `bazel run`) — `{name, value}` entries; **PII**, requires `include_command_args` |
-| `bazel.run.should_exec`                | bool               | `ExecRequestConstructed.should_exec` (only on `bazel run`) |
-| `bazel.patterns`                       | Slice[Map]         | `PatternExpanded` — one entry per requested pattern: `{pattern, target_count}`. Aggregated across events; capped by `high_cardinality_caps.patterns` (default 50). |
+| `bazel.run.argv`                                | Slice[string]      | `ExecRequestConstructed.argv` (only on `bazel run`) — **PII**, requires `include_command_args` |
+| `bazel.run.argv_count`                          | int                | `len(ExecRequestConstructed.argv)` (only on `bazel run`) — pre-cap count |
+| `bazel.run.working_directory`                   | string             | `ExecRequestConstructed.working_directory` (only on `bazel run`) — **PII**, requires `include_working_dir` |
+| `bazel.run.environment_variable_count`          | int                | `len(ExecRequestConstructed.environment_variable)` (only on `bazel run`) — pre-cap count |
+| `bazel.run.environment_variable_to_clear_count` | int                | `len(ExecRequestConstructed.environment_variable_to_clear)` (only on `bazel run`) |
+| `bazel.run.environment`                         | Slice[Map]         | `ExecRequestConstructed.environment_variable` (only on `bazel run`) — `{name, value}` entries sorted by name, capped at 50; **PII**, requires `include_run_environment` |
+| `bazel.run.environment_variable_to_clear`       | Slice[string]      | `ExecRequestConstructed.environment_variable_to_clear` — env names Bazel will unset before exec; sorted, capped at 50; **PII**, requires `include_run_environment` |
+| `bazel.run.should_exec`                         | bool               | `ExecRequestConstructed.should_exec` (only on `bazel run`) — `false` means Bazel wrote a script via `--script_path` instead of execing |
+| `bazel.patterns`                                | Slice[Map]         | `PatternExpanded` — one entry per requested pattern: `{pattern, target_count}`. Aggregated across events; capped by `high_cardinality_caps.patterns` (default 50). |
 
 The `bazel.run.*` group is populated only for `bazel run` invocations, where
 Bazel emits `ExecRequestConstructed` after the build succeeds and before the
-target is exec'd. `bazel build` / `bazel test` invocations carry none of
-these attributes. `bazel.run.environment_variable_count` and
-`bazel.run.should_exec` are always emitted when the event arrives (counts
-and bools carry no PII); argv, environment, and working_directory are
-PII-gated per the table above.
+target is exec'd. The proto explicitly says this event is "announced only
+after a successful build and before trying to execute" — i.e. it can arrive
+*after* `BuildFinished` on the wire. The receiver handles both orderings:
+when the event arrives before `BuildFinished` the attrs land on the root
+`bazel.build` span; when it arrives after, the receiver emits a standalone
+`bazel.run` child span (parented to the root via traceID/spanID) carrying
+the same attrs.
+
+`bazel build` / `bazel test` invocations carry none of these attributes.
+`bazel.run.argv_count`, `bazel.run.environment_variable_count`,
+`bazel.run.environment_variable_to_clear_count`, and `bazel.run.should_exec`
+are always emitted when the event arrives (counts and bools carry no PII);
+argv requires `include_command_args`; environment + the to-clear list are
+gated separately by the new `include_run_environment` flag because run
+environments routinely carry credentials and host secrets that command-line
+arguments do not.
+
+**Bounds.** `bazel.run.argv` is capped at 200 entries, `bazel.run.environment`
+and `bazel.run.environment_variable_to_clear` at 50 each. Per-value bytes
+(argv strings, env names, env values, working_directory, env-to-clear names)
+are clipped to 256 bytes at a UTF-8 rune boundary via the shared
+`truncateAttrValue` helper. The `..._count` attributes report the pre-cap
+size so operators see when truncation occurred — separately, each truncation
+emits a Warn log with `invocation_id`, `attribute`, `original_count`, and
+`kept` (matches the `applyPatternAttrs` / `bazel.metrics.garbage` pattern).
+Non-UTF-8 entries are silently skipped to avoid OTLP/JSON exporter rejection.
 
 `bazel.patterns` captures what the user asked for: e.g. a `bazel test //...`
 invocation that fans out to 1,400 tests emits a single entry
@@ -260,7 +284,8 @@ receivers:
       include_username: false              # bazel.user + user-like workspace/metadata keys
       include_workspace_dir: false         # bazel.workspace_directory + matching workspace/metadata keys
       include_working_dir: false           # bazel.working_directory + bazel.run.working_directory + matching workspace/metadata keys
-      include_command_args: false          # bazel.action.command_line + bazel.run.argv + bazel.run.environment
+      include_command_args: false          # bazel.action.command_line + bazel.run.argv
+      include_run_environment: false       # bazel.run.environment + bazel.run.environment_variable_to_clear
       include_fetch_query_string: false    # preserve query string on bazel.fetch.url (default off — strips pre-signed S3/GCS creds)
       include_action_output_paths: false   # bazel.action.primary_output
       include_workspace_status: false      # bazel.workspace.* pathway (per-key filtered)

--- a/receiver/besreceiver/config.go
+++ b/receiver/besreceiver/config.go
@@ -186,9 +186,16 @@ type PIIConfig struct {
 	// any bazel.workspace/metadata.<k> where k is "working_dir" or
 	// "working_directory".
 	IncludeWorkingDir bool `mapstructure:"include_working_dir"`
-	// IncludeCommandArgs gates bazel.action.command_line on action spans.
-	// For large monorepos this can materially inflate span payload size.
+	// IncludeCommandArgs gates bazel.action.command_line on action spans
+	// and bazel.run.argv on the root span (`bazel run` only). For large
+	// monorepos this can materially inflate span payload size.
 	IncludeCommandArgs bool `mapstructure:"include_command_args"`
+	// IncludeRunEnvironment gates bazel.run.environment and
+	// bazel.run.environment_variable_to_clear on the root span (`bazel run`
+	// only). Run environments routinely carry credentials, tokens, and
+	// host-derived secrets, so this flag is separate from IncludeCommandArgs:
+	// operators can surface the argv without exposing the env.
+	IncludeRunEnvironment bool `mapstructure:"include_run_environment"`
 	// IncludeActionOutputPaths gates bazel.action.primary_output on action spans.
 	IncludeActionOutputPaths bool `mapstructure:"include_action_output_paths"`
 	// IncludeWorkspaceStatus opens the bazel.workspace.* pathway (items from

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -141,6 +142,15 @@ type invocationState struct {
 	// repository_cache evictions). Combined with FetchId.Downloader the
 	// resulting SpanID is unique per fetch event in the stream.
 	fetchSeq int64
+
+	// runEmitted is set after the post-flush bazel.run span has been emitted
+	// for this invocation. Bazel's BEP contract is one ExecRequestConstructed
+	// per invocation, but BES gRPC reconnect/replay scenarios remove the
+	// invariant — without this guard a duplicate event would emit a second
+	// bazel.run span with the same SpanID, which downstream backends collapse
+	// or reject. Pre-flush re-stamping is naturally idempotent (same root
+	// span, same attribute keys), so this only gates the lateRunSpan path.
+	runEmitted bool
 }
 
 // BuildSummary holds per-invocation aggregate counters emitted as
@@ -535,7 +545,9 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) []truncatio
 		span.Attributes().PutStr("bazel.command_line", s.commandLine)
 	}
 
-	s.applyExecRequestAttrs(span)
+	// applyExecRequestAttrs returns truncation records — collected below.
+	var truncs []truncationRecord
+	truncs = s.applyExecRequestAttrs(span, truncs)
 
 	s.applyContextAttributes(span)
 
@@ -559,7 +571,6 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) []truncatio
 		span.Status().SetMessage("aborted: " + s.abortReason + ": " + s.abortDescription)
 	}
 
-	var truncs []truncationRecord
 	truncs = s.applyPatternAttrs(span, truncs)
 	return truncs
 }
@@ -591,65 +602,228 @@ func (s *invocationState) applyStartedAttributes(span ptrace.Span) {
 	}
 }
 
+// Caps applied to bazel.run.* slice attributes. Bazel does not document
+// upper bounds, but in practice `bazel run` argv lists rarely exceed 150
+// entries (binary path + flags + a handful of args), OS-typical process
+// environments are 30-100 entries with CI runners landing at the high
+// end, and clear-lists are short (PROXY/PATH/HOME-style). 200 covers
+// argv comfortably; 150 covers env without clipping CI environments
+// at the median; 50 covers clear-lists. truncationRecord-driven Warn
+// logs surface whenever the cap fires so operators with concrete data
+// can argue for a higher value.
+const (
+	maxRunArgvEntries     = 200
+	maxRunEnvEntries      = 150
+	maxRunEnvClearEntries = 50
+)
+
 // applyExecRequestAttrs stamps bazel.run.* attributes from a buffered
 // ExecRequestConstructed. No-op when the event was never buffered (the
 // common case for `bazel build` / `bazel test` invocations, which never
 // emit ExecRequestConstructed).
 //
 // Gating matrix:
-//   - bazel.run.argv:                     PII.IncludeCommandArgs
-//   - bazel.run.environment:              PII.IncludeCommandArgs (env often
-//     carries argv-adjacent secrets, so it reuses the same gate)
-//   - bazel.run.working_directory:        PII.IncludeWorkingDir
-//   - bazel.run.environment_variable_count: always emitted (count only, safe)
-//   - bazel.run.should_exec:              always emitted (bool, safe)
 //
-// The BEP proto types argv / working_directory / env name+value as bytes,
-// not string — they are filesystem paths and OS environment values that
-// may contain arbitrary bytes. We cast to string for attribute emission
-// (matching the convention used for other byte-typed BEP fields).
-func (s *invocationState) applyExecRequestAttrs(span ptrace.Span) {
+//   - bazel.run.argv:                                  PII.IncludeCommandArgs
+//   - bazel.run.environment:                           PII.IncludeRunEnvironment
+//   - bazel.run.environment_variable_to_clear:         PII.IncludeRunEnvironment
+//   - bazel.run.working_directory:                     PII.IncludeWorkingDir
+//   - bazel.run.environment_variable_count:            always (count, safe)
+//   - bazel.run.environment_variable_to_clear_count:   always (count, safe)
+//   - bazel.run.should_exec:                           always (bool, safe;
+//     `false` means Bazel wrote a script via --script_path instead of execing)
+//
+// The BEP proto types argv / working_directory / env name+value as bytes
+// — Bazel exposes filesystem paths and OS environment values that may
+// contain arbitrary bytes. We validate UTF-8 on every conversion (pdata
+// accepts any string but OTLP/JSON exporters reject invalid encoding,
+// which is total-batch loss) and skip entries that fail. Per-value bytes
+// are clipped at maxAttrValueLen via truncateAttrValue. Slice lengths are
+// capped to keep span payload bounded; env entries are sorted by name
+// server-side so the emission is deterministic regardless of how Bazel
+// iterates the process environ.
+func (s *invocationState) applyExecRequestAttrs(span ptrace.Span, truncs []truncationRecord) []truncationRecord {
 	er := s.execRequest
 	if er == nil {
-		return
+		return truncs
 	}
 
-	// Always-on attrs first: count and should_exec are safe to emit even
-	// when details are redacted, giving operators an "event arrived" signal.
-	span.Attributes().PutInt("bazel.run.environment_variable_count", int64(len(er.GetEnvironmentVariable())))
-	span.Attributes().PutBool("bazel.run.should_exec", er.GetShouldExec())
+	attrs := span.Attributes()
+
+	// Always-on counts/bool give operators an "event arrived" signal even
+	// when the redacted variants suppress all detail. Counts reflect the
+	// raw payload size, not the post-cap slice length, so operators see
+	// the truth even when applyExecRequest{Argv,Env,EnvToClear} truncates.
+	attrs.PutInt("bazel.run.argv_count", int64(len(er.GetArgv())))
+	attrs.PutInt("bazel.run.environment_variable_count", int64(len(er.GetEnvironmentVariable())))
+	attrs.PutInt("bazel.run.environment_variable_to_clear_count", int64(len(er.GetEnvironmentVariableToClear())))
+	attrs.PutBool("bazel.run.should_exec", er.GetShouldExec())
 
 	if s.pii.IncludeWorkingDir {
-		if wd := er.GetWorkingDirectory(); len(wd) > 0 {
-			span.Attributes().PutStr("bazel.run.working_directory", string(wd))
+		if wd := string(er.GetWorkingDirectory()); wd != "" && utf8.ValidString(wd) {
+			attrs.PutStr("bazel.run.working_directory", truncateAttrValue(wd))
 		}
 	}
 
 	if s.pii.IncludeCommandArgs {
-		if argv := er.GetArgv(); len(argv) > 0 {
-			slice := span.Attributes().PutEmptySlice("bazel.run.argv")
-			for _, a := range argv {
-				slice.AppendEmpty().SetStr(string(a))
-			}
-		}
-		if env := er.GetEnvironmentVariable(); len(env) > 0 {
-			slice := span.Attributes().PutEmptySlice("bazel.run.environment")
-			for _, v := range env {
-				m := slice.AppendEmpty().SetEmptyMap()
-				m.PutStr("name", string(v.GetName()))
-				m.PutStr("value", string(v.GetValue()))
-			}
-		}
+		truncs = applyExecRequestArgv(attrs, er.GetArgv(), truncs)
 	}
+
+	if s.pii.IncludeRunEnvironment {
+		truncs = applyExecRequestEnv(attrs, er.GetEnvironmentVariable(), truncs)
+		truncs = applyExecRequestEnvToClear(attrs, er.GetEnvironmentVariableToClear(), truncs)
+	}
+	return truncs
 }
 
-// setExecRequest buffers an ExecRequestConstructed payload for emission on
-// the root span. No-op after the invocation has been flushed.
-func (s *invocationState) setExecRequest(er *bep.ExecRequestConstructed) {
-	if s.flushed || er == nil {
-		return
+// All three apply* helpers maintain a consistent truncationRecord
+// contract: `original` always equals the raw proto length (which matches
+// the always-on `*_count` attrs), and `kept` always equals the actual
+// emitted slice length. The gap between them — whether driven by the
+// hard cap, by UTF-8 skips, or by both — is what operators need to see.
+//
+// argv keeps cap-first (positional adjacency in argv matters: dropping
+// items at the end is more interpretable than dropping them after a sort
+// would shuffle order). env and env-to-clear filter-first because the
+// sort already destroys positional meaning; filtering first keeps the
+// cap from clipping past valid entries we'd then drop again.
+
+// applyExecRequestArgv emits bazel.run.argv.
+func applyExecRequestArgv(attrs pcommon.Map, argv [][]byte, truncs []truncationRecord) []truncationRecord {
+	if len(argv) == 0 {
+		return truncs
 	}
-	s.execRequest = er
+	original := len(argv)
+	if len(argv) > maxRunArgvEntries {
+		// 3-index reslice defends the backing array — even if the caller
+		// later mutates argv (none do today, but the BEP proto generator
+		// could), the receiver's truncated view doesn't accidentally
+		// expose past-cap entries.
+		argv = argv[:maxRunArgvEntries:maxRunArgvEntries]
+	}
+	slice := attrs.PutEmptySlice("bazel.run.argv")
+	for _, a := range argv {
+		v := string(a)
+		if !utf8.ValidString(v) {
+			continue
+		}
+		slice.AppendEmpty().SetStr(truncateAttrValue(v))
+	}
+	if slice.Len() < original {
+		truncs = append(truncs, truncationRecord{
+			attribute: "bazel.run.argv",
+			original:  original,
+			kept:      slice.Len(),
+		})
+	}
+	return truncs
+}
+
+func applyExecRequestEnv(attrs pcommon.Map, env []*bep.EnvironmentVariable, truncs []truncationRecord) []truncationRecord {
+	if len(env) == 0 {
+		return truncs
+	}
+	original := len(env)
+	// UTF-8 filter first — sort destroys positional meaning anyway, so
+	// no information is lost. utf8.Valid on the byte slice avoids the
+	// allocation utf8.ValidString(string(b)) would force.
+	valid := make([]*bep.EnvironmentVariable, 0, len(env))
+	for _, v := range env {
+		if utf8.Valid(v.GetName()) && utf8.Valid(v.GetValue()) {
+			valid = append(valid, v)
+		}
+	}
+	// SliceStable so two entries with the same name (rare but allowed by
+	// repeated EnvironmentVariable) keep their wire order.
+	sort.SliceStable(valid, func(i, j int) bool {
+		return string(valid[i].GetName()) < string(valid[j].GetName())
+	})
+	if len(valid) > maxRunEnvEntries {
+		valid = valid[:maxRunEnvEntries]
+	}
+	slice := attrs.PutEmptySlice("bazel.run.environment")
+	for _, v := range valid {
+		m := slice.AppendEmpty().SetEmptyMap()
+		m.PutStr("name", truncateAttrValue(string(v.GetName())))
+		m.PutStr("value", truncateAttrValue(string(v.GetValue())))
+	}
+	if slice.Len() < original {
+		truncs = append(truncs, truncationRecord{
+			attribute: "bazel.run.environment",
+			original:  original,
+			kept:      slice.Len(),
+		})
+	}
+	return truncs
+}
+
+func applyExecRequestEnvToClear(attrs pcommon.Map, clearList [][]byte, truncs []truncationRecord) []truncationRecord {
+	if len(clearList) == 0 {
+		return truncs
+	}
+	original := len(clearList)
+	names := make([]string, 0, len(clearList))
+	for _, b := range clearList {
+		s := string(b)
+		if utf8.ValidString(s) {
+			names = append(names, s)
+		}
+	}
+	sort.Strings(names)
+	if len(names) > maxRunEnvClearEntries {
+		names = names[:maxRunEnvClearEntries]
+	}
+	slice := attrs.PutEmptySlice("bazel.run.environment_variable_to_clear")
+	for _, name := range names {
+		slice.AppendEmpty().SetStr(truncateAttrValue(name))
+	}
+	if slice.Len() < original {
+		truncs = append(truncs, truncationRecord{
+			attribute: "bazel.run.environment_variable_to_clear",
+			original:  original,
+			kept:      slice.Len(),
+		})
+	}
+	return truncs
+}
+
+// lateRunSpan emits a standalone bazel.run span carrying the bazel.run.*
+// attributes for an ExecRequestConstructed event that arrived after the
+// main batch was flushed. Bazel's BEP doc places ExecRequestConstructed
+// "after a successful build and before trying to execute" — i.e.
+// potentially after BuildFinished — so the post-flush path is the
+// production path, not defense-in-depth. Without it, every `bazel run`
+// invocation would silently emit empty bazel.run.* attributes.
+//
+// The span is parented to the (already-emitted) root span via
+// state.rootSpanID so consumers correlate it as a child of the build.
+//
+// Filter-exemption contract: bazel.run.* carries displaced root-span
+// data (the attrs would have landed on bazel.build had the event arrived
+// pre-flush). The root span itself is filter-exempt by design, so this
+// span is too — gating only the post-flush path would create wire-order-
+// dependent output across {drop, build_only, targets, verbose} which is
+// strictly worse than uniform emission. A symmetric receiver-wide
+// `allowRun()` gate is tracked separately as a follow-up.
+//
+// The span is zero-width at `at` (event-processing instant). The Fetch
+// proto and ExecRequestConstructed both lack per-event timestamps;
+// stamping a zero-width instant is the right shape — non-zero timestamps
+// matter to OTLP backends for correlation, but inferring a duration
+// would fabricate data.
+func (s *invocationState) lateRunSpan(at time.Time) (ptrace.Traces, []truncationRecord) {
+	traces, ss := newTracesPayload()
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(s.traceID)
+	span.SetSpanID(spanIDFromIdentity(s.uuid, "run"))
+	span.SetParentSpanID(s.rootSpanID)
+	span.SetName("bazel.run")
+	span.SetKind(ptrace.SpanKindInternal)
+	ts := pcommon.NewTimestampFromTime(at)
+	span.SetStartTimestamp(ts)
+	span.SetEndTimestamp(ts)
+	truncs := s.applyExecRequestAttrs(span, nil)
+	return traces, truncs
 }
 
 // recordAbort stores the first abort reason and description on the invocation

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -5,11 +5,15 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	pb "google.golang.org/genproto/googleapis/devtools/build/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -480,30 +484,35 @@ func makeBuildMetricsOBE(t testing.TB, invID string, seqNum, wallMs, cpuMs int64
 }
 
 // makeExecRequestConstructedOBE builds an ExecRequestConstructed event for
-// `bazel run` tests. argv and envVars are emitted as-is (argv as a list of
-// strings, env as a list of name=value pairs). workingDir and shouldExec are
-// set directly on the payload. The BEP proto types these fields as bytes, so
-// we cast through []byte to match the generated Go shape.
+// `bazel run` tests. argv goes through verbatim; env entries are emitted in
+// the order Go's map iteration produces them — the receiver is responsible
+// for sorting, so this exposes any non-determinism there. Working dir and
+// shouldExec are set directly. The BEP proto types these fields as bytes,
+// so we cast through []byte to match the generated Go shape.
 func makeExecRequestConstructedOBE(t testing.TB, invID string, seqNum int64, argv []string, workingDir string, env map[string]string, shouldExec bool) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeExecRequestConstructedOBEFull(t, invID, seqNum, argv, workingDir, env, nil, shouldExec)
+}
+
+// makeExecRequestConstructedOBEFull is the full-arity helper exposing
+// environment_variable_to_clear (proto field 4). Used by tests that need
+// the unset list; most tests pass nil and use the simpler wrapper above.
+func makeExecRequestConstructedOBEFull(t testing.TB, invID string, seqNum int64, argv []string, workingDir string, env map[string]string, envToClear []string, shouldExec bool) *pb.OrderedBuildEvent {
 	t.Helper()
 	argvBytes := make([][]byte, 0, len(argv))
 	for _, a := range argv {
 		argvBytes = append(argvBytes, []byte(a))
 	}
-	// Sort env by key for deterministic emission — BEP map iteration order is
-	// non-deterministic and assertions on the environment slice compare by
-	// index.
-	keys := make([]string, 0, len(env))
-	for k := range env {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
 	envVars := make([]*bep.EnvironmentVariable, 0, len(env))
-	for _, k := range keys {
+	for k, v := range env {
 		envVars = append(envVars, &bep.EnvironmentVariable{
 			Name:  []byte(k),
-			Value: []byte(env[k]),
+			Value: []byte(v),
 		})
+	}
+	clearBytes := make([][]byte, 0, len(envToClear))
+	for _, n := range envToClear {
+		clearBytes = append(clearBytes, []byte(n))
 	}
 	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
 		Id: &bep.BuildEventId{
@@ -513,10 +522,11 @@ func makeExecRequestConstructedOBE(t testing.TB, invID string, seqNum int64, arg
 		},
 		Payload: &bep.BuildEvent_ExecRequest{
 			ExecRequest: &bep.ExecRequestConstructed{
-				Argv:                argvBytes,
-				WorkingDirectory:    []byte(workingDir),
-				EnvironmentVariable: envVars,
-				ShouldExec:          shouldExec,
+				Argv:                       argvBytes,
+				WorkingDirectory:           []byte(workingDir),
+				EnvironmentVariable:        envVars,
+				EnvironmentVariableToClear: clearBytes,
+				ShouldExec:                 shouldExec,
 			},
 		},
 	})
@@ -636,6 +646,42 @@ func makeBuildFinishedReq(t testing.TB, invID string, seqNum int64, code int32, 
 			},
 		},
 	})
+}
+
+// flakyTracesConsumer fails ConsumeTraces N times then forwards to a real
+// sink. Used to exercise retryable-error paths without hand-rolling a
+// `consumer.Traces` impl in each test.
+type flakyTracesConsumer struct {
+	sink *consumertest.TracesSink
+
+	mu      sync.Mutex
+	nextErr error
+}
+
+func (f *flakyTracesConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (f *flakyTracesConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	f.mu.Lock()
+	err := f.nextErr
+	f.nextErr = nil
+	f.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if f.sink == nil {
+		f.sink = new(consumertest.TracesSink)
+	}
+	return f.sink.ConsumeTraces(ctx, td)
+}
+
+// failNext arms the consumer to return err once on the next ConsumeTraces
+// call; subsequent calls forward to the embedded sink.
+func (f *flakyTracesConsumer) failNext(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextErr = err
 }
 
 func makeBuildMetricsReq(t testing.TB, invID string, seqNum, wallMs, cpuMs int64) *pb.PublishBuildToolEventStreamRequest {

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -806,23 +806,80 @@ func truncateUTF8(s string, maxBytes int) (string, bool) {
 	return s[:end], true
 }
 
-// handleExecRequestConstructed buffers the ExecRequestConstructed payload on
-// the invocation state for emission as bazel.run.* attributes on the root
-// span. Emitted by Bazel only for `bazel run`, after the build succeeds and
-// just before the run target is exec'd. One event per invocation; post-flush
-// arrivals are dropped (the root span is already out).
-func (tb *TraceBuilder) handleExecRequestConstructed(_ context.Context, invocations map[string]*invocationState, invocationID string, er *bep.ExecRequestConstructed) error {
+// handleExecRequestConstructed routes an ExecRequestConstructed payload to
+// the right span. Emitted by Bazel only for `bazel run`, "announced only
+// after a successful build and before trying to execute" per the BEP proto
+// — i.e. potentially after BuildFinished. Two paths:
+//
+//   - Pre-flush: buffer on invocationState; writeRootSpan stamps bazel.run.*
+//     onto the root span at finalize time.
+//   - Post-flush: emit a standalone bazel.run span (parented to the
+//     already-flushed root) carrying the same attrs. Without this, every
+//     `bazel run` invocation would silently emit empty bazel.run.* attrs.
+//
+// One event per invocation per the BEP contract; BES gRPC reconnect/replay
+// can violate that, so the post-flush path additionally guards on
+// state.runEmitted to avoid emitting duplicate-SpanID `bazel.run` spans.
+func (tb *TraceBuilder) handleExecRequestConstructed(ctx context.Context, invocations map[string]*invocationState, invocationID string, er *bep.ExecRequestConstructed) error {
 	state := invocations[invocationID]
-	if state == nil {
+	if state == nil || er == nil {
 		return nil
 	}
-	state.setExecRequest(er)
-	tb.logger.Debug("ExecRequestConstructed received",
+
+	if !state.flushed {
+		// Pre-flush: buffer for writeRootSpan to stamp on root. Re-stamping
+		// the same root span on a duplicate event is idempotent (same
+		// attribute keys) so no separate guard is needed here.
+		state.execRequest = er
+		tb.logger.Debug("ExecRequestConstructed received (pre-flush)",
+			zap.String("invocation_id", invocationID),
+			zap.Int("argv_count", len(er.GetArgv())),
+			zap.Int("env_var_count", len(er.GetEnvironmentVariable())),
+			zap.Int("env_to_clear_count", len(er.GetEnvironmentVariableToClear())),
+			zap.Bool("should_exec", er.GetShouldExec()),
+		)
+		return nil
+	}
+
+	// Post-flush: a duplicate event would create a second `bazel.run` span
+	// with the same SpanID — backends collapse or reject. Guard once and
+	// drop the duplicate with a Warn so operators see the abnormal sequence.
+	if state.runEmitted {
+		tb.logger.Warn("Duplicate post-flush ExecRequestConstructed dropped",
+			zap.String("invocation_id", invocationID),
+		)
+		return nil
+	}
+	state.execRequest = er
+
+	// Info severity (not Debug) so the abnormal sequencing is visible in
+	// production deployments — this is the only signal that bazel.run.*
+	// data took the displaced-span path rather than landing on root.
+	tb.logger.Info("ExecRequestConstructed late arrival — emitting standalone bazel.run span",
 		zap.String("invocation_id", invocationID),
-		zap.Int("argv_len", len(er.GetArgv())),
-		zap.Int("env_count", len(er.GetEnvironmentVariable())),
+		zap.Int("argv_count", len(er.GetArgv())),
+		zap.Int("env_var_count", len(er.GetEnvironmentVariable())),
+		zap.Int("env_to_clear_count", len(er.GetEnvironmentVariableToClear())),
 		zap.Bool("should_exec", er.GetShouldExec()),
 	)
+	traces, truncs := state.lateRunSpan(time.Now())
+	for _, tr := range truncs {
+		tb.logger.Warn("Truncated bazel.run.* attribute",
+			zap.String("invocation_id", invocationID),
+			zap.String("attribute", tr.attribute),
+			zap.Int("original_count", tr.original),
+			zap.Int("kept", tr.kept),
+		)
+	}
+	// Set runEmitted only AFTER the consumer accepts the payload. The
+	// `invocations` map persists across BES stream reconnects (per
+	// TraceBuilder.run lifetime, not per stream), so a retryable consumer
+	// error must NOT commit the flag — otherwise the replayed event Bazel
+	// resends after reconnect would be silently dropped here.
+	if err := tb.consumeAndRecord(ctx, traces); err != nil {
+		return err
+	}
+	state.runEmitted = true
 	return nil
 }
 

--- a/receiver/besreceiver/tracebuilder_test.go
+++ b/receiver/besreceiver/tracebuilder_test.go
@@ -21,6 +21,8 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -3124,18 +3126,30 @@ func runExecRequestStream(t *testing.T, pii PIIConfig) *consumertest.TracesSink 
 }
 
 // TestExecRequest_AllPIIOn verifies every bazel.run.* attribute is stamped
-// when the necessary PII gates are open.
+// when the necessary PII gates are open. Asserts the receiver sorts env
+// entries server-side (input map iteration order is non-deterministic).
 func TestExecRequest_AllPIIOn(t *testing.T) {
 	sink := runExecRequestStream(t, PIIConfig{
-		IncludeCommandArgs: true,
-		IncludeWorkingDir:  true,
+		IncludeCommandArgs:    true,
+		IncludeRunEnvironment: true,
+		IncludeWorkingDir:     true,
 	})
 	root := findRootSpan(t, sink)
 
-	// Always-on: count + should_exec.
+	// Always-on: counts + should_exec. argv_count parallels env counts so
+	// operators see the raw payload size even when the slice is capped or
+	// the gate is closed.
+	argvCount, ok := root.Attributes().Get("bazel.run.argv_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(3), argvCount.Int())
+
 	count, ok := root.Attributes().Get("bazel.run.environment_variable_count")
 	require.True(t, ok)
 	assert.Equal(t, int64(2), count.Int())
+
+	clearCount, ok := root.Attributes().Get("bazel.run.environment_variable_to_clear_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(0), clearCount.Int())
 
 	se, ok := root.Attributes().Get("bazel.run.should_exec")
 	require.True(t, ok)
@@ -3155,8 +3169,8 @@ func TestExecRequest_AllPIIOn(t *testing.T) {
 	assert.Equal(t, "--flag", argv.Slice().At(1).Str())
 	assert.Equal(t, "value", argv.Slice().At(2).Str())
 
-	// environment (gated by IncludeCommandArgs) as Slice[Map{name,value}],
-	// sorted by key thanks to the test helper.
+	// environment (gated by IncludeRunEnvironment) as Slice[Map{name,value}],
+	// sorted by name server-side.
 	env, ok := root.Attributes().Get("bazel.run.environment")
 	require.True(t, ok)
 	require.Equal(t, pcommon.ValueTypeSlice, env.Type())
@@ -3192,6 +3206,10 @@ func TestExecRequest_PIIOff_CountAndShouldExecStillEmitted(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, int64(2), count.Int())
 
+	clearCount, ok := root.Attributes().Get("bazel.run.environment_variable_to_clear_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(0), clearCount.Int())
+
 	se, ok := root.Attributes().Get("bazel.run.should_exec")
 	require.True(t, ok)
 	assert.True(t, se.Bool())
@@ -3201,6 +3219,7 @@ func TestExecRequest_PIIOff_CountAndShouldExecStillEmitted(t *testing.T) {
 		"bazel.run.argv",
 		"bazel.run.working_directory",
 		"bazel.run.environment",
+		"bazel.run.environment_variable_to_clear",
 	} {
 		_, has := root.Attributes().Get(key)
 		assert.False(t, has, "expected %s to be redacted with PII off", key)
@@ -3220,13 +3239,14 @@ func TestExecRequest_WorkingDirGate_OnlyDir(t *testing.T) {
 	_, hasArgv := root.Attributes().Get("bazel.run.argv")
 	assert.False(t, hasArgv, "argv must stay redacted without IncludeCommandArgs")
 	_, hasEnv := root.Attributes().Get("bazel.run.environment")
-	assert.False(t, hasEnv, "environment must stay redacted without IncludeCommandArgs")
+	assert.False(t, hasEnv, "environment must stay redacted without IncludeRunEnvironment")
 }
 
-// TestExecRequest_CommandArgsGate_ArgvAndEnv asserts IncludeCommandArgs
-// surfaces both argv and environment (shared gate per issue #63) while
-// keeping working_directory redacted.
-func TestExecRequest_CommandArgsGate_ArgvAndEnv(t *testing.T) {
+// TestExecRequest_CommandArgsGate_ArgvOnly asserts IncludeCommandArgs alone
+// surfaces argv but NOT the environment — environment is gated separately
+// via IncludeRunEnvironment so operators can show the command without the
+// secrets that often live in env.
+func TestExecRequest_CommandArgsGate_ArgvOnly(t *testing.T) {
 	sink := runExecRequestStream(t, PIIConfig{IncludeCommandArgs: true})
 	root := findRootSpan(t, sink)
 
@@ -3235,22 +3255,38 @@ func TestExecRequest_CommandArgsGate_ArgvAndEnv(t *testing.T) {
 	require.Equal(t, pcommon.ValueTypeSlice, argv.Type())
 	assert.Equal(t, 3, argv.Slice().Len())
 
+	_, hasEnv := root.Attributes().Get("bazel.run.environment")
+	assert.False(t, hasEnv, "environment must stay redacted without IncludeRunEnvironment")
+	_, hasClear := root.Attributes().Get("bazel.run.environment_variable_to_clear")
+	assert.False(t, hasClear, "env_to_clear must stay redacted without IncludeRunEnvironment")
+	_, hasWD := root.Attributes().Get("bazel.run.working_directory")
+	assert.False(t, hasWD, "working_directory must stay redacted without IncludeWorkingDir")
+}
+
+// TestExecRequest_RunEnvironmentGate_EnvOnly asserts IncludeRunEnvironment
+// alone surfaces the environment block but keeps argv redacted (the
+// gates are independent so operators can show env without command args).
+func TestExecRequest_RunEnvironmentGate_EnvOnly(t *testing.T) {
+	sink := runExecRequestStream(t, PIIConfig{IncludeRunEnvironment: true})
+	root := findRootSpan(t, sink)
+
 	env, ok := root.Attributes().Get("bazel.run.environment")
 	require.True(t, ok)
 	require.Equal(t, pcommon.ValueTypeSlice, env.Type())
 	assert.Equal(t, 2, env.Slice().Len())
 
-	_, hasWD := root.Attributes().Get("bazel.run.working_directory")
-	assert.False(t, hasWD, "working_directory must stay redacted without IncludeWorkingDir")
+	_, hasArgv := root.Attributes().Get("bazel.run.argv")
+	assert.False(t, hasArgv, "argv must stay redacted without IncludeCommandArgs")
 }
 
 // TestExecRequest_NoWorkingDirectory asserts that an ExecRequestConstructed
 // event with an empty working_directory does not emit a blank attribute even
-// when IncludeWorkingDir is true.
+// when IncludeWorkingDir is true. should_exec=false here also covers the
+// --script_path mode where Bazel writes a script to disk instead of execing.
 func TestExecRequest_NoWorkingDirectory(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
-		PII: PIIConfig{IncludeWorkingDir: true, IncludeCommandArgs: true},
+		PII: PIIConfig{IncludeWorkingDir: true, IncludeCommandArgs: true, IncludeRunEnvironment: true},
 	})
 	tb.Start()
 	defer tb.Stop()
@@ -3283,7 +3319,7 @@ func TestExecRequest_NoWorkingDirectory(t *testing.T) {
 func TestExecRequest_BazelBuild_NoAttrsEmitted(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
-		PII: PIIConfig{IncludeWorkingDir: true, IncludeCommandArgs: true},
+		PII: PIIConfig{IncludeWorkingDir: true, IncludeCommandArgs: true, IncludeRunEnvironment: true},
 	})
 	tb.Start()
 	defer tb.Stop()
@@ -3299,7 +3335,9 @@ func TestExecRequest_BazelBuild_NoAttrsEmitted(t *testing.T) {
 		"bazel.run.argv",
 		"bazel.run.working_directory",
 		"bazel.run.environment_variable_count",
+		"bazel.run.environment_variable_to_clear_count",
 		"bazel.run.environment",
+		"bazel.run.environment_variable_to_clear",
 		"bazel.run.should_exec",
 	} {
 		_, has := root.Attributes().Get(key)
@@ -3712,4 +3750,592 @@ func TestTraceBuilder_Fetch_FilterSuppressesLogToo(t *testing.T) {
 	assert.Empty(t, findFetchSpans(t, sink), "filter must suppress the span")
 	assert.Empty(t, logRecordsByEventName(t, logsSink, "bazel.fetch"),
 		"filter must suppress bazel.fetch log records too")
+}
+
+// findRunSpans walks every emitted Traces batch and returns the bazel.run
+// spans across all of them. Tests should not unroll the four-level pdata
+// iteration manually.
+func findRunSpans(t *testing.T, sink *consumertest.TracesSink) []ptrace.Span {
+	t.Helper()
+	var out []ptrace.Span
+	for _, traces := range sink.AllTraces() {
+		for i := range traces.ResourceSpans().Len() {
+			rs := traces.ResourceSpans().At(i)
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					if span := ss.Spans().At(k); span.Name() == "bazel.run" {
+						out = append(out, span)
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// TestExecRequest_LatePostFlush — Bazel's BEP doc places
+// ExecRequestConstructed "after a successful build and before trying to
+// execute", which in production means after BuildFinished on the wire. The
+// receiver must still emit bazel.run.* attrs in that case via a standalone
+// `bazel.run` span parented to the (already-flushed) root.
+func TestExecRequest_LatePostFlush(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true, IncludeRunEnvironment: true, IncludeWorkingDir: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-late", "uuid-late", "run", 1),
+		// BuildFinished arrives BEFORE ExecRequestConstructed — production order.
+		makeBuildFinishedOBE(t, "inv-late", 2, 0, "SUCCESS"),
+		makeExecRequestConstructedOBE(t, "inv-late", 3,
+			[]string{"/bin/tool", "--flag"},
+			"/wd",
+			map[string]string{"K": "v"},
+			true,
+		),
+	)
+
+	runSpans := findRunSpans(t, sink)
+	require.Len(t, runSpans, 1, "post-flush ExecRequestConstructed must produce exactly one bazel.run span")
+	runSpan := runSpans[0]
+
+	// TraceID matches the invocation; parent is the root; SpanID is the
+	// expected deterministic identity (catches duplicate-emission bugs).
+	assert.Equal(t, traceIDFromUUID("uuid-late"), runSpan.TraceID())
+	assert.Equal(t, spanIDFromIdentity("uuid-late", "root"), runSpan.ParentSpanID())
+	assert.Equal(t, spanIDFromIdentity("uuid-late", "run"), runSpan.SpanID())
+
+	// Zero-width timestamps stamped at handler time — non-zero so OTLP
+	// backends treat the span as a real instant rather than 1970-epoch.
+	assert.NotEqual(t, pcommon.Timestamp(0), runSpan.StartTimestamp(),
+		"late bazel.run span must have a non-zero start timestamp")
+	assert.Equal(t, runSpan.StartTimestamp(), runSpan.EndTimestamp(),
+		"late bazel.run span must be zero-width (start == end)")
+
+	// All bazel.run.* attrs land on the late span, gated identically to the
+	// pre-flush path.
+	argv, ok := runSpan.Attributes().Get("bazel.run.argv")
+	require.True(t, ok)
+	assert.Equal(t, 2, argv.Slice().Len())
+	wd, ok := runSpan.Attributes().Get("bazel.run.working_directory")
+	require.True(t, ok)
+	assert.Equal(t, "/wd", wd.Str())
+	env, ok := runSpan.Attributes().Get("bazel.run.environment")
+	require.True(t, ok)
+	assert.Equal(t, 1, env.Slice().Len())
+	se, ok := runSpan.Attributes().Get("bazel.run.should_exec")
+	require.True(t, ok)
+	assert.True(t, se.Bool())
+}
+
+// TestExecRequest_LateConsumerErrorDoesNotCommitGuard — when the late
+// `bazel.run` span fails to forward (retryable consumer error), the
+// receiver closes the BES stream so Bazel reconnects and replays the
+// event. The `invocations` map persists across reconnects (per
+// TraceBuilder.run lifetime, not per stream), so committing
+// runEmitted=true before the consume succeeds would silently drop the
+// replayed event. This test pins the contract: the SECOND attempt
+// (after a transient consumer error) must still emit the span.
+func TestExecRequest_LateConsumerErrorDoesNotCommitGuard(t *testing.T) {
+	flaky := &flakyTracesConsumer{sink: new(consumertest.TracesSink)}
+	tb := NewTraceBuilder(flaky, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Set up the invocation up to the late-path branch.
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-retry", "uuid-retry", "run", 1),
+		makeBuildFinishedOBE(t, "inv-retry", 2, 0, "SUCCESS"),
+	)
+
+	// First ExecRequestConstructed: flaky consumer fails the consume.
+	// The handler returns the error and the BES stream would be closed
+	// to prompt Bazel reconnect. runEmitted must NOT be committed.
+	flaky.failNext(errors.New("transient pipeline error"))
+	firstAttempt := makeExecRequestConstructedOBE(t, "inv-retry", 3,
+		[]string{"/bin/tool"}, "", nil, true,
+	)
+	require.Error(t, tb.ProcessOrderedBuildEvent(ctx, firstAttempt),
+		"flaky consumer must surface its error to the BES handler")
+
+	// Replay the event (Bazel's reconnect behaviour). Second attempt
+	// should succeed and emit the span — possible only if runEmitted
+	// was not committed on the failed attempt.
+	processEvents(ctx, t, tb,
+		makeExecRequestConstructedOBE(t, "inv-retry", 3,
+			[]string{"/bin/tool"}, "", nil, true,
+		),
+	)
+
+	require.Len(t, findRunSpans(t, flaky.sink), 1,
+		"replayed ExecRequestConstructed must produce a bazel.run span — runEmitted may not be committed before consume succeeds")
+}
+
+// TestExecRequest_LateDuplicateDropped — Bazel's BEP contract is one
+// ExecRequestConstructed per invocation, but BES gRPC reconnect/replay
+// can violate it. A duplicate post-flush event must be dropped to avoid
+// emitting a second bazel.run span with the same SpanID (which backends
+// collapse or reject).
+func TestExecRequest_LateDuplicateDropped(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-dup", "uuid-dup", "run", 1),
+		makeBuildFinishedOBE(t, "inv-dup", 2, 0, "SUCCESS"),
+		makeExecRequestConstructedOBE(t, "inv-dup", 3,
+			[]string{"/bin/tool"}, "", nil, true,
+		),
+		// Duplicate ExecRequestConstructed — must be dropped.
+		makeExecRequestConstructedOBE(t, "inv-dup", 4,
+			[]string{"/bin/tool", "extra"}, "", nil, true,
+		),
+	)
+
+	runSpans := findRunSpans(t, sink)
+	require.Len(t, runSpans, 1,
+		"duplicate post-flush ExecRequestConstructed must not produce a second bazel.run span")
+}
+
+// TestExecRequest_WireOrderParity — pre-flush and post-flush wire orders
+// must yield byte-identical bazel.run.* attribute sets across every
+// filter level. Per the design (lateRunSpan filter-exempt because it
+// carries displaced root-span data), output cannot depend on whether
+// ExecRequestConstructed beat or trailed BuildFinished.
+func TestExecRequest_WireOrderParity(t *testing.T) {
+	pii := PIIConfig{IncludeCommandArgs: true, IncludeRunEnvironment: true, IncludeWorkingDir: true}
+	argv := []string{"/bin/tool", "--flag", "value"}
+	envMap := map[string]string{"FOO": "bar", "PATH": "/usr/bin"}
+
+	for _, level := range []DetailLevel{DetailLevelDrop, DetailLevelBuildOnly, DetailLevelTargets, DetailLevelVerbose} {
+		t.Run(string(level), func(t *testing.T) {
+			runOne := func(t *testing.T, postFlush bool) map[string]string {
+				t.Helper()
+				sink := new(consumertest.TracesSink)
+				tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+					PII:    pii,
+					Filter: FilterConfig{DefaultLevel: level},
+				})
+				tb.Start()
+				defer tb.Stop()
+				ctx := context.Background()
+
+				if postFlush {
+					processEvents(ctx, t, tb,
+						makeBuildStartedOBE(t, "inv", "uuid-parity", "run", 1),
+						makeBuildFinishedOBE(t, "inv", 2, 0, "SUCCESS"),
+						makeExecRequestConstructedOBE(t, "inv", 3, argv, "/wd", envMap, true),
+					)
+				} else {
+					processEvents(ctx, t, tb,
+						makeBuildStartedOBE(t, "inv", "uuid-parity", "run", 1),
+						makeExecRequestConstructedOBE(t, "inv", 2, argv, "/wd", envMap, true),
+						makeBuildFinishedOBE(t, "inv", 3, 0, "SUCCESS"),
+					)
+				}
+
+				// Collect bazel.run.* attrs from whichever span carries them
+				// (root pre-flush, late span post-flush).
+				out := make(map[string]string)
+				collect := func(span ptrace.Span) {
+					span.Attributes().Range(func(k string, v pcommon.Value) bool {
+						if strings.HasPrefix(k, "bazel.run.") {
+							out[k] = v.AsString()
+						}
+						return true
+					})
+				}
+				collect(findRootSpan(t, sink))
+				for _, rs := range findRunSpans(t, sink) {
+					collect(rs)
+				}
+				return out
+			}
+
+			pre := runOne(t, false)
+			post := runOne(t, true)
+			assert.Equal(t, pre, post,
+				"bazel.run.* attribute set must be wire-order-independent at level %s", level)
+		})
+	}
+}
+
+// TestExecRequest_TruncationRecordsEmitted — argv / env / env-to-clear
+// truncation must surface as truncationRecord-driven Warn logs, matching
+// applyPatternAttrs / appendGarbageMetrics. Validates the late-path
+// emission via the observable logger.
+func TestExecRequest_TruncationRecordsEmitted(t *testing.T) {
+	core, observed := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, logger, TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true, IncludeRunEnvironment: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Drive each list past its cap so the late-path Warn loop fires for
+	// all three. Each derives from the configured cap so test stays in
+	// sync if caps move.
+	overArgv := maxRunArgvEntries + 50
+	overEnv := maxRunEnvEntries + 30
+	overClear := maxRunEnvClearEntries + 20
+	argv := make([]string, overArgv)
+	for i := range argv {
+		argv[i] = fmt.Sprintf("--arg%03d", i)
+	}
+	envMap := make(map[string]string, overEnv)
+	for i := range overEnv {
+		envMap[fmt.Sprintf("VAR_%03d", i)] = "v"
+	}
+	clearList := make([]string, overClear)
+	for i := range clearList {
+		clearList[i] = fmt.Sprintf("UNSET_%03d", i)
+	}
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-trunc", "uuid-trunc", "run", 1),
+		makeBuildFinishedOBE(t, "inv-trunc", 2, 0, "SUCCESS"),
+		makeExecRequestConstructedOBEFull(t, "inv-trunc", 3, argv, "", envMap, clearList, true),
+	)
+
+	// One Warn log per truncated attribute.
+	warns := observed.FilterMessage("Truncated bazel.run.* attribute").All()
+	gotAttrs := make(map[string]bool)
+	for _, e := range warns {
+		for _, f := range e.Context {
+			if f.Key == "attribute" {
+				gotAttrs[f.String] = true
+			}
+		}
+	}
+	assert.True(t, gotAttrs["bazel.run.argv"], "expected truncation Warn for bazel.run.argv")
+	assert.True(t, gotAttrs["bazel.run.environment"], "expected truncation Warn for bazel.run.environment")
+	assert.True(t, gotAttrs["bazel.run.environment_variable_to_clear"], "expected truncation Warn for bazel.run.environment_variable_to_clear")
+
+	// Always-on counts reflect the original payload size, not the cap.
+	runSpans := findRunSpans(t, sink)
+	require.Len(t, runSpans, 1)
+	root := runSpans[0]
+	argvCount, _ := root.Attributes().Get("bazel.run.argv_count")
+	assert.Equal(t, int64(overArgv), argvCount.Int())
+	envCount, _ := root.Attributes().Get("bazel.run.environment_variable_count")
+	assert.Equal(t, int64(overEnv), envCount.Int())
+	clearCount, _ := root.Attributes().Get("bazel.run.environment_variable_to_clear_count")
+	assert.Equal(t, int64(overClear), clearCount.Int())
+}
+
+// TestExecRequest_TruncationAccountingThreeNumbersAlign — when invalid
+// UTF-8 entries AND over-cap entries are both present, the three numbers
+// reviewers track must be mutually consistent:
+//
+//   - `bazel.run.*_count` attribute       = raw proto length
+//   - truncationRecord.original           = raw proto length (matches count)
+//   - truncationRecord.kept = slice.Len() = actually-emitted entries
+//
+// The gap (count - kept) is the operator's signal for "data dropped";
+// whether by cap or UTF-8 skip is a follow-up signal but not part of the
+// truncation contract itself.
+func TestExecRequest_TruncationAccountingThreeNumbersAlign(t *testing.T) {
+	core, observed := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, logger, TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true, IncludeRunEnvironment: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Build an argv with a few invalid-UTF-8 entries scattered through and
+	// the total over the cap. Same for env and env-to-clear.
+	const invalidEvery = 7
+	invalid := []byte{0xff, 0xfe}
+
+	overArgv := maxRunArgvEntries + 30
+	argvBytes := make([][]byte, overArgv)
+	for i := range argvBytes {
+		if i%invalidEvery == 0 {
+			argvBytes[i] = invalid
+		} else {
+			argvBytes[i] = fmt.Appendf(nil, "--arg%03d", i)
+		}
+	}
+
+	overEnv := maxRunEnvEntries + 20
+	envVars := make([]*bep.EnvironmentVariable, overEnv)
+	for i := range envVars {
+		if i%invalidEvery == 0 {
+			envVars[i] = &bep.EnvironmentVariable{Name: invalid, Value: []byte("v")}
+		} else {
+			envVars[i] = &bep.EnvironmentVariable{
+				Name:  fmt.Appendf(nil, "VAR_%03d", i),
+				Value: []byte("v"),
+			}
+		}
+	}
+
+	overClear := maxRunEnvClearEntries + 15
+	clearBytes := make([][]byte, overClear)
+	for i := range clearBytes {
+		if i%invalidEvery == 0 {
+			clearBytes[i] = invalid
+		} else {
+			clearBytes[i] = fmt.Appendf(nil, "UNSET_%03d", i)
+		}
+	}
+
+	// Drive the late path so handleExecRequestConstructed's Warn loop fires.
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-acct", "uuid-acct", "run", 1),
+		makeBuildFinishedOBE(t, "inv-acct", 2, 0, "SUCCESS"),
+		makeOrderedBuildEvent(t, "inv-acct", 3, &bep.BuildEvent{
+			Id: &bep.BuildEventId{Id: &bep.BuildEventId_ExecRequest{ExecRequest: &bep.BuildEventId_ExecRequestId{}}},
+			Payload: &bep.BuildEvent_ExecRequest{
+				ExecRequest: &bep.ExecRequestConstructed{
+					Argv:                       argvBytes,
+					EnvironmentVariable:        envVars,
+					EnvironmentVariableToClear: clearBytes,
+					ShouldExec:                 true,
+				},
+			},
+		}),
+	)
+
+	runSpans := findRunSpans(t, sink)
+	require.Len(t, runSpans, 1)
+	root := runSpans[0]
+
+	// Pull truncationRecord values out of the Warn log fields keyed by attribute.
+	type rec struct{ original, kept int64 }
+	got := map[string]rec{}
+	for _, e := range observed.FilterMessage("Truncated bazel.run.* attribute").All() {
+		var r rec
+		var attr string
+		for _, f := range e.Context {
+			switch f.Key {
+			case "attribute":
+				attr = f.String
+			case "original_count":
+				r.original = f.Integer
+			case "kept":
+				r.kept = f.Integer
+			}
+		}
+		got[attr] = r
+	}
+
+	// argv: count == original == raw proto length; kept == emitted slice length.
+	argvCount, _ := root.Attributes().Get("bazel.run.argv_count")
+	argvSlice, _ := root.Attributes().Get("bazel.run.argv")
+	assert.Equal(t, int64(overArgv), argvCount.Int(), "argv_count must equal raw proto length")
+	assert.Equal(t, int64(overArgv), got["bazel.run.argv"].original,
+		"argv truncationRecord.original must match argv_count")
+	assert.Equal(t, int64(argvSlice.Slice().Len()), got["bazel.run.argv"].kept,
+		"argv truncationRecord.kept must match emitted slice length")
+
+	// env: same.
+	envCount, _ := root.Attributes().Get("bazel.run.environment_variable_count")
+	envSlice, _ := root.Attributes().Get("bazel.run.environment")
+	assert.Equal(t, int64(overEnv), envCount.Int())
+	assert.Equal(t, int64(overEnv), got["bazel.run.environment"].original)
+	assert.Equal(t, int64(envSlice.Slice().Len()), got["bazel.run.environment"].kept)
+
+	// env-to-clear: same.
+	clearCount, _ := root.Attributes().Get("bazel.run.environment_variable_to_clear_count")
+	clearSlice, _ := root.Attributes().Get("bazel.run.environment_variable_to_clear")
+	assert.Equal(t, int64(overClear), clearCount.Int())
+	assert.Equal(t, int64(overClear), got["bazel.run.environment_variable_to_clear"].original)
+	assert.Equal(t, int64(clearSlice.Slice().Len()), got["bazel.run.environment_variable_to_clear"].kept)
+}
+
+// TestExecRequest_PreBuildStartedDropped — ExecRequestConstructed arriving
+// before the BuildStarted event for an invocation has no state to attach
+// to and must be silently dropped, matching every other handler.
+func TestExecRequest_PreBuildStartedDropped(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true, IncludeRunEnvironment: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeExecRequestConstructedOBE(t, "inv-orphan", 1,
+			[]string{"/bin/tool"}, "/wd",
+			map[string]string{"K": "v"}, true,
+		),
+	)
+
+	assert.Empty(t, sink.AllTraces(), "no traces should emit before BuildStarted")
+}
+
+// TestExecRequest_EnvironmentVariableToClear — proto field 4 is emitted
+// alongside environment when IncludeRunEnvironment is on, plus the
+// always-on count for parity with environment_variable_count.
+func TestExecRequest_EnvironmentVariableToClear(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeRunEnvironment: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-clr", "uuid-clr", "run", 1),
+		makeExecRequestConstructedOBEFull(t, "inv-clr", 2,
+			[]string{}, "",
+			map[string]string{"KEEP": "1"},
+			[]string{"PROXY", "AWS_SECRET", "PATH"},
+			true,
+		),
+		makeBuildFinishedOBE(t, "inv-clr", 3, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	clearCount, ok := root.Attributes().Get("bazel.run.environment_variable_to_clear_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(3), clearCount.Int())
+
+	clearList, ok := root.Attributes().Get("bazel.run.environment_variable_to_clear")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeSlice, clearList.Type())
+	require.Equal(t, 3, clearList.Slice().Len())
+	// Sorted.
+	assert.Equal(t, "AWS_SECRET", clearList.Slice().At(0).Str())
+	assert.Equal(t, "PATH", clearList.Slice().At(1).Str())
+	assert.Equal(t, "PROXY", clearList.Slice().At(2).Str())
+}
+
+// TestExecRequest_NonUTF8Skipped — non-UTF-8 bytes in argv/env must be
+// dropped before pdata sees them. OTLP/JSON exporters reject invalid
+// UTF-8 and that failure cascades the entire span batch, so silent skip
+// is the correct trade-off.
+func TestExecRequest_NonUTF8Skipped(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true, IncludeRunEnvironment: true, IncludeWorkingDir: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	// Construct payload directly so we control the bytes — \xff is the start
+	// of an illegal UTF-8 sequence.
+	invalid := []byte{0xff, 0xfe}
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-utf8", "uuid-utf8", "run", 1),
+		makeOrderedBuildEvent(t, "inv-utf8", 2, &bep.BuildEvent{
+			Id: &bep.BuildEventId{Id: &bep.BuildEventId_ExecRequest{ExecRequest: &bep.BuildEventId_ExecRequestId{}}},
+			Payload: &bep.BuildEvent_ExecRequest{
+				ExecRequest: &bep.ExecRequestConstructed{
+					Argv:             [][]byte{[]byte("/bin/ok"), invalid, []byte("--flag")},
+					WorkingDirectory: invalid,
+					EnvironmentVariable: []*bep.EnvironmentVariable{
+						{Name: []byte("OK"), Value: []byte("value")},
+						{Name: invalid, Value: []byte("v")},
+						{Name: []byte("BAD_VAL"), Value: invalid},
+					},
+					ShouldExec: true,
+				},
+			},
+		}),
+		makeBuildFinishedOBE(t, "inv-utf8", 3, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	// argv: invalid entry skipped, two valid kept.
+	argv, ok := root.Attributes().Get("bazel.run.argv")
+	require.True(t, ok)
+	require.Equal(t, 2, argv.Slice().Len())
+	assert.Equal(t, "/bin/ok", argv.Slice().At(0).Str())
+	assert.Equal(t, "--flag", argv.Slice().At(1).Str())
+
+	// working_directory: invalid → attribute absent.
+	_, hasWD := root.Attributes().Get("bazel.run.working_directory")
+	assert.False(t, hasWD, "invalid UTF-8 working_directory must be skipped")
+
+	// env: only the entry with both valid name AND value survives.
+	env, ok := root.Attributes().Get("bazel.run.environment")
+	require.True(t, ok)
+	require.Equal(t, 1, env.Slice().Len())
+	name, _ := env.Slice().At(0).Map().Get("name")
+	assert.Equal(t, "OK", name.Str())
+}
+
+// TestExecRequest_ArgvCappedAt200 — large argv is truncated to the cap.
+func TestExecRequest_ArgvCappedAt200(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeCommandArgs: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	const overCap = 250
+	argv := make([]string, overCap)
+	for i := range overCap {
+		argv[i] = fmt.Sprintf("--arg%03d", i)
+	}
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-cap", "uuid-cap", "run", 1),
+		makeExecRequestConstructedOBE(t, "inv-cap", 2, argv, "", nil, true),
+		makeBuildFinishedOBE(t, "inv-cap", 3, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	got, ok := root.Attributes().Get("bazel.run.argv")
+	require.True(t, ok)
+	assert.Equal(t, maxRunArgvEntries, got.Slice().Len(),
+		"argv must be capped at maxRunArgvEntries (%d) when input exceeds it", maxRunArgvEntries)
+}
+
+// TestExecRequest_EnvCapped — large env is truncated to the cap.
+func TestExecRequest_EnvCapped(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{
+		PII: PIIConfig{IncludeRunEnvironment: true},
+	})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	overCap := maxRunEnvEntries + 50
+	env := make(map[string]string, overCap)
+	for i := range overCap {
+		env[fmt.Sprintf("VAR_%03d", i)] = "v"
+	}
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-envcap", "uuid-envcap", "run", 1),
+		makeExecRequestConstructedOBE(t, "inv-envcap", 2, nil, "", env, true),
+		makeBuildFinishedOBE(t, "inv-envcap", 3, 0, "SUCCESS"),
+	)
+
+	root := findRootSpan(t, sink)
+	got, ok := root.Attributes().Get("bazel.run.environment")
+	require.True(t, ok)
+	assert.Equal(t, maxRunEnvEntries, got.Slice().Len(),
+		"environment must be capped at maxRunEnvEntries (%d) when input exceeds it", maxRunEnvEntries)
+
+	// The ALWAYS-ON count reflects the full payload, not the capped slice —
+	// operators see the truth even when the slice is clipped.
+	count, _ := root.Attributes().Get("bazel.run.environment_variable_count")
+	assert.Equal(t, int64(overCap), count.Int())
 }


### PR DESCRIPTION
Lands the review feedback that was prepared for #69 but did not reach `main` before the merge — plus the consensus P0/P1 list from #74's own review. The squash-merged #69 in main describes the pre-review-fix design (single PII gate, no `environment_variable_to_clear`, byte-boundary truncation, no UTF-8 validation, no late-path handling, silent argv/env truncation). This PR brings the implementation in line with the reviewers' agreed outcome.

## Review-driven fixes applied this round

**P0 (must fix before merge — codex held P0 for the cluster):**
- **Late-path span timestamps.** `lateRunSpan` now stamps a zero-width span at handler-time (`time.Now()`) — start == end, both non-zero. Previously the span had epoch timestamps, which OTLP backends interpret as 1970 and either reject or display as off-the-flamegraph. Mirrors the `populateFetchSpan` pattern.
- **Duplicate-event guard.** Bazel's BEP contract is one `ExecRequestConstructed` per invocation, but BES gRPC reconnect/replay can violate it. New `runEmitted bool` on `invocationState` gates the late-path branch — a duplicate post-flush event now logs Warn and drops, instead of emitting a second `bazel.run` span with the same SpanID (which downstream backends collapse or reject). Pre-flush re-stamping is naturally idempotent so no separate guard is needed there.

**P1 (3/3 reviewer consensus):**
- **Truncation records.** `applyExecRequestArgv`, `applyExecRequestEnv`, and `applyExecRequestEnvToClear` now thread `[]truncationRecord` through and append a record on cap. Pre-flush records ride `writeRootSpan`'s existing root-span Warn loop; post-flush records are logged from `handleExecRequestConstructed`. Matches the `applyPatternAttrs` / `appendGarbageMetrics` pattern.
- **`bazel.run.argv_count` (always-on).** Parallels `environment_variable_count` so operators see the raw argv payload size even when the slice is capped or `IncludeCommandArgs` is closed. All three count attributes now report pre-cap totals.
- **Post-flush log severity Debug → Info.** `handleExecRequestConstructed` logs the late-path emission at Info (visible in production) instead of Debug (suppressed). Truncations during late emission also log at Warn.

**P2 (consensus polish):**
- **Wire-order parity test.** New `TestExecRequest_WireOrderParity` runs the same payload through both pre-flush and post-flush wire orders × {drop, build_only, targets, verbose} and asserts byte-identical `bazel.run.*` output — formalizes the design choice that `bazel.run` is filter-exempt because it carries displaced root-span data. A symmetric receiver-wide `allowRun()` gate is tracked separately as a follow-up; opening would create wire-order-dependent output, which is strictly worse.
- **`findRunSpans` test helper.** Replaces the hand-rolled four-level pdata iteration in `TestExecRequest_LatePostFlush`. Same shape as `findFetchSpans`.
- **`TestExecRequest_LatePostFlush` asserts SpanID identity** (`spanIDFromIdentity(uuid, "run")`) and **non-zero zero-width timestamps** — would have caught the P0 bugs immediately.
- **`TestExecRequest_LateDuplicateDropped`.** Regression guard for the new `runEmitted` flag.
- **`TestExecRequest_TruncationRecordsEmitted`.** Asserts the Warn-log contract via `zaptest/observer`, parallel to existing pattern-truncation tests.
- **Cap rationale.** Comment on `maxRunArgvEntries` / `maxRunEnvEntries` / `maxRunEnvClearEntries` cites observed shapes ("argv rarely exceeds 150 entries; OS-typical env has 30-100 entries").
- **Per-value 256-byte truncation documented** in `docs/attributes.md` (attribute table footer covers argv strings, env names/values, working_directory, env-to-clear names).
- **`env_count` Debug log key renamed** to `env_var_count` for parity with `env_to_clear_count`.

## Lifted from #69 review (already in this PR pre-#74-review)

- Late post-flush handling via `lateRunSpan` (against silent drop)
- `environment_variable_to_clear` emitted with always-on count
- `IncludeRunEnvironment` PII gate split from `IncludeCommandArgs`
- UTF-8 validation on every bytes→string cast
- argv/env caps + per-value `truncateAttrValue`
- Server-side env sort

## Tests

12 new across the two review rounds: late post-flush (existing), pre-`BuildStarted` drop, `environment_variable_to_clear`, non-UTF-8 skipped, argv-cap, env-cap, `IncludeCommandArgs`-only, `IncludeRunEnvironment`-only, late-duplicate dropped, wire-order parity (4 sub-cases), truncation records emitted. Total `receiver/besreceiver` count: **354**.

## Deferred to follow-ups

- `bes_receiver_late_run_spans_total` metric (new counter, separate concern from the trace path).
- Receiver-wide `allowRun()` symmetric filter gate. Single-side gating would create wire-order-dependent output; the test asserting parity is the placeholder until a coherent design lands.
- Cap-consts colocation across `attrs.go` (file-wide `maxAttrValueLen`) and `invocation.go` (per-feature caps). Cosmetic.

Cross-references #69 (the original feature) and the review summaries at `/tmp/besreceiver-reviews/pr-69-review.md` and `/tmp/besreceiver-reviews/pr-74-review.md`.