### PR TITLE
fix(besreceiver): correct PatternExpanded semantics and surface pattern_skipped

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -57,7 +57,8 @@ without `BuildFinished`, from the reaper path.
 | `bazel.run.environment`                         | Slice[Map]         | `ExecRequestConstructed.environment_variable` (only on `bazel run`) — `{name, value}` entries sorted by name, capped at 50; **PII**, requires `include_run_environment` |
 | `bazel.run.environment_variable_to_clear`       | Slice[string]      | `ExecRequestConstructed.environment_variable_to_clear` — env names Bazel will unset before exec; sorted, capped at 50; **PII**, requires `include_run_environment` |
 | `bazel.run.should_exec`                         | bool               | `ExecRequestConstructed.should_exec` (only on `bazel run`) — `false` means Bazel wrote a script via `--script_path` instead of execing |
-| `bazel.patterns`                                | Slice[Map]         | `PatternExpanded` — one entry per requested pattern: `{pattern, target_count}`. Aggregated across events; capped by `high_cardinality_caps.patterns` (default 50). |
+| `bazel.patterns`                                | Slice[Map]         | `PatternExpanded` (id `pattern`) — one entry per successfully expanded pattern: `{pattern, target_count}`. `target_count` counts only `TargetConfigured` children. Aggregated across events; capped by `high_cardinality_caps.patterns` (default 50). |
+| `bazel.patterns_skipped`                        | Slice[string]      | `PatternExpanded` (id `pattern_skipped`) — patterns Bazel reported as skipped under `--keep_going`. No `target_count` (skipped patterns did not expand). Sorted, deduplicated; shares the `high_cardinality_caps.patterns` cap. |
 
 The `bazel.run.*` group is populated only for `bazel run` invocations, where
 Bazel emits `ExecRequestConstructed` after the build succeeds and before the
@@ -89,14 +90,30 @@ emits a Warn log with `invocation_id`, `attribute`, `original_count`, and
 Non-UTF-8 entries are silently skipped to avoid OTLP/JSON exporter rejection.
 
 `bazel.patterns` captures what the user asked for: e.g. a `bazel test //...`
-invocation that fans out to 1,400 tests emits a single entry
-`{pattern: "//...", target_count: 1400}`. Patterns are aggregated by
-pattern string across multiple `PatternExpanded` events (unlikely in
-practice, but preserved for correctness). Empty pattern strings and
-zero-target expansions are skipped; when no `PatternExpanded` event
-arrives the attribute is absent entirely. Exceeding
+invocation whose top-level pattern resolves to a few hundred test targets
+emits one entry `{pattern: "//...", target_count: <N>}` where `N` is the
+number of `TargetConfigured` children Bazel reports for the expansion (the
+exact count of targets the receiver will see — not necessarily the count of
+test cases that ran, since each target can fan out at runtime). Nested
+`PatternExpanded` ids and `UnconfiguredLabel` failure markers among the
+event's children are excluded from `target_count`. Patterns are aggregated
+by pattern string across multiple `PatternExpanded` events. The rare
+multi-pattern event (one BEP event carrying N>1 patterns) has no
+per-pattern attribution in the proto, so its `target_count` is divided
+evenly across the non-empty patterns (`floor(targetCount / N)`); single-
+pattern events — Bazel's dominant case — keep the exact count. Empty
+pattern strings and zero-target expansions are skipped; when no
+`PatternExpanded` event arrives the attribute is absent entirely. Exceeding
 `high_cardinality_caps.patterns` truncates in sorted pattern order and
 emits a Warn log with the invocation id, original count, and kept count.
+
+`bazel.patterns_skipped` records pattern strings carried on `pattern_skipped`
+ids — Bazel emits these for parts of a top-level pattern whose expansion
+was skipped, typically under `--keep_going` after an earlier failure. They
+have no `target_count` (skipped patterns did not resolve to targets). The
+attribute is a deduplicated `Slice[string]` aggregated across events;
+absent when no skipped expansions arrived. The cap is shared with
+`bazel.patterns` so operators tune one knob.
 
 Key sanitization for `bazel.workspace.*` and `bazel.metadata.*`: lowercase,
 collapse whitespace to `_`, strip characters outside `[a-z0-9_.]`, trim

--- a/receiver/besreceiver/invocation.go
+++ b/receiver/besreceiver/invocation.go
@@ -93,6 +93,13 @@ type invocationState struct {
 	// writeRootSpan. Capped at caps.Patterns entries with a warning log.
 	patterns map[string]int64
 
+	// patternsSkipped buffers the set of patterns Bazel reported via
+	// pattern_skipped ids (--keep_going partial expansions). Keyed for
+	// dedup; emitted as bazel.patterns_skipped Slice[string] on the root
+	// span. Reuses caps.Patterns for the limit — same magnitude as
+	// patterns and operators tune one knob.
+	patternsSkipped map[string]struct{}
+
 	// configurations maps config id → Configuration payload. Populated by
 	// handleConfiguration so handleTargetConfigured can stamp config attrs
 	// on the target span at creation time. No back-patching: if a
@@ -572,6 +579,7 @@ func (s *invocationState) writeRootSpan(finished *bep.BuildFinished) []truncatio
 	}
 
 	truncs = s.applyPatternAttrs(span, truncs)
+	truncs = s.applyPatternsSkippedAttrs(span, truncs)
 	return truncs
 }
 
@@ -904,17 +912,37 @@ func (s *invocationState) addBuildMetadata(md map[string]string) {
 // addPatternExpanded aggregates a PatternExpanded event onto the invocation
 // state for emission as bazel.patterns on the root span. patterns is the
 // list of pattern strings from BuildEventId_PatternExpandedId (a single BEP
-// event may carry multiple patterns); targetCount is the number of targets
-// the expansion resolved to (len of the event's children). Empty patterns
-// and zero-target expansions are skipped. Aggregation sums target_count for
-// duplicate pattern keys. The cap is enforced at emission time in
-// applyPatternAttrs, not here, so late-arriving low-cardinality aggregates
-// aren't silently dropped.
+// event may carry multiple patterns); targetCount is the number of
+// TargetConfigured children on the event. Empty patterns and zero-target
+// expansions are skipped.
+//
+// Multi-pattern events have no per-pattern attribution in the proto, so the
+// count is divided evenly across the event's non-empty patterns
+// (floor(targetCount / N)). The per-event sum across the slice never
+// exceeds targetCount, eliminating the N×M inflation an earlier
+// implementation produced. Single-pattern events — Bazel's dominant case —
+// keep the exact count. Same-key contributions across events are summed.
+//
+// The cap is enforced at emission time in applyPatternAttrs, not here, so
+// late-arriving low-cardinality aggregates aren't silently dropped.
 func (s *invocationState) addPatternExpanded(patterns []string, targetCount int64) {
 	if s.flushed {
 		return
 	}
 	if targetCount <= 0 {
+		return
+	}
+	nonEmpty := 0
+	for _, p := range patterns {
+		if p != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty == 0 {
+		return
+	}
+	share := targetCount / int64(nonEmpty)
+	if share == 0 {
 		return
 	}
 	if s.patterns == nil {
@@ -924,7 +952,27 @@ func (s *invocationState) addPatternExpanded(patterns []string, targetCount int6
 		if p == "" {
 			continue
 		}
-		s.patterns[p] += targetCount
+		s.patterns[p] += share
+	}
+}
+
+// addPatternsSkipped records pattern strings carried on a pattern_skipped
+// event id. Bazel emits these for parts of a pattern whose expansion was
+// skipped under --keep_going. Empty strings are dropped. The cap is
+// enforced at emission time in applyPatternsSkippedAttrs (shares
+// caps.Patterns with bazel.patterns).
+func (s *invocationState) addPatternsSkipped(patterns []string) {
+	if s.flushed {
+		return
+	}
+	if s.patternsSkipped == nil {
+		s.patternsSkipped = make(map[string]struct{})
+	}
+	for _, p := range patterns {
+		if p == "" {
+			continue
+		}
+		s.patternsSkipped[p] = struct{}{}
 	}
 }
 
@@ -1149,6 +1197,42 @@ func (s *invocationState) applyPatternAttrs(span ptrace.Span, truncs []truncatio
 	if kept < original {
 		truncs = append(truncs, truncationRecord{
 			attribute: "bazel.patterns",
+			original:  original,
+			kept:      kept,
+		})
+	}
+	return truncs
+}
+
+// applyPatternsSkippedAttrs emits bazel.patterns_skipped as a Slice[string]
+// on the root span from buffered pattern_skipped ids. Patterns are sorted
+// for stable truncation; the cap is shared with bazel.patterns. Absent when
+// no pattern_skipped events arrived.
+func (s *invocationState) applyPatternsSkippedAttrs(span ptrace.Span, truncs []truncationRecord) []truncationRecord {
+	if len(s.patternsSkipped) == 0 {
+		return truncs
+	}
+	keys := make([]string, 0, len(s.patternsSkipped))
+	for k := range s.patternsSkipped {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	limit := s.caps.withDefaults().Patterns
+	original := len(keys)
+	kept := original
+	if limit > 0 && original > limit {
+		keys = keys[:limit]
+		kept = limit
+	}
+
+	slice := span.Attributes().PutEmptySlice("bazel.patterns_skipped")
+	for _, k := range keys {
+		slice.AppendEmpty().SetStr(k)
+	}
+	if kept < original {
+		truncs = append(truncs, truncationRecord{
+			attribute: "bazel.patterns_skipped",
 			original:  original,
 			kept:      kept,
 		})

--- a/receiver/besreceiver/patterns_test.go
+++ b/receiver/besreceiver/patterns_test.go
@@ -61,7 +61,7 @@ func TestPatternExpanded_SingleEvent_ProducesOneEntry(t *testing.T) {
 	assert.Equal(t, int64(3), entries["//foo/..."])
 }
 
-func TestPatternExpanded_MultiplePatterns_EmitsEntryPerPattern(t *testing.T) {
+func TestPatternExpanded_MultiplePatterns_EvenSplitsTargetCount(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
 	tb.Start()
@@ -70,8 +70,12 @@ func TestPatternExpanded_MultiplePatterns_EmitsEntryPerPattern(t *testing.T) {
 
 	processEvents(ctx, t, tb,
 		makeBuildStartedOBE(t, "inv-pat-multi", "uuid-pat-multi", "build", 1),
-		// One event carrying two patterns — each gets target_count=2.
-		makePatternExpandedOBE(t, "inv-pat-multi", 2, []string{"//a/...", "//b/..."}, 2),
+		// One event with two patterns and 4 TargetConfigured children. The
+		// proto carries no per-pattern attribution, so the receiver divides
+		// evenly: floor(4/2)=2 per pattern. Per-event sum equals the child
+		// count (no N×M inflation across the slice).
+		makePatternExpandedOBE(t, "inv-pat-multi", 2, []string{"//a/...", "//b/..."}, 4),
+		// Single-pattern events keep the exact count.
 		makePatternExpandedOBE(t, "inv-pat-multi", 3, []string{"//c:tgt"}, 1),
 		makeBuildFinishedOBE(t, "inv-pat-multi", 4, 0, "SUCCESS"),
 	)
@@ -84,6 +88,92 @@ func TestPatternExpanded_MultiplePatterns_EmitsEntryPerPattern(t *testing.T) {
 		"//b/...": 2,
 		"//c:tgt": 1,
 	}, entries)
+}
+
+// TestPatternExpanded_NonTargetConfiguredChildren_NotCounted verifies that
+// only TargetConfigured ids contribute to target_count. PatternExpanded
+// children of nested patterns and unconfigured-label children (failure
+// markers) must not inflate the count of resolved targets.
+func TestPatternExpanded_NonTargetConfiguredChildren_NotCounted(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-mixed", "uuid-pat-mixed", "build", 1),
+		// 3 TargetConfigured + 2 nested-pattern + 4 unconfigured-label children.
+		// Only the 3 TargetConfigured ids count toward target_count.
+		makePatternExpandedMixedChildrenOBE(t, "inv-pat-mixed", 2, []string{"//top/..."}, 3, 2, 4),
+		makeBuildFinishedOBE(t, "inv-pat-mixed", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok)
+	assert.Equal(t, map[string]int64{"//top/...": 3}, entries)
+}
+
+// TestPatternExpanded_PatternSkipped_EmitsSkippedAttribute verifies that
+// pattern_skipped events route to bazel.patterns_skipped (not bazel.patterns)
+// — Bazel emits these under --keep_going for patterns whose expansion was
+// skipped. They have no target_count by definition.
+func TestPatternExpanded_PatternSkipped_EmitsSkippedAttribute(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-skipped", "uuid-pat-skipped", "test", 1),
+		makePatternExpandedOBE(t, "inv-pat-skipped", 2, []string{"//ok/..."}, 2),
+		makePatternSkippedOBE(t, "inv-pat-skipped", 3, []string{"//missing/..."}),
+		makePatternSkippedOBE(t, "inv-pat-skipped", 4, []string{"//also/missing"}),
+		makeBuildFinishedOBE(t, "inv-pat-skipped", 5, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok, "expected bazel.patterns for the successful expansion")
+	assert.Equal(t, map[string]int64{"//ok/...": 2}, entries)
+
+	skipped, sok := span.Attributes().Get("bazel.patterns_skipped")
+	require.True(t, sok, "expected bazel.patterns_skipped attribute")
+	require.Equal(t, pcommon.ValueTypeSlice, skipped.Type())
+	got := make([]string, 0, skipped.Slice().Len())
+	for i := range skipped.Slice().Len() {
+		got = append(got, skipped.Slice().At(i).Str())
+	}
+	assert.ElementsMatch(t, []string{"//missing/...", "//also/missing"}, got)
+}
+
+// TestPatternExpanded_PatternSkippedOnly_NoPatternsAttribute verifies that
+// when only pattern_skipped events arrive (no successful expansions), the
+// bazel.patterns attribute is absent — skipped patterns alone do not
+// promise any targets ran.
+func TestPatternExpanded_PatternSkippedOnly_NoPatternsAttribute(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-skip-only", "uuid-pat-skip-only", "build", 1),
+		makePatternSkippedOBE(t, "inv-pat-skip-only", 2, []string{"//gone/..."}),
+		makeBuildFinishedOBE(t, "inv-pat-skip-only", 3, 0, "SUCCESS"),
+	)
+
+	span := findRootSpan(t, sink)
+	_, ok := span.Attributes().Get("bazel.patterns")
+	assert.False(t, ok, "bazel.patterns must be absent when no successful expansions arrived")
+	skipped, sok := span.Attributes().Get("bazel.patterns_skipped")
+	require.True(t, sok)
+	require.Equal(t, pcommon.ValueTypeSlice, skipped.Type())
+	require.Equal(t, 1, skipped.Slice().Len())
+	assert.Equal(t, "//gone/...", skipped.Slice().At(0).Str())
 }
 
 func TestPatternExpanded_RepeatedPattern_AggregatesTargetCount(t *testing.T) {
@@ -190,6 +280,35 @@ func TestPatternExpanded_OverCap_TruncatedWithWarning(t *testing.T) {
 	assert.Equal(t, "bazel.patterns", fields["attribute"])
 	assert.Equal(t, int64(5), fields["original_count"])
 	assert.Equal(t, int64(3), fields["kept"])
+}
+
+// TestPatternExpanded_PostFlush_Dropped verifies that a PatternExpanded
+// event arriving after the root span has been flushed (between
+// BuildFinished and BuildMetrics, when state.flushed is set) does not
+// retroactively mutate bazel.patterns. The receiver follows the
+// workspace_status / build_metadata buffering policy: pre-finalize-only.
+func TestPatternExpanded_PostFlush_Dropped(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	tb := NewTraceBuilder(sink, nil, nil, zap.NewNop(), TraceBuilderConfig{})
+	tb.Start()
+	defer tb.Stop()
+	ctx := context.Background()
+
+	processEvents(ctx, t, tb,
+		makeBuildStartedOBE(t, "inv-pat-postflush", "uuid-pat-postflush", "build", 1),
+		makePatternExpandedOBE(t, "inv-pat-postflush", 2, []string{"//pre"}, 2),
+		makeBuildFinishedOBE(t, "inv-pat-postflush", 3, 0, "SUCCESS"),
+		// Arrives after finalize; must not appear in bazel.patterns.
+		makePatternExpandedOBE(t, "inv-pat-postflush", 4, []string{"//post"}, 5),
+		makePatternSkippedOBE(t, "inv-pat-postflush", 5, []string{"//also-post"}),
+	)
+
+	span := findRootSpan(t, sink)
+	entries, ok := patternEntries(t, span)
+	require.True(t, ok)
+	assert.Equal(t, map[string]int64{"//pre": 2}, entries)
+	_, sok := span.Attributes().Get("bazel.patterns_skipped")
+	assert.False(t, sok, "post-flush pattern_skipped must not retro-stamp the root span")
 }
 
 func TestPatternExpanded_DefaultCapIs50(t *testing.T) {

--- a/receiver/besreceiver/testhelpers_test.go
+++ b/receiver/besreceiver/testhelpers_test.go
@@ -165,7 +165,7 @@ func makeBuildMetadataOBE(t testing.TB, invID string, seqNum int64, entries map[
 // id (BuildEventId.pattern.pattern); targetCount is the number of synthetic
 // TargetConfigured children used to represent how many targets the
 // expansion resolved to. Child labels are irrelevant — the receiver only
-// counts them.
+// counts TargetConfigured children.
 func makePatternExpandedOBE(t testing.TB, invID string, seqNum int64, patterns []string, targetCount int) *pb.OrderedBuildEvent {
 	t.Helper()
 	children := make([]*bep.BuildEventId, 0, targetCount)
@@ -185,6 +185,71 @@ func makePatternExpandedOBE(t testing.TB, invID string, seqNum int64, patterns [
 			},
 		},
 		Children: children,
+		Payload: &bep.BuildEvent_Expanded{
+			Expanded: &bep.PatternExpanded{},
+		},
+	})
+}
+
+// makePatternExpandedMixedChildrenOBE builds a PatternExpanded event whose
+// children mix TargetConfigured ids with other id shapes (nested
+// PatternExpanded, UnconfiguredLabel). Used to verify the receiver counts
+// only TargetConfigured children when stamping target_count.
+func makePatternExpandedMixedChildrenOBE(t testing.TB, invID string, seqNum int64, patterns []string, targetConfiguredCount, nestedPatternCount, unconfiguredLabelCount int) *pb.OrderedBuildEvent {
+	t.Helper()
+	children := make([]*bep.BuildEventId, 0, targetConfiguredCount+nestedPatternCount+unconfiguredLabelCount)
+	for i := range targetConfiguredCount {
+		children = append(children, &bep.BuildEventId{
+			Id: &bep.BuildEventId_TargetConfigured{
+				TargetConfigured: &bep.BuildEventId_TargetConfiguredId{
+					Label: fmt.Sprintf("//pattern_child:tc%d", i),
+				},
+			},
+		})
+	}
+	for i := range nestedPatternCount {
+		children = append(children, &bep.BuildEventId{
+			Id: &bep.BuildEventId_Pattern{
+				Pattern: &bep.BuildEventId_PatternExpandedId{
+					Pattern: []string{fmt.Sprintf("//nested%d/...", i)},
+				},
+			},
+		})
+	}
+	for i := range unconfiguredLabelCount {
+		children = append(children, &bep.BuildEventId{
+			Id: &bep.BuildEventId_UnconfiguredLabel{
+				UnconfiguredLabel: &bep.BuildEventId_UnconfiguredLabelId{
+					Label: fmt.Sprintf("//pattern_child:un%d", i),
+				},
+			},
+		})
+	}
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_Pattern{
+				Pattern: &bep.BuildEventId_PatternExpandedId{Pattern: patterns},
+			},
+		},
+		Children: children,
+		Payload: &bep.BuildEvent_Expanded{
+			Expanded: &bep.PatternExpanded{},
+		},
+	})
+}
+
+// makePatternSkippedOBE builds a PatternExpanded payload riding on a
+// pattern_skipped id (Bazel emits this for parts of a pattern skipped under
+// --keep_going). The children list is irrelevant — skipped patterns by
+// definition did not expand to runnable targets.
+func makePatternSkippedOBE(t testing.TB, invID string, seqNum int64, patterns []string) *pb.OrderedBuildEvent {
+	t.Helper()
+	return makeOrderedBuildEvent(t, invID, seqNum, &bep.BuildEvent{
+		Id: &bep.BuildEventId{
+			Id: &bep.BuildEventId_PatternSkipped{
+				PatternSkipped: &bep.BuildEventId_PatternExpandedId{Pattern: patterns},
+			},
+		},
 		Payload: &bep.BuildEvent_Expanded{
 			Expanded: &bep.PatternExpanded{},
 		},

--- a/receiver/besreceiver/tracebuilder.go
+++ b/receiver/besreceiver/tracebuilder.go
@@ -358,7 +358,7 @@ func (tb *TraceBuilder) processEvent(ctx context.Context, invocations map[string
 
 // eventTypeName returns a short name for the BEP event type, used as a metric attribute.
 //
-//nolint:gocyclo // Flat payload dispatch mirrors processEvent; grows with handled types.
+//nolint:gocyclo,cyclop // Flat payload dispatch mirrors processEvent; grows with handled types.
 func eventTypeName(event *bep.BuildEvent) string {
 	switch event.GetPayload().(type) {
 	case *bep.BuildEvent_Started:
@@ -396,6 +396,13 @@ func eventTypeName(event *bep.BuildEvent) string {
 	case *bep.BuildEvent_Fetch:
 		return "fetch"
 	case *bep.BuildEvent_Expanded:
+		// PatternExpanded payloads ride on one of two id shapes; surface them
+		// as distinct event_type labels so bes.events.processed counts them
+		// separately. Other Expanded id-shape combinations (none defined
+		// today) fall back to the generic label.
+		if event.GetId().GetPatternSkipped() != nil {
+			return "pattern_skipped"
+		}
 		return "pattern_expanded"
 	default:
 		return "other"
@@ -680,20 +687,40 @@ func (tb *TraceBuilder) handleWorkspaceStatus(_ context.Context, invocations map
 	return nil
 }
 
-// handlePatternExpanded aggregates a PatternExpanded event onto the
-// invocation state for later emission as bazel.patterns on the root span.
-// Pattern strings come from BuildEventId.pattern.pattern (repeated); the
-// target count is the number of children on the event — each child is a
-// target/pattern the expansion resolved to. Empty pattern lists and zero-
-// target expansions are dropped. Post-flush arrivals are ignored (matches
-// the buffering semantics of workspace_status / build_metadata).
+// handlePatternExpanded routes PatternExpanded payloads to the invocation
+// state. The payload rides on one of two id shapes:
+//
+//   - id.pattern → the patterns successfully expanded; aggregated as
+//     bazel.patterns {pattern, target_count}. target_count is the number of
+//     TargetConfigured children only (nested patterns and unconfigured-label
+//     failure markers do not count as resolved targets).
+//   - id.pattern_skipped → patterns Bazel skipped under --keep_going;
+//     aggregated as bazel.patterns_skipped (Slice[string]). No target_count
+//     because skipped patterns by definition did not expand to targets.
+//
+// Empty pattern strings and zero-target expansions are dropped. Post-flush
+// arrivals are ignored (matches workspace_status / build_metadata).
 func (tb *TraceBuilder) handlePatternExpanded(_ context.Context, invocations map[string]*invocationState, invocationID string, event *bep.BuildEvent) error {
 	state := invocations[invocationID]
 	if state == nil {
 		return nil
 	}
-	patterns := event.GetId().GetPattern().GetPattern()
-	targetCount := int64(len(event.GetChildren()))
+	id := event.GetId()
+	if skipped := id.GetPatternSkipped(); skipped != nil {
+		state.addPatternsSkipped(skipped.GetPattern())
+		tb.logger.Debug("Pattern skipped",
+			zap.String("invocation_id", invocationID),
+			zap.Int("patterns", len(skipped.GetPattern())),
+		)
+		return nil
+	}
+	patterns := id.GetPattern().GetPattern()
+	var targetCount int64
+	for _, child := range event.GetChildren() {
+		if child.GetTargetConfigured() != nil {
+			targetCount++
+		}
+	}
 	state.addPatternExpanded(patterns, targetCount)
 	tb.logger.Debug("Pattern expanded",
 		zap.String("invocation_id", invocationID),


### PR DESCRIPTION
## Summary

Three P0 corrections to `bazel.patterns` from the post-merge review of #71.

- **`target_count` now filters to `TargetConfigured` children.** Previously `len(children)` counted nested `PatternExpanded` ids and `UnconfiguredLabel` failure markers, inflating the reported count of resolved targets.
- **Multi-pattern events even-split `target_count`** across the event's non-empty patterns (`floor(M/N)`). The proto carries no per-pattern attribution; the prior code stamped the full count to each pattern, summing to `N×M` across the slice. Single-pattern events — Bazel's dominant case — keep the exact count. Eliminates the inflation that the prior multi-pattern test had cemented as the contract.
- **`pattern_skipped` events surface as a new `bazel.patterns_skipped` `Slice[string]`** on the root span instead of being silently dropped. Bazel emits these under `--keep_going` for parts of a top-level pattern whose expansion was skipped. `eventTypeName` distinguishes them so `bes.events.processed` no longer conflates the two id shapes.

`docs/attributes.md` drops the misleading "1,400 tests" example and documents the new even-split + filter semantics plus the new attribute.

## Why this approach

Multi-pattern events are rare (Bazel emits one `PatternExpanded` per top-level pattern in practice), and the proto offers no per-pattern attribution within them. Even-split keeps the slice shape stable, makes the per-event sum match the child count, and gives an exact answer for the common case. Reusing `caps.Patterns` for `bazel.patterns_skipped` keeps operator tuning to one knob.

## Test plan
- [x] `make build`
- [x] `make vet`
- [x] `make test` — 360 tests, 4 new + 1 renamed/updated
  - `TestPatternExpanded_NonTargetConfiguredChildren_NotCounted`
  - `TestPatternExpanded_PatternSkipped_EmitsSkippedAttribute`
  - `TestPatternExpanded_PatternSkippedOnly_NoPatternsAttribute`
  - `TestPatternExpanded_PostFlush_Dropped`
  - `TestPatternExpanded_MultiplePatterns_EvenSplitsTargetCount` (renamed, semantics inverted from prior assertion)
- [x] `make lint`

Refs #62, follow-up to #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)