### PR TITLE
chore(tooling): add prek pre-commit + pre-push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,28 @@ repos:
 
   - repo: local
     hooks:
+      # Fast path: lint only the packages of staged Go files (per-commit).
       - id: golangci-lint
         name: golangci-lint (changed packages)
         description: Lint Go packages whose files are staged.
         language: system
         types: [go]
+        stages: [pre-commit]
         # examples/bazel-project/ is a separate Go module (own go.mod);
         # exclude it so the root-module linter doesn't see foreign packages.
         exclude: ^examples/bazel-project/
         pass_filenames: true
         require_serial: true
         entry: scripts/precommit-golangci-lint.sh
+
+      # Slow path: lint the whole root module before pushing. Mirrors CI.
+      - id: golangci-lint-full
+        name: golangci-lint (full module)
+        description: Run golangci-lint over ./... before pushing.
+        language: system
+        types: [go]
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true
+        require_serial: true
+        entry: golangci-lint run ./...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Fast-path pre-commit hooks. Run via `prek` (drop-in for pre-commit):
+#   make precommit-install   # installs prek and wires up .git/hooks/pre-commit
+#   make precommit           # runs all hooks against every file
+#
+# Scope: only staged Go files / their packages. Authoritative lint+test pass
+# lives in CI (.github/workflows/ci.yml) — keep this loop fast.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: mixed-line-ending
+
+  - repo: local
+    hooks:
+      - id: golangci-lint
+        name: golangci-lint (changed packages)
+        description: Lint Go packages whose files are staged.
+        language: system
+        types: [go]
+        # examples/bazel-project/ is a separate Go module (own go.mod);
+        # exclude it so the root-module linter doesn't see foreign packages.
+        exclude: ^examples/bazel-project/
+        pass_filenames: true
+        require_serial: true
+        entry: scripts/precommit-golangci-lint.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,14 @@ make generate   # buf generate third_party/bazel/protobuf (regenerate Go code fr
 make ocb        # build custom collector binary with OCB
 make docker     # docker build
 
-make pre-commit-install  # install prek + wire up git pre-commit hook
-make pre-commit          # run all pre-commit hooks against every file
+make pre-commit-install  # install prek + wire up git pre-commit and pre-push hooks
+make pre-commit          # run pre-commit-stage hooks (fast: changed packages)
+make pre-push            # run pre-push-stage hooks (slow: full module lint)
 ```
 
-Pre-commit is fast-path: lints only packages of staged Go files
-(`scripts/precommit-golangci-lint.sh`). CI remains the authoritative
-full-module pass.
+Two-stage setup: `pre-commit` lints only packages of staged Go files
+(`scripts/precommit-golangci-lint.sh`); `pre-push` runs `golangci-lint run ./...`
+over the root module before pushing. CI remains the authoritative pass.
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,14 @@ make tidy       # go mod tidy
 make generate   # buf generate third_party/bazel/protobuf (regenerate Go code from protos)
 make ocb        # build custom collector binary with OCB
 make docker     # docker build
+
+make pre-commit-install  # install prek + wire up git pre-commit hook
+make pre-commit          # run all pre-commit hooks against every file
 ```
+
+Pre-commit is fast-path: lints only packages of staged Go files
+(`scripts/precommit-golangci-lint.sh`). CI remains the authoritative
+full-module pass.
 
 ## Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build test test-short test-cover test-bench test-e2e lint vet clean fuzz fix generate ocb ci docker \
        compose-build compose-up compose-down compose-clean example record record-fixtures agent-status nilaway deadcode changelog \
-       install uninstall
+       install uninstall pre-commit-install pre-commit
 
 # Use absolute path: GNU Make 3.81 (macOS default) doesn't propagate export PATH to recipe shells.
 GOTESTSUM := $(shell go env GOPATH)/bin/gotestsum
@@ -146,3 +146,12 @@ install:
 ## uninstall: Remove the besreceiver service, binary, and config (pass CONFIRM=1 to actually remove)
 uninstall:
 	sudo packaging/uninstall.sh $(if $(CONFIRM),--yes,) $(UNINSTALL_ARGS)
+
+## pre-commit-install: Install prek and wire up the git pre-commit hook
+pre-commit-install:
+	@command -v prek >/dev/null || cargo binstall --locked prek
+	prek install
+
+## pre-commit: Run pre-commit hooks against all files (CI-equivalent)
+pre-commit:
+	prek run --all-files

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build test test-short test-cover test-bench test-e2e lint vet clean fuzz fix generate ocb ci docker \
        compose-build compose-up compose-down compose-clean example record record-fixtures agent-status nilaway deadcode changelog \
-       install uninstall pre-commit-install pre-commit
+       install uninstall pre-commit-install pre-commit pre-push
 
 # Use absolute path: GNU Make 3.81 (macOS default) doesn't propagate export PATH to recipe shells.
 GOTESTSUM := $(shell go env GOPATH)/bin/gotestsum
@@ -147,11 +147,15 @@ install:
 uninstall:
 	sudo packaging/uninstall.sh $(if $(CONFIRM),--yes,) $(UNINSTALL_ARGS)
 
-## pre-commit-install: Install prek and wire up the git pre-commit hook
+## pre-commit-install: Install prek and wire up the git pre-commit + pre-push hooks
 pre-commit-install:
 	@command -v prek >/dev/null || cargo binstall --locked prek
-	prek install
+	prek install --hook-type pre-commit --hook-type pre-push
 
-## pre-commit: Run pre-commit hooks against all files (CI-equivalent)
+## pre-commit: Run pre-commit-stage hooks against all files (fast path)
 pre-commit:
 	prek run --all-files
+
+## pre-push: Run pre-push-stage hooks against all files (slow path; full-module lint)
+pre-push:
+	prek run --all-files --hook-stage pre-push

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ make test-bench # Run benchmarks
 make fuzz       # Run fuzz tests
 ```
 
+Optional: install the [prek](https://github.com/j178/prek) git hook to lint
+staged Go packages on every commit (CI remains the source of truth):
+
+```bash
+make pre-commit-install   # cargo binstall prek + prek install
+make pre-commit           # run all hooks against every file
+```
+
 ## Documentation
 
 - [Architecture](docs/architecture.md) -- system overview, internal components, and span hierarchy

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ make test-bench # Run benchmarks
 make fuzz       # Run fuzz tests
 ```
 
-Optional: install the [prek](https://github.com/j178/prek) git hook to lint
-staged Go packages on every commit (CI remains the source of truth):
+Optional: install the [prek](https://github.com/j178/prek) git hooks to lint
+staged Go packages on commit and the full module on push (CI remains the
+source of truth):
 
 ```bash
-make pre-commit-install   # cargo binstall prek + prek install
-make pre-commit           # run all hooks against every file
+make pre-commit-install   # cargo binstall prek + wire up commit & push hooks
+make pre-commit           # fast: lint changed packages
+make pre-push             # slow: lint the whole root module
 ```
 
 ## Documentation

--- a/scripts/precommit-golangci-lint.sh
+++ b/scripts/precommit-golangci-lint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run golangci-lint on the unique package directories of staged Go files.
+# Invoked by .pre-commit-config.yaml (fast-path); CI runs lint over the whole module.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+# Reduce staged file paths to unique package directories (./pkg/foo).
+# bash 3.2 compatible (macOS default) — no mapfile.
+pkgs=()
+while IFS= read -r dir; do
+  case "$dir" in
+    .) pkgs+=(".") ;;
+    *) pkgs+=("./$dir") ;;
+  esac
+done < <(printf '%s\n' "$@" | xargs -n1 dirname | sort -u)
+
+exec golangci-lint run "${pkgs[@]}"


### PR DESCRIPTION
## Summary

Two-stage [`prek`](https://github.com/j178/prek) hook setup (drop-in for `pre-commit`):

- **pre-commit (fast):** file hygiene + `golangci-lint` on packages of staged `.go` files
- **pre-push (slow):** file hygiene + `golangci-lint run ./...` (mirrors CI)

`examples/bazel-project/` is excluded from the lint hook because it's a separate Go module.

## Usage

```bash
make pre-commit-install   # cargo binstall prek + install both git hooks
make pre-commit           # run pre-commit-stage hooks on all files
make pre-push             # run pre-push-stage hooks on all files
```

CI remains the source of truth.

## Test plan

- [x] `make pre-commit` — pass
- [x] `make pre-push` — pass
- [x] `git commit` triggers the installed hook end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)